### PR TITLE
88 l3 syntax right to left conj relation conj must go left to right

### DIFF
--- a/rules/post_udapy_fixes.grs
+++ b/rules/post_udapy_fixes.grs
@@ -126,3 +126,40 @@ rule change_det_to_obl {
       del_edge e;
     }
 }
+
+
+rule conj_left_to_right {
+  global { sent_id <> "015775" }
+  pattern {
+      HEAD -> N1;
+      e: HEAD -[conj]-> N2; 
+      N2 -[cc]-> C;
+      N1 << N2;
+      N1 < C;
+      N2 << HEAD;
+  }
+  commands {
+    add_edge f: N1 -> N2;
+    f.label = conj; 
+    del_edge e;
+  }
+}
+
+rule conj_left_to_right_with_dashes {
+  global { sent_id <> "015775" }
+  pattern {
+      HEAD -> N1;
+      e: HEAD -[conj]-> N2; 
+      N2 -[cc]-> C;
+      N1 << N2;
+      P [upos=PUNCT];
+      P < C;
+      N1 < P;
+      N2 << HEAD;
+  }
+  commands {
+    add_edge f: N1 -> N2;
+    f.label = conj; 
+    del_edge e;
+  }
+}

--- a/rules/reverse_heads_nn.grs
+++ b/rules/reverse_heads_nn.grs
@@ -174,6 +174,20 @@ package shift_sentence_internal {
       del_edge e;
     }
   }
+
+  rule det_should_not_have_children {
+    pattern {
+      H -[DET]-> DEP;
+      DEP [upos = DET];
+      e: DEP -> Y; 
+    }
+    commands {
+      add_edge f: H -> Y;
+      f.label = e.label;
+      del_edge e;
+    }
+  }
+
 }
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 package comma {

--- a/rules/testpattern.req
+++ b/rules/testpattern.req
@@ -1,5 +1,12 @@
-    pattern {
-    H -[DET]-> DEP;
-    DEP [upos = DET];
-    e: DEP -> Y;
-    }
+global { sent_id <> "015775" }
+pattern {
+    HEAD -> N1;
+    e: HEAD -[conj]-> N2; 
+    N2 -[cc]-> C;
+    N1 << N2;
+    P [upos=PUNCT];
+    P < C;
+    N1 < P;
+    N2 << HEAD;
+}
+

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,0 +1,6 @@
+./convert_ndt2ud.sh -l nb -p dev
+./convert_ndt2ud.sh -l nb -p test
+./convert_ndt2ud.sh -l nb -p train
+./convert_ndt2ud.sh -l nn -p dev
+./convert_ndt2ud.sh -l nn -p test
+./convert_ndt2ud.sh -l nn -p train


### PR DESCRIPTION
# Endringer

Skriv regel for å flytte hodet til konjunkter fra høyre til venstre. 

Legg til regel for determinativer (se tidligere issue #87 ) for nynorsk. 