### PR TITLE
Fix multiple subjects

### DIFF
--- a/convert_ndt2ud.sh
+++ b/convert_ndt2ud.sh
@@ -1,30 +1,37 @@
 #!/bin/bash
 
-while getopts "i:l:" opt; do
+# Handle user input arguments
+while getopts "i:l:o:r:" opt; do
  case $opt in
     i) INPUT_FILE=$OPTARG ;;
-    l) LANG=$OPTARG ;;          # Must be nb or nn
+    l) L=$OPTARG ;;          # Must be nb or nn
+    o) OUTPUT_FILE=$OPTARG ;;
+    r) REPORTFILE=$OPTARG ;;
     \?) echo "Invalid option: -$OPTARG" >&2; exit 1 ;;
     :) echo "Option -$OPTARG requires an argument." >&2; exit 1 ;;
   esac
 done
 
-#LIA_FILE = /home/ingeridd/prosjekter/trebank/spoken_norwegian_resources/treebanks/Norwegian-NynorskLIA/aal_uio_02.conll
+: "${INPUT_FILE:?Need to set input file}"
+: "${L:?Need to set language with -l nb or -l nn}"
+: "${OUTPUT_FILE:=UD_output.conllu}"  # Set default output file name if not provided
+: "${REPORTFILE:=validation-report.txt}"  # Set default report file name if not provided
 
 # Create temporary directory
 TEMPDIR="tmp"
 mkdir -p $TEMPDIR
 
-OUTPUT_FILE="output.conllu"
-REPORTFILE="validation-report.txt"
-
-echo "--- CONVERT TREEBANK ---"
-echo "Language: $LANG"
-echo "Input file: $INPUT_FILE"
-echo "Output will be written to $OUTPUT_FILE and $REPORTFILE"
-
+echo "--- CONVERT NDT TREEBANK to UD ---"
+echo ""
+echo "--- Input parameters ---"
+echo "  Language: $L"
+echo "  Input NDT file: $INPUT_FILE"
+echo "  Output UD file: $OUTPUT_FILE"
+echo "  Validation report: $REPORTFILE"
+echo ""
 
 # START CONVERSION
+
 echo "--- Convert morphology: feats and pos-tags ---"
 TEMPFILE="${TEMPDIR}/01_convert_morph_output.conllu"
 python utils/convert_morph.py -f $INPUT_FILE -o $TEMPFILE
@@ -43,7 +50,7 @@ grew transform \
     -i  $TEMPFILE \
     -o  $TEMPOUT \
     -grs  rules/NDT_to_UD.grs \
-    -strat "main_$LANG" \
+    -strat "main_$L" \
     -safe_commands
 
 TEMPFILE=$TEMPOUT

--- a/data/converted/no_bokmaal-ud-dev.conllu
+++ b/data/converted/no_bokmaal-ud-dev.conllu
@@ -20,7 +20,7 @@
 17	inntrykk	inntrykk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	12	obl	_	_
 18	retten	rett	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	24	nsubj	_	_
 19	for	for	ADP	prep	_	21	case	_	_
-20	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	21	det	_	_
+20	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	21	nmod:poss	_	_
 21	vedkommende	vedkommende	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	24	advmod	_	_
 22	måtte	måtte	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	24	aux	_	_
 23	ha	ha	AUX	verb	VerbForm=Inf	24	aux	_	_
@@ -31,7 +31,7 @@
 28	handlinger	handling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	24	obl	_	_
 29	retten	rett	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	30	nsubj	_	_
 30	finner	finne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	28	acl:relcl	_	_
-31	bevist	bevise	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	30	xcomp	_	_
+31	bevist	bevise	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	30	xcomp	_	_
 32	og	og	CCONJ	konj	_	34	cc	_	_
 33	av	av	ADP	prep	_	34	case	_	_
 34	lovovertrederen	lovovertreder	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	28	conj	_	SpaceAfter=No
@@ -121,12 +121,12 @@
 16	i	i	ADP	prep	_	17	case	_	_
 17	Oslo	Oslo	PROPN	subst	_	15	nmod	_	SpaceAfter=No
 18	,	$,	PUNCT	<komma>	_	19	punct	_	_
-19	ferdig	ferdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	conj	_	_
+19	ferdig	ferdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	conj	_	_
 20	med	med	ADP	prep	_	22	case	_	_
-21	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	22	det	_	_
+21	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	22	nmod:poss	_	_
 22	meddommergjerning	meddommergjerning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	obl	_	SpaceAfter=No
 23	,	$,	PUNCT	<komma>	_	24	punct	_	_
-24	fotografert	fotografere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	12	conj	_	_
+24	fotografert	fotografere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	12	conj	_	_
 25	i	i	ADP	prep	_	26	case	_	_
 26	farger	farge	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	24	obl	_	_
 27	over	over	ADP	prep	_	29	case	_	_
@@ -138,7 +138,7 @@
 33	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	34	det	_	_
 34	veske	veske	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	31	obl	_	_
 35	med	med	ADP	prep	_	37	case	_	_
-36	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	37	det	_	_
+36	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	37	nmod:poss	_	_
 37	notater	notat	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	34	nmod	_	_
 38	og	og	CCONJ	konj	_	39	cc	_	_
 39	solbriller	solbrille	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	37	conj	_	_
@@ -159,7 +159,7 @@
 3	på	på	ADP	prep	_	4	case	_	_
 4	vei	vei	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 5	til	til	ADP	prep	_	8	case	_	_
-6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 7	neste	neste	DET	det	Definite=Def|PronType=Dem	8	det	_	_
 8	gjerning	gjerning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nmod	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	4	punct	_	_
@@ -224,7 +224,7 @@
 7	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
 8	skille	skille	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	6	obj	_	_
 9	i	i	ADP	prep	_	11	case	_	_
-10	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	kriminaljournalistikk	kriminaljournalistikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -242,7 +242,7 @@
 10	bare	bare	ADV	adv	_	4	advmod	_	_
 11	å	å	PART	inf-merke	_	12	mark	_	_
 12	bli	bli	VERB	verb	VerbForm=Inf	4	xcomp	_	_
-13	kjent	kjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	xcomp	_	_
+13	kjent	kjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	xcomp	_	_
 14	med	med	ADP	prep	_	16	case	_	_
 15	domstolens	domstol	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	_
 16	faktabeskrivelse	faktabeskrivelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	obl	_	_
@@ -311,15 +311,15 @@
 # text = Meddommerens lovbestemte posisjon innen retten utvides til en ekstern og selvvalgt, etterfølgende forkynnelsesfunksjon om meddommerens egne standpunkt og oppfatninger.
 1	Meddommerens	meddommer	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 2	lovbestemte	lovbestemt	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	3	amod	_	_
-3	posisjon	posisjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nsubj	_	_
+3	posisjon	posisjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nsubj:pass	_	_
 4	innen	innen	ADP	prep	_	5	case	_	_
 5	retten	rett	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 6	utvides	utvide	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 7	til	til	ADP	prep	_	14	case	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-9	ekstern	ekstern	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+9	ekstern	ekstern	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 10	og	og	CCONJ	konj	_	11	cc	_	_
-11	selvvalgt	selvvalgt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	conj	_	SpaceAfter=No
+11	selvvalgt	selvvalgt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	conj	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	11	punct	_	_
 13	etterfølgende	etterfølge	ADJ	adj	VerbForm=Part	14	amod	_	_
 14	forkynnelsesfunksjon	forkynnelsesfunksjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obl	_	_
@@ -348,7 +348,7 @@
 12	eksempel	eksempel	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	obj	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	9	punct	_	_
 14	at	at	SCONJ	sbu	_	16	mark	_	_
-15	spørsmålet	spørsmål	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	16	nsubj	_	_
+15	spørsmålet	spørsmål	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	16	nsubj:pass	_	_
 16	stilles	stille	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	3	csubj	_	_
 17	hvorvidt	hvorvidt	SCONJ	sbu	_	21	mark	_	_
 18	dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	21	nsubj	_	_
@@ -373,12 +373,12 @@
 10	,	$,	PUNCT	<komma>	_	22	punct	_	_
 11	som	som	SCONJ	sbu	_	22	mark	_	_
 12	i	i	ADP	prep	_	15	case	_	_
-13	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	15	det	_	_
+13	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 14	utrolige	utrolig	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	15	amod	_	_
 15	mangfold	mangfold	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	22	obl	_	_
 16	og	og	CCONJ	konj	_	19	cc	_	_
 17	med	med	ADP	prep	_	19	case	_	_
-18	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	19	det	_	_
+18	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 19	alvor	alvor	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	15	conj	_	_
 20	vel	vel	ADV	adv	_	22	advmod	_	_
 21	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	22	aux	_	_
@@ -406,8 +406,8 @@
 2	representerer	representere	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 4	nærmest	nær	ADJ	adj	Definite=Ind|Degree=Sup	5	advmod	_	_
-5	genuin	genuin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
-6	journalistisk	journalistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+5	genuin	genuin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
+6	journalistisk	journalistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	åpning	åpning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 8	på	på	ADP	prep	_	11	case	_	_
 9	den	den	DET	det	Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
@@ -420,12 +420,12 @@
 1	I	i	ADP	prep	_	7	case	_	_
 2	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 3	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	4	advmod	_	_
-4	stakkato	stakkato	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+4	stakkato	stakkato	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 5	og	og	CCONJ	konj	_	6	cc	_	_
-6	hjerte-arytmisk	hjerte-arytmisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	conj	_	_
+6	hjerte-arytmisk	hjerte-arytmisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	conj	_	_
 7	tone	tone	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obl	_	_
 8	beskrives	beskrive	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
-9	Thomassen	Thomassen	PROPN	subst	_	8	nsubj	_	_
+9	Thomassen	Thomassen	PROPN	subst	_	8	nsubj:pass	_	_
 10	hvordan	hvordan	ADV	adv	_	14	advmod	_	_
 11	også	også	ADV	adv	_	12	advmod	_	_
 12	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
@@ -448,7 +448,7 @@
 4	og	og	CCONJ	konj	_	5	cc	_	_
 5	ustoppelig	ustoppelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	3	conj	_	_
 6	frembringe	frembringe	VERB	verb	VerbForm=Inf	0	root	_	_
-7	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	det	_	_
+7	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 8	samvittighets-aggressive	samvittighets-aggressiv	ADJ	adj	Degree=Pos|Number=Plur	11	amod	_	_
 9	og	og	CCONJ	konj	_	10	cc	_	_
 10	aksjonsivrige	aksjonsivrig	ADJ	adj	Degree=Pos|Number=Plur	8	conj	_	_
@@ -491,7 +491,7 @@
 # sent_id = 015721
 # text = At meddommeren nærmest mini-portrettintervjues som en meddommer i samvittighetskval, gjør ikke saken enklere, ikke mer forståelig.
 1	At	at	SCONJ	sbu	_	4	mark	_	_
-2	meddommeren	meddommer	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
+2	meddommeren	meddommer	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj:pass	_	_
 3	nærmest	nær	ADJ	adj	Definite=Ind|Degree=Sup	4	advmod	_	_
 4	mini-portrettintervjues	mini-portrettintervjue	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	11	csubj	_	_
 5	som	som	ADP	prep	_	7	case	_	_
@@ -507,7 +507,7 @@
 15	,	$,	PUNCT	<komma>	_	18	punct	_	_
 16	ikke	ikke	PART	adv	Polarity=Neg	18	advmod	_	_
 17	mer	mye	ADJ	adj	Degree=Cmp	18	advmod	_	_
-18	forståelig	forståelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	conj	_	SpaceAfter=No
+18	forståelig	forståelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	conj	_	SpaceAfter=No
 19	.	$.	PUNCT	clb	_	11	punct	_	_
 
 # sent_id = 015722
@@ -566,7 +566,7 @@
 5	i	i	ADP	prep	_	6	case	_	_
 6	strid	strid	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nmod	_	_
 7	med	med	ADP	prep	_	9	case	_	_
-8	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	9	det	_	_
+8	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 9	rettsprinsipper	rettsprinsipp	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	6	nmod	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	14	punct	_	_
 11	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	expl	_	_
@@ -581,7 +581,7 @@
 20	enkelte	enkelt	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	21	amod	_	_
 21	meddommer	meddommer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	conj	_	_
 22	etter	etter	ADP	prep	_	24	case	_	_
-23	utført	utføre	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	24	amod	_	_
+23	utført	utføre	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	24	amod	_	_
 24	jobb	jobb	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	21	obl	_	_
 25	i	i	ADP	prep	_	27	case	_	_
 26	statens	stat	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	27	nmod	_	_
@@ -618,7 +618,7 @@
 57	formentlig	formentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	58	advmod	_	_
 58	da	da	ADV	adv	_	63	advmod	_	_
 59	mest	mye	ADJ	adj	Definite=Ind|Degree=Sup	63	amod	_	_
-60	Inge	Inge	PROPN	subst	_	63	nmod	_	_
+60	Inge	Inge	PROPN	subst	_	63	nmod:poss	_	_
 61	D.	D.	PROPN	subst	Abbr=Yes	60	flat:name	_	_
 62	Hanssens	Hanssen	PROPN	subst	Case=Gen	60	flat:name	_	_
 63	kommentarspalte	kommentarspalte	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	49	dislocated	_	_
@@ -647,7 +647,7 @@
 2	utspill	utspill	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	nsubj	_	_
 3	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	selvfølgelig	selvfølgelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	selvfølgelig	selvfølgelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	smitteeffekt	smitteeffekt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -659,7 +659,7 @@
 4	også	også	ADV	adv	_	2	advmod	_	_
 5	selv	selv	ADV	adv	_	2	advmod	_	_
 6	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	advmod	_	_
-7	smittet	smitte	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	2	xcomp	_	SpaceAfter=No
+7	smittet	smitte	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	2	xcomp	_	SpaceAfter=No
 8	;	$;	PUNCT	clb	_	10	punct	_	_
 9	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	_	_
 10	spør	spørre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	_	SpaceAfter=No
@@ -682,7 +682,7 @@
 2	meddommerens	meddommer	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 3	beretning	beretning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	1	nsubj	_	_
 4	som	som	ADP	prep	_	5	case	_	_
-5	troverdig	troverdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	1	xcomp	_	SpaceAfter=No
+5	troverdig	troverdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	1	xcomp	_	SpaceAfter=No
 6	?	$?	PUNCT	clb	_	1	punct	_	_
 
 # sent_id = 015730
@@ -713,7 +713,7 @@
 18	være	være	AUX	verb	VerbForm=Inf	21	cop	_	_
 19	totalt	total	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	21	advmod	_	_
 20	mentalt	mental	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	21	advmod	_	_
-21	uforberedt	uforberedt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	_
+21	uforberedt	uforberedt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	_
 22	på	på	ADP	prep	_	31	case	_	_
 23	hva	hva	PRON	pron	PronType=Int	31	obj	_	_
 24	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
@@ -735,12 +735,12 @@
 3	mulig	mulig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	0	root	_	_
 4	å	å	PART	inf-merke	_	6	mark	_	_
 5	være	være	AUX	verb	VerbForm=Inf	6	cop	_	_
-6	uvitende	uvitende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	csubj	_	_
+6	uvitende	uvitende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	csubj	_	_
 7	om	om	ADP	prep	_	8	case	_	_
 8	innholdet	innhold	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	obl	_	_
 9	i	i	ADP	prep	_	12	case	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-11	moralsk-sosial	moralsk-sosial	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	moralsk-sosial	moralsk-sosial	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	samfunnsdebatt	samfunnsdebatt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nmod	_	_
 13	som	som	SCONJ	sbu	_	15	mark	_	_
 14	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	_	_
@@ -769,7 +769,7 @@
 5	retten	rett	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 6	etterlyses	etterlyse	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 7	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	debatt	debatt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nsubj	_	_
+8	debatt	debatt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nsubj:pass	_	_
 9	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	14	nsubj	_	_
 10	andre	annen	DET	det	Number=Plur|PronType=Dem	9	det	_	_
 11	enten	enten	CCONJ	konj	_	14	cc	_	_
@@ -806,7 +806,7 @@
 # sent_id = 015735
 # text = Så slått ut var meddommeren av det han opplevet i retten, at da han gikk gjennom sine notater fra rettsforhandlingene, trodde han ikke det som sto der var sant.
 1	Så	så	ADV	adv	_	2	advmod	_	_
-2	slått	slå	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	_
+2	slått	slå	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	_
 3	ut	ut	ADV	prep	_	2	advmod	_	_
 4	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	cop	_	_
 5	meddommeren	meddommer	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
@@ -822,7 +822,7 @@
 15	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
 16	gikk	gå	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	23	advcl	_	_
 17	gjennom	gjennom	ADP	prep	_	19	case	_	_
-18	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	19	det	_	_
+18	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 19	notater	notat	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	16	obl	_	_
 20	fra	fra	ADP	prep	_	21	case	_	_
 21	rettsforhandlingene	rettsforhandling	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	19	nmod	_	SpaceAfter=No
@@ -848,7 +848,7 @@
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 7	person	person	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	xcomp	_	_
 8	med	med	ADP	prep	_	10	case	_	_
-9	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	psyke	psyke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -856,7 +856,7 @@
 # text = Meddommere med svak psyke må ligge livløse ved tilsvarende rettsforhandlingers avslutning.
 1	Meddommere	meddommer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	6	nsubj	_	_
 2	med	med	ADP	prep	_	4	case	_	_
-3	svak	svak	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	svak	svak	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	psyke	psyke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	nmod	_	_
 5	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 6	ligge	ligge	VERB	verb	VerbForm=Inf	0	root	_	_
@@ -909,7 +909,7 @@
 3	kun	kun	ADV	adv	_	2	advmod	_	_
 4	om	om	ADP	prep	_	5	case	_	_
 5	begrepet	begrep	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	obl	_	_
-6	skjult	skjule	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	7	amod	_	_
+6	skjult	skjule	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	7	amod	_	_
 7	agenda	agenda	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	appos	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -981,7 +981,7 @@
 5	å	å	PART	inf-merke	_	6	mark	_	_
 6	si	si	VERB	verb	VerbForm=Inf	2	advcl	_	_
 7	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	6	obj	_	_
-8	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	xcomp	_	_
+8	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	xcomp	_	_
 9	i	i	ADP	prep	_	10	case	_	_
 10	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	obl	_	_
 11	alle	alle	PRON	pron	Number=Plur|Person=3|PronType=Prs,Tot	13	nsubj	_	_
@@ -1000,11 +1000,11 @@
 6	utvikling	utvikling	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 7	der	der	SCONJ	sbu	_	11	mark	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	straffedømts	straffedømt	ADJ	adj	Case=Gen|Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	nmod	_	_
+9	straffedømts	straffedømt	ADJ	adj	Case=Gen|Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	nmod	_	_
 10	gjerninger	gjerning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	11	nsubj	_	_
 11	blir	bli	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-13	mental	mental	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	mental	mental	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	unnskyldning	unnskyldning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	xcomp	_	_
 15	for	for	ADP	prep	_	17	case	_	_
 16	egne	egen	DET	det	Number=Plur|PronType=Prs	17	det	_	_
@@ -1052,9 +1052,9 @@
 # sent_id = 015748
 # text = Selv meddommere med lang fartstid ville blitt berørt av å sitte å høre på historiene som er kommet frem i denne rettssaken.
 1	Selv	selv	ADV	adv	_	2	advmod	_	_
-2	meddommere	meddommer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	nsubj	_	_
+2	meddommere	meddommer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	nsubj:pass	_	_
 3	med	med	ADP	prep	_	5	case	_	_
-4	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	fartstid	fartstid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	nmod	_	_
 6	ville	ville	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	aux	_	_
 7	blitt	bli	AUX	verb	VerbForm=Part	8	aux:pass	_	_
@@ -1116,7 +1116,7 @@
 14	ser	se	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	acl:relcl	_	_
 15	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	expl	_	_
 16	som	som	ADP	prep	_	18	case	_	_
-17	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	18	det	_	_
+17	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	18	nmod:poss	_	_
 18	plikt	plikt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	xcomp	_	_
 19	for	for	ADP	prep	_	21	case	_	_
 20	all	all	DET	det	Gender=Masc|Number=Sing|PronType=Tot	21	det	_	_
@@ -1124,7 +1124,7 @@
 22	å	å	PART	inf-merke	_	23	mark	_	_
 23	fremkomme	fremkomme	VERB	verb	VerbForm=Inf	14	xcomp	_	_
 24	med	med	ADP	prep	_	27	case	_	_
-25	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	27	det	_	_
+25	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	27	nmod:poss	_	_
 26	private	privat	ADJ	adj	Degree=Pos|Number=Plur	27	amod	_	_
 27	straffutmålingsbetraktninger	straffutmålingsbetraktning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	23	obl	_	SpaceAfter=No
 28	?	$?	PUNCT	clb	_	4	punct	_	_
@@ -1148,13 +1148,13 @@
 3	synes	synes	VERB	verb	VerbForm=Inf	0	root	_	_
 4	synd	synd	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obj	_	_
 5	på	på	ADP	prep	_	6	case	_	_
-6	vedkommende	vedkommende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+6	vedkommende	vedkommende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 7	fremfor	fremfor	ADP	prep	_	9	case	_	_
 8	å	å	PART	inf-merke	_	9	mark	_	_
 9	ære	ære	VERB	verb	VerbForm=Inf	3	advcl	_	_
 10	ham	han	PRON	pron	Animacy=Hum|Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	obj	_	_
 11	som	som	ADP	prep	_	13	case	_	_
-12	valgt	velge	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	13	amod	_	_
+12	valgt	velge	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	13	amod	_	_
 13	innehaver	innehaver	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	xcomp	_	_
 14	av	av	ADP	prep	_	15	case	_	_
 15	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	nmod	_	_
@@ -1181,10 +1181,10 @@
 8	i	i	ADP	prep	_	15	case	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
 10	høyst	høyst	ADV	adv	_	11	advmod	_	_
-11	aktuell	aktuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	SpaceAfter=No
+11	aktuell	aktuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	11	punct	_	_
 13	ikke-rettskraftig	ikke-rettskraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	14	advmod	_	_
-14	avgjort	avgjort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	avgjort	avgjort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	straffesak	straffesak	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -1201,13 +1201,13 @@
 8	muligens	muligens	ADV	adv	_	11	advmod	_	_
 9	ikke	ikke	PART	adv	Polarity=Neg	11	advmod	_	_
 10	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	_	_
-11	kjent	kjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	advcl	_	_
+11	kjent	kjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	advcl	_	_
 12	med	med	ADP	prep	_	19	case	_	_
 13	i	i	ADP	prep	_	15	case	_	_
 14	hvilken	hvilken	DET	det	Gender=Masc|Number=Sing|PronType=Int	15	det	_	_
 15	kontekst	kontekst	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	obl	_	_
-16	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	17	det	_	_
-17	uttalelser	uttalelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	19	nsubj	_	_
+16	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
+17	uttalelser	uttalelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	19	nsubj:pass	_	_
 18	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux	_	_
 19	benyttes	benytte	VERB	verb	VerbForm=Inf|Voice=Pass	11	advcl	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -1220,7 +1220,7 @@
 4	,	$,	PUNCT	<komma>	_	3	punct	_	_
 5	hensett	hense	ADJ	adj	Definite=Ind|Gender=Neut|Number=Sing|VerbForm=Part	13	advmod	_	_
 6	til	til	ADP	prep	_	8	case	_	_
-7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	stilling	stilling	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	5	punct	_	_
 10	til	til	ADP	prep	_	12	case	_	_
@@ -1248,7 +1248,7 @@
 4	tidligere	tidlig	ADJ	adj	Degree=Cmp	13	advmod	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	10	punct	_	_
 6	og	og	CCONJ	konj	_	10	cc	_	_
-7	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	advmod	_	_
+7	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	advmod	_	_
 8	opp	opp	ADP	prep	_	10	case	_	_
 9	til	til	ADP	prep	_	10	case	_	_
 10	hovedforhandlingen	hovedforhandling	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	conj	_	SpaceAfter=No
@@ -1299,7 +1299,7 @@
 22	vært	være	AUX	verb	VerbForm=Part	23	cop	_	_
 23	grunnlaget	grunnlag	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	19	nmod	_	_
 24	for	for	ADP	prep	_	26	case	_	_
-25	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	26	det	_	_
+25	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	26	nmod:poss	_	_
 26	kontakt	kontakt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	23	nmod	_	SpaceAfter=No
 27	.	$.	PUNCT	clb	_	16	punct	_	_
 
@@ -1310,7 +1310,7 @@
 3	i	i	ADP	prep	_	5	case	_	_
 4	alle	all	DET	det	Number=Plur|PronType=Tot	5	det	_	_
 5	fall	fall	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	2	obl	_	_
-6	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+6	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 7	respekt	respekt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	10	punct	_	_
 9	som	som	ADP	prep	_	10	case	_	_
@@ -1319,7 +1319,7 @@
 
 # sent_id = 015763
 # text = Tvisynt ombudsmann
-1	Tvisynt	tvisynt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Tvisynt	tvisynt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	ombudsmann	ombudsmann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 
 # newpar
@@ -1377,7 +1377,7 @@
 # text = Ingen av Per Bortens uttalelser gjennom mer enn 50 år som lokalpolitiker, stortingsrepresentant, statsminister og politisk kårkall er blitt så legendarisk som da han ved avskjeden som statsminister i 1971 sammenlignet det å lede en koalisjonsregjering med å bære sprikende staur.
 1	Ingen	ingen	PRON	pron	Number=Plur|Person=3|PronType=Prs	21	nsubj	_	_
 2	av	av	ADP	prep	_	5	case	_	_
-3	Per	Per	PROPN	subst	Gender=Masc	5	nmod	_	_
+3	Per	Per	PROPN	subst	Gender=Masc	5	nmod:poss	_	_
 4	Bortens	Borten	PROPN	subst	Case=Gen	3	flat:name	_	_
 5	uttalelser	uttalelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	1	obl	_	_
 6	gjennom	gjennom	ADP	prep	_	10	case	_	_
@@ -1392,12 +1392,12 @@
 15	,	$,	PUNCT	<komma>	_	16	punct	_	_
 16	statsminister	statsminister	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	conj	_	_
 17	og	og	CCONJ	konj	_	19	cc	_	_
-18	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	kårkall	kårkall	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	conj	_	_
 20	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	21	cop	_	_
 21	blitt	bli	VERB	verb	VerbForm=Part	0	root	_	_
 22	så	så	ADV	adv	_	23	advmod	_	_
-23	legendarisk	legendarisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	xcomp	_	_
+23	legendarisk	legendarisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	xcomp	_	_
 24	som	som	ADV	prep	_	22	advmod	_	_
 25	da	da	SCONJ	sbu	_	33	mark	_	_
 26	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	33	nsubj	_	_
@@ -1439,7 +1439,7 @@
 
 # sent_id = 015771
 # text = Per Borten ble valgt som statsminister etter den borgerlige valgseieren i 1965 fordi flertallet i Høyres stortingsgruppe mente at han kunne bli den mest samlende regjeringssjefen.
-1	Per	Per	PROPN	subst	Gender=Masc	4	nsubj	_	_
+1	Per	Per	PROPN	subst	Gender=Masc	4	nsubj:pass	_	_
 2	Borten	Borten	PROPN	subst	_	1	flat:name	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	_	_
 4	valgt	velge	VERB	verb	VerbForm=Part	0	root	_	_
@@ -1553,7 +1553,7 @@
 4	å	å	PART	inf-merke	_	5	mark	_	_
 5	skjule	skjule	VERB	verb	VerbForm=Inf	2	acl	_	_
 6	for	for	ADP	prep	_	8	case	_	_
-7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	regjering	regjering	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 9	at	at	SCONJ	sbu	_	12	mark	_	_
 10	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nsubj	_	_
@@ -1606,11 +1606,11 @@
 15	uforsonlige	uforsonlig	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	16	amod	_	_
 16	EF-kampen	EF-kamp	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
 17	mente	mene	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	ccomp	_	_
-18	deres	deres	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	19	det	_	_
+18	deres	deres	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 19	sak	sak	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	22	nsubj	_	_
 20	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	22	cop	_	_
 21	best	god	ADJ	adj	Definite=Ind|Degree=Sup	22	advmod	_	_
-22	tjent	tjene	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	17	xcomp	_	_
+22	tjent	tjene	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	17	xcomp	_	_
 23	med	med	ADP	prep	_	26	case	_	_
 24	at	at	SCONJ	sbu	_	26	mark	_	_
 25	Borten-regjeringen	Borten-regjering	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	26	nsubj	_	_
@@ -1635,7 +1635,7 @@
 13	Ap-styre	Ap-styre	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	7	nmod	_	SpaceAfter=No
 14	,	$,	PUNCT	<komma>	_	2	punct	_	_
 15	møtte	møte	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-16	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	det	_	_
+16	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
 17	skjebne	skjebne	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obj	_	_
 18	fordi	fordi	SCONJ	sbu	_	22	mark	_	_
 19	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	22	expl	_	_
@@ -1663,9 +1663,9 @@
 4	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	3	iobj	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
 6	både	både	CCONJ	konj	_	7	cc	_	_
-7	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+7	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 8	og	og	CCONJ	konj	_	9	cc	_	_
-9	vanskelig	vanskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	conj	_	_
+9	vanskelig	vanskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	conj	_	_
 10	oppgave	oppgave	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -1688,7 +1688,7 @@
 15	,	$,	PUNCT	<komma>	_	12	punct	_	_
 16	å	å	PART	inf-merke	_	17	mark	_	_
 17	bli	bli	VERB	verb	VerbForm=Inf	7	csubj	_	_
-18	klok	klok	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	xcomp	_	_
+18	klok	klok	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	xcomp	_	_
 19	på	på	ADP	prep	_	20	case	_	_
 20	Borten	Borten	PROPN	subst	_	18	obl	_	SpaceAfter=No
 21	.	$.	PUNCT	clb	_	7	punct	_	_
@@ -1749,7 +1749,7 @@
 1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	fremmed	fremmed	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	fremmed	fremmed	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	tanke	tanke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 6	for	for	ADP	prep	_	7	case	_	_
 7	Borten	Borten	PROPN	subst	_	5	obl	_	SpaceAfter=No
@@ -1807,10 +1807,10 @@
 7	med	med	ADP	prep	_	8	case	_	_
 8	Borten	Borten	PROPN	subst	_	6	nmod	_	_
 9	i	i	ADP	prep	_	11	case	_	_
-10	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	obl	_	_
 12	som	som	ADP	prep	_	14	case	_	_
-13	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	politiker	politiker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 15	,	$,	PUNCT	<komma>	_	20	punct	_	_
 16	eller	eller	CCONJ	konj	_	20	cc	_	_
@@ -1846,10 +1846,10 @@
 4	systematikk	systematikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	nmod	_	_
 5	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	cop	_	_
 6	ingen	ingen	DET	det	Gender=Masc|Number=Sing|Polarity=Neg	8	det	_	_
-7	fremtredende	fremtredende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	fremtredende	fremtredende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	egenskap	egenskap	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 9	ved	ved	ADP	prep	_	11	case	_	_
-10	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	personlighet	personlighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	8	nmod	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	8	punct	_	_
 
@@ -1858,7 +1858,7 @@
 1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	cop	_	_
 3	mer	mye	ADJ	adj	Degree=Cmp	4	advmod	_	_
-4	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	av	av	ADP	prep	_	7	case	_	_
 6	å	å	PART	inf-merke	_	7	mark	_	_
 7	lytte	lytte	VERB	verb	VerbForm=Inf	4	advcl	_	SpaceAfter=No
@@ -1871,37 +1871,37 @@
 14	å	å	PART	inf-merke	_	15	mark	_	_
 15	bidra	bidra	VERB	verb	VerbForm=Inf	3	advcl	_	_
 16	til	til	ADP	prep	_	19	case	_	_
-17	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	19	det	_	_
+17	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 18	eget	egen	DET	det	Definite=Ind|Gender=Neut|Number=Sing|PronType=Prs	19	det	_	_
 19	ettermæle	ettermæle	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	15	obl	_	_
 20	i	i	ADP	prep	_	21	case	_	_
 21	form	form	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	15	obl	_	_
 22	av	av	ADP	prep	_	26	case	_	_
 23	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	26	det	_	_
-24	arbeidskrevende	arbeidskrevende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	amod	_	_
-25	skriftlig	skriftlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	amod	_	_
+24	arbeidskrevende	arbeidskrevende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	amod	_	_
+25	skriftlig	skriftlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	amod	_	_
 26	fremstilling	fremstilling	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
 27	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 015788
 # text = Hans fascinerende blanding av intellektuell nysgjerrighet, bondeful folkelighet og politisk uforutsigbarhet gjorde ham til en spennende samtalepartner både for politisk interesserte og folk flest.
-1	Hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	_
+1	Hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	_
 2	fascinerende	fascinere	ADJ	adj	VerbForm=Part	3	amod	_	_
 3	blanding	blanding	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	13	nsubj	_	_
 4	av	av	ADP	prep	_	6	case	_	_
-5	intellektuell	intellektuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	intellektuell	intellektuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	nysgjerrighet	nysgjerrighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	nmod	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	9	punct	_	_
-8	bondeful	bondeful	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	bondeful	bondeful	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	folkelighet	folkelighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	conj	_	_
 10	og	og	CCONJ	konj	_	12	cc	_	_
-11	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	uforutsigbarhet	uforutsigbarhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	conj	_	_
 13	gjorde	gjøre	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 14	ham	han	PRON	pron	Animacy=Hum|Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	obj	_	_
 15	til	til	ADP	prep	_	18	case	_	_
 16	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
-17	spennende	spennende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	spennende	spennende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	samtalepartner	samtalepartner	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	obl	_	_
 19	både	både	CCONJ	konj	_	22	cc	_	_
 20	for	for	ADP	prep	_	22	case	_	_
@@ -1935,13 +1935,13 @@
 4	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
 5	i	i	ADP	prep	_	8	case	_	_
 6	så	så	ADV	adv	_	7	advmod	_	_
-7	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	grad	grad	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obl	_	_
 9	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	_	_
 10	måttet	måtte	AUX	verb	VerbForm=Part	11	aux	_	_
 11	begynne	begynne	VERB	verb	VerbForm=Inf	2	acl	_	_
 12	på	på	ADP	prep	_	14	case	_	_
-13	bar	bar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	bar	bar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	bakke	bakke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
 15	,	$,	PUNCT	<komma>	_	11	punct	_	_
 16	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	20	cop	_	_
@@ -1963,12 +1963,12 @@
 32	forsvarsskrift	forsvarsskrift	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	30	nmod	_	_
 33	for	for	ADP	prep	_	36	case	_	_
 34	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	36	det	_	_
-35	utradisjonell	utradisjonell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	36	amod	_	_
+35	utradisjonell	utradisjonell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	36	amod	_	_
 36	politiker	politiker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	32	nmod	_	_
 37	enn	enn	ADP	prep	_	38	case	_	_
 38	biografi	biografi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	29	obl	_	_
 39	med	med	ADP	prep	_	41	case	_	_
-40	kritisk	kritisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	41	amod	_	_
+40	kritisk	kritisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	41	amod	_	_
 41	avstand	avstand	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	38	nmod	_	SpaceAfter=No
 42	.	$.	PUNCT	clb	_	20	punct	_	_
 
@@ -1992,7 +1992,7 @@
 16	i	i	ADP	prep	_	17	case	_	_
 17	lys	lys	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	11	obl	_	_
 18	av	av	ADP	prep	_	22	case	_	_
-19	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	22	det	_	_
+19	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	22	nmod:poss	_	_
 20	egen	egen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Prs	22	det	_	_
 21	politiske	politisk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	22	amod	_	_
 22	fortid	fortid	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	nmod	_	_
@@ -2022,7 +2022,7 @@
 18	siste	sist	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	19	amod	_	_
 19	året	år	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	16	nmod	_	_
 20	av	av	ADP	prep	_	22	case	_	_
-21	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	22	det	_	_
+21	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	22	nmod:poss	_	_
 22	statsministertid	statsministertid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	19	nmod	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	7	punct	_	_
 
@@ -2031,7 +2031,7 @@
 1	Et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	2	det	_	_
 2	annet	annen	DET	det	Definite=Ind|Gender=Neut|Number=Sing|PronType=Dem	5	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
-4	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+4	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	forsøk	forsøk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	0	root	_	_
 6	på	på	ADP	prep	_	8	case	_	_
 7	å	å	PART	inf-merke	_	8	mark	_	_
@@ -2109,14 +2109,14 @@
 5	fremstår	fremstå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	kampen	kamp	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
 7	mot	mot	ADP	prep	_	9	case	_	_
-8	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	overvåking	overvåking	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	nmod	_	_
 10	som	som	ADP	prep	_	13	case	_	_
 11	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
 12	tydeligste	tydelig	ADJ	adj	Definite=Def|Degree=Sup	13	amod	_	_
 13	delen	del	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	xcomp	_	_
 14	av	av	ADP	prep	_	16	case	_	_
-15	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	16	det	_	_
+15	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	16	nmod:poss	_	_
 16	samfunnsvirke	samfunnsvirke	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	13	nmod	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -2134,7 +2134,7 @@
 10	konsekvente	konsekvent	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	11	amod	_	_
 11	linje	linje	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	obj	_	_
 12	i	i	ADP	prep	_	17	case	_	_
-13	Per	Per	PROPN	subst	Gender=Masc	17	nmod	_	_
+13	Per	Per	PROPN	subst	Gender=Masc	17	nmod:poss	_	_
 14	Bortens	Borten	PROPN	subst	Case=Gen	13	flat:name	_	_
 15	motsetningsfylte	motsetningsfylt	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	17	amod	_	_
 16	politiske	politisk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	17	amod	_	_
@@ -2166,7 +2166,7 @@
 21	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	17	conj	_	_
 22	falt	falle	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	acl:relcl	_	_
 23	i	i	ADP	prep	_	25	case	_	_
-24	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	25	det	_	_
+24	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	25	nmod:poss	_	_
 25	lodd	lodd	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	22	obl	_	_
 26	å	å	PART	inf-merke	_	30	mark	_	_
 27	være	være	AUX	verb	VerbForm=Inf	30	cop	_	_
@@ -2183,10 +2183,10 @@
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 4	minst	liten	ADJ	adj	Definite=Ind|Degree=Sup	5	advmod	_	_
 5	like	like	ADV	adv	_	6	advmod	_	_
-6	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 8	av	av	ADP	prep	_	11	case	_	_
-9	Per	Per	PROPN	subst	Gender=Masc	11	nmod	_	_
+9	Per	Per	PROPN	subst	Gender=Masc	11	nmod:poss	_	_
 10	Bortens	Borten	PROPN	subst	Case=Gen	9	flat:name	_	_
 11	ettermæle	ettermæle	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	7	nmod	_	_
 12	som	som	ADP	prep	_	15	case	_	_
@@ -2231,14 +2231,14 @@
 # newpar
 # sent_id = 015803
 # text = Albania og Kroatia ble onsdag formelt ønsket velkommen som NATOs 27. og 28. medlemsland.
-1	Albania	Albania	PROPN	subst	_	7	nsubj	_	_
+1	Albania	Albania	PROPN	subst	_	7	nsubj:pass	_	_
 2	og	og	CCONJ	konj	_	3	cc	_	_
 3	Kroatia	Kroatia	PROPN	subst	_	1	conj	_	_
 4	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
 5	onsdag	onsdag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obl	_	_
 6	formelt	formell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	advmod	_	_
 7	ønsket	ønske	VERB	verb	VerbForm=Part	0	root	_	_
-8	velkommen	velkommen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	xcomp	_	_
+8	velkommen	velkommen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	xcomp	_	_
 9	som	som	ADP	prep	_	14	case	_	_
 10	NATOs	NATO	NOUN	subst	Abbr=Yes|Case=Gen	14	nmod	_	_
 11	27.	27.	ADJ	adj	Number=Plur|NumType=Ord	14	amod	_	_
@@ -2312,16 +2312,16 @@
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
 2	Vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	innstilt	innstille	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	30	ccomp	_	_
+4	innstilt	innstille	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	30	ccomp	_	_
 5	på	på	ADP	prep	_	7	case	_	_
 6	å	å	PART	inf-merke	_	7	mark	_	_
 7	ta	ta	VERB	verb	VerbForm=Inf	4	advcl	_	_
-8	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	det	_	_
+8	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 9	andel	andel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	_
 10	av	av	ADP	prep	_	11	case	_	_
 11	ansvaret	ansvar	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	9	nmod	_	_
 12	for	for	ADP	prep	_	14	case	_	_
-13	global	global	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	global	global	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	fred	fred	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nmod	_	_
 15	og	og	CCONJ	konj	_	16	cc	_	_
 16	stabilitet	stabilitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	conj	_	_
@@ -2364,7 +2364,7 @@
 3	NATO-medlemsland	NATO-medlemsland	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	6	xcomp	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 5	Albania	Albania	PROPN	subst	_	6	nsubj	_	_
-6	beredt	beredt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	ccomp	_	_
+6	beredt	beredt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	ccomp	_	_
 7	til	til	ADP	prep	_	9	case	_	_
 8	å	å	PART	inf-merke	_	9	mark	_	_
 9	ta	ta	VERB	verb	VerbForm=Inf	6	advcl	_	_
@@ -2405,7 +2405,7 @@
 1	I	i	ADP	prep	_	2	case	_	_
 2	Brussel	Brussel	PROPN	subst	_	19	obl	_	_
 3	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux:pass	_	_
-4	bekreftelsen	bekreftelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	19	nsubj	_	_
+4	bekreftelsen	bekreftelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	19	nsubj:pass	_	_
 5	fra	fra	ADP	prep	_	6	case	_	_
 6	USA	USA	PROPN	subst	Abbr=Yes	4	nmod	_	_
 7	om	om	ADP	prep	_	14	case	_	_
@@ -2486,7 +2486,7 @@
 23	på	på	ADP	prep	_	24	case	_	_
 24	Balkan	Balkan	PROPN	subst	_	22	nmod	_	_
 25	og	og	CCONJ	konj	_	27	cc	_	_
-26	internasjonal	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	27	amod	_	_
+26	internasjonal	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	27	amod	_	_
 27	sikkerhet	sikkerhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	22	conj	_	SpaceAfter=No
 28	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -2499,7 +2499,7 @@
 5	nyte	nyte	VERB	verb	VerbForm=Inf	21	ccomp	_	_
 6	godt	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
 7	av	av	ADP	prep	_	9	case	_	_
-8	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	sikkerhet	sikkerhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	obl	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	14	punct	_	_
 11	men	men	CCONJ	konj	_	14	cc	_	_
@@ -2527,7 +2527,7 @@
 6	nå	nå	ADV	adv	_	7	advmod	_	_
 7	få	få	VERB	verb	VerbForm=Inf	0	root	_	_
 8	hver	hver	DET	det	Gender=Masc|Number=Sing|PronType=Tot	11	det	_	_
-9	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+9	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 10	alfabetiske	alfabetisk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	11	amod	_	_
 11	plass	plass	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	16	punct	_	_
@@ -2721,7 +2721,7 @@
 # sent_id = 015830
 # text = I Knut Nærums elleville valgkampsatire om kaptein Stoltentann og hans mannskap på piratskipet «Den rødgrønne dame» bryter det ut et kraftig tordenvær hver gang hun hvis navn ikke kan nevnes, havheksen Siv, likevel blir navngitt.
 1	I	i	ADP	prep	_	5	case	_	_
-2	Knut	Knut	PROPN	subst	Gender=Masc	5	nmod	_	_
+2	Knut	Knut	PROPN	subst	Gender=Masc	5	nmod:poss	_	_
 3	Nærums	Nærum	PROPN	subst	Case=Gen	2	flat:name	_	_
 4	elleville	ellevill	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	5	amod	_	_
 5	valgkampsatire	valgkampsatire	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	obl	_	_
@@ -2729,7 +2729,7 @@
 7	kaptein	kaptein	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nmod	_	_
 8	Stoltentann	Stoltentann	PROPN	subst	_	5	nmod	_	_
 9	og	og	CCONJ	konj	_	11	cc	_	_
-10	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	mannskap	mannskap	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	8	conj	_	_
 12	på	på	ADP	prep	_	13	case	_	_
 13	piratskipet	piratskip	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	11	nmod	_	_
@@ -2746,9 +2746,9 @@
 24	tordenvær	tordenvær	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	19	obj	_	_
 25	hver	hver	DET	det	Gender=Masc|Number=Sing|PronType=Tot	26	det	_	_
 26	gang	gang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	obl	_	_
-27	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	39	nsubj	_	_
-28	hvis	hvis	PRON	pron	Animacy=Hum|Poss=Yes|PronType=Int	29	det	_	_
-29	navn	navn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	32	nsubj	_	_
+27	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	39	nsubj:pass	_	_
+28	hvis	hvis	PRON	pron	Animacy=Hum|Poss=Yes|PronType=Int	29	nmod:poss	_	_
+29	navn	navn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	32	nsubj:pass	_	_
 30	ikke	ikke	PART	adv	Polarity=Neg	32	advmod	_	_
 31	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	32	aux	_	_
 32	nevnes	nevne	VERB	verb	VerbForm=Inf|Voice=Pass	27	acl:relcl	_	SpaceAfter=No
@@ -2804,7 +2804,7 @@
 10	motstands	motstand	NOUN	subst	Case=Gen|Definite=Ind|Gender=Masc|Number=Sing	11	nmod	_	_
 11	vei	vei	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obj	_	_
 12	når	når	SCONJ	sbu	_	16	mark	_	_
-13	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
+13	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	nsubj:pass	_	_
 14	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	cop	_	_
 15	blitt	bli	AUX	verb	VerbForm=Part	16	aux:pass	_	_
 16	spurt	spørre	VERB	verb	VerbForm=Part	8	advcl	_	_
@@ -2899,7 +2899,7 @@
 12	opposisjonen	opposisjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	nsubj	_	_
 13	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
 14	mer	mye	ADJ	adj	Degree=Cmp	15	advmod	_	_
-15	regjeringsdyktig	regjeringsdyktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	advcl	_	_
+15	regjeringsdyktig	regjeringsdyktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	advcl	_	_
 16	enn	enn	SCONJ	sbu	_	18	mark	_	_
 17	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	18	nsubj	_	_
 18	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	advcl	_	SpaceAfter=No
@@ -2998,7 +2998,7 @@
 4	for	for	ADP	prep	_	7	case	_	_
 5	å	å	PART	inf-merke	_	7	mark	_	_
 6	være	være	AUX	verb	VerbForm=Inf	7	cop	_	_
-7	tilbakeholden	tilbakeholden	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+7	tilbakeholden	tilbakeholden	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 8	med	med	ADP	prep	_	9	case	_	_
 9	plan	plan	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obl	_	_
 10	B	b	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nmod	_	_
@@ -3019,8 +3019,8 @@
 9	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	_	_
 10	tror	tro	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl	_	_
 11	på	på	ADP	prep	_	14	case	_	_
-12	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
-13	rødgrønn	rødgrønn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+12	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
+13	rødgrønn	rødgrønn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	valgseier	valgseier	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obl	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -3055,7 +3055,7 @@
 27	resultatet	resultat	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	26	xcomp	_	_
 28	uansett	uansett	ADV	prep	_	29	advmod	_	_
 29	hvordan	hvordan	ADV	adv	_	31	advmod	_	_
-30	stemmene	stemme	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	31	nsubj	_	_
+30	stemmene	stemme	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	31	nsubj:pass	_	_
 31	fordeles	fordele	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	26	advcl	_	SpaceAfter=No
 32	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -3074,7 +3074,7 @@
 10	plan	plan	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	iobj	_	_
 11	B	b	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nmod	_	_
 12	være	være	AUX	verb	VerbForm=Inf	13	cop	_	_
-13	unevnelig	unevnelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	xcomp	_	SpaceAfter=No
+13	unevnelig	unevnelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	xcomp	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 015841
@@ -3088,7 +3088,7 @@
 7	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 8	bruke	bruke	VERB	verb	VerbForm=Inf	4	xcomp	_	_
 9	all	all	DET	det	Gender=Masc|Number=Sing|PronType=Tot	11	det	_	_
-10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	valgkampkraft	valgkampkraft	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obj	_	_
 12	på	på	ADP	prep	_	13	case	_	_
 13	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	obl	_	_
@@ -3098,7 +3098,7 @@
 17	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	aux	_	_
 18	vedtatt	vedta	VERB	verb	VerbForm=Part	13	acl:relcl	_	_
 19	på	på	ADP	prep	_	21	case	_	_
-20	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	21	det	_	_
+20	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	21	nmod:poss	_	_
 21	landsmøter	landsmøte	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	18	obl	_	_
 22	-	$-	PUNCT	<strek>	_	24	punct	_	_
 23	å	å	PART	inf-merke	_	24	mark	_	_
@@ -3125,7 +3125,7 @@
 6	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 7	se	se	VERB	verb	VerbForm=Inf	3	acl:relcl	_	_
 8	hvor	hvor	ADV	adv	_	9	advmod	_	_
-9	splittet	splitte	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	11	xcomp	_	_
+9	splittet	splitte	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	11	xcomp	_	_
 10	opposisjonen	opposisjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	nsubj	_	_
 11	fremstår	fremstå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	ccomp	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	3	punct	_	_
@@ -3168,7 +3168,7 @@
 2	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	allerede	allerede	ADV	adv	_	4	advmod	_	_
 4	markert	markere	VERB	verb	VerbForm=Part	0	root	_	_
-5	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+5	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 6	nei	nei	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	4	obj	_	_
 7	til	til	ADP	prep	_	8	case	_	_
 8	oljeaktivitet	oljeaktivitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nmod	_	_
@@ -3244,7 +3244,7 @@
 36	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	40	det	_	_
 37	langt	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	38	advmod	_	_
 38	mer	mye	ADJ	adj	Degree=Cmp	39	advmod	_	_
-39	fremtidsrettet	fremtidsrettet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	40	amod	_	_
+39	fremtidsrettet	fremtidsrettet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	40	amod	_	_
 40	næringspolitikk	næringspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	35	obj	_	_
 41	enn	enn	SCONJ	sbu	_	44	mark	_	_
 42	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	44	nsubj	_	_
@@ -3260,7 +3260,7 @@
 # text = Så hardt presset som de to minste regjeringspartiene er på meningsmålingene, vil det være naivt å tro at det ikke kommer flere lignende flagginger i løpet av valgkampinnspurten.
 1	Så	så	ADV	adv	_	2	advmod	_	_
 2	hardt	hard	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	3	advmod	_	_
-3	presset	presse	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	16	advmod	_	_
+3	presset	presse	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	16	advmod	_	_
 4	som	som	SCONJ	sbu	_	9	mark	_	_
 5	de	de	DET	det	Number=Plur|PronType=Art	8	det	_	_
 6	to	to	NUM	det	Number=Plur|NumType=Card	8	nummod	_	_
@@ -3313,7 +3313,7 @@
 20	kommer	komme	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	conj	_	_
 21	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	20	obj	_	_
 22	noenlunde	noenlunde	ADV	adv	_	23	advmod	_	_
-23	helskinnet	helskinnet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	xcomp	_	_
+23	helskinnet	helskinnet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	xcomp	_	_
 24	gjennom	gjennom	ADP	prep	_	25	case	_	_
 25	møtet	møte	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	20	obl	_	_
 26	med	med	ADP	prep	_	27	case	_	_
@@ -3535,7 +3535,7 @@
 8	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	expl	_	_
 9	klart	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	xcomp	_	_
 10	at	at	SCONJ	sbu	_	13	mark	_	_
-11	deres	deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	det	_	_
+11	deres	deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 12	partier	parti	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	13	nsubj	_	_
 13	går	gå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	ccomp	_	_
 14	til	til	ADP	prep	_	15	case	_	_
@@ -3645,7 +3645,7 @@
 25	store	stor	ADJ	adj	Degree=Pos|Number=Plur	26	amod	_	_
 26	deler	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	24	obj	_	_
 27	av	av	ADP	prep	_	29	case	_	_
-28	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	29	det	_	_
+28	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	29	nmod:poss	_	_
 29	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	26	nmod	_	_
 30	ved	ved	ADP	prep	_	31	case	_	_
 31	hjelp	hjelp	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	24	obl	_	_
@@ -3701,7 +3701,7 @@
 # text = Arrestert for ulovlig grensekryssing
 1	Arrestert	arrestere	VERB	verb	VerbForm=Part	0	root	_	_
 2	for	for	ADP	prep	_	4	case	_	_
-3	ulovlig	ulovlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	ulovlig	ulovlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	grensekryssing	grensekryssing	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	1	obl	_	_
 
 # newpar
@@ -3732,12 +3732,12 @@
 7	å	å	PART	inf-merke	_	8	mark	_	_
 8	få	få	VERB	verb	VerbForm=Inf	2	advcl	_	_
 9	journalistene	journalist	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	8	obj	_	_
-10	benådet	benåde	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	8	xcomp	_	_
+10	benådet	benåde	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	8	xcomp	_	_
 11	fra	fra	ADP	prep	_	13	case	_	_
 12	12	12	NUM	det	Number=Plur|NumType=Card	13	nummod	_	_
 13	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	10	obl	_	_
 14	i	i	ADP	prep	_	16	case	_	_
-15	nordkoreansk	nordkoreansk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	nordkoreansk	nordkoreansk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	arbeidsleir	arbeidsleir	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nmod	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -3752,9 +3752,9 @@
 
 # sent_id = 015868
 # text = Fangene slippes fri
-1	Fangene	fange	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	2	nsubj	_	_
+1	Fangene	fange	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	2	nsubj:pass	_	_
 2	slippes	slippe	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
-3	fri	fri	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	xcomp	_	_
+3	fri	fri	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	xcomp	_	_
 
 # sent_id = 015869
 # text = Journalister som forhandlingskort
@@ -3857,7 +3857,7 @@
 # newpar
 # sent_id = 015874
 # text = Clinton ble mottatt med blomster og vennlige håndtrykk da han landet, og dro så i et møte med den nordkoreanske lederen, Kim Jong-il.
-1	Clinton	Clinton	PROPN	subst	_	3	nsubj	_	_
+1	Clinton	Clinton	PROPN	subst	_	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	mottatt	motta	VERB	verb	VerbForm=Part	0	root	_	_
 4	med	med	ADP	prep	_	5	case	_	_
@@ -3902,14 +3902,14 @@
 14	tidligere	tidlig	ADJ	adj	Degree=Cmp	15	amod	_	_
 15	presidenten	president	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	20	nsubj	_	_
 16	og	og	CCONJ	konj	_	19	cc	_	_
-17	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	19	det	_	_
+17	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 18	to	to	NUM	det	Number=Plur|NumType=Card	19	nummod	_	_
 19	medarbeidere	medarbeider	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	15	conj	_	_
 20	spiste	spise	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	_	_
 21	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
 22	to	to	NUM	det	Number=Plur|NumType=Card	23	nummod	_	_
 23	timer	time	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	24	obl	_	_
-24	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	middag	middag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	20	obj	_	_
 26	sammen	sammen	ADV	adv	_	30	advmod	_	_
 27	med	med	ADP	prep	_	30	case	_	_
@@ -3940,7 +3940,7 @@
 
 # sent_id = 015877
 # text = Hva som ble sagt på møtet mellom Kim Jong-il og Clinton er ikke kjent, men ifølge flere amerikanske medier skal Clintons besøk ha åpnet en kanal for dialog mellom de to landene, som ikke har et spesielt godt forhold.
-1	Hva	hva	PRON	pron	PronType=Int	4	nsubj	_	_
+1	Hva	hva	PRON	pron	PronType=Int	4	nsubj:pass	_	_
 2	som	som	SCONJ	sbu	_	4	mark	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	_	_
 4	sagt	si	VERB	verb	VerbForm=Part	14	csubj	_	_
@@ -3992,7 +3992,7 @@
 5	Clinton	Clinton	PROPN	subst	_	6	nsubj	_	_
 6	leverte	levere	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	personlig	personlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	personlig	personlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	melding	melding	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
 10	til	til	ADP	prep	_	11	case	_	_
 11	Kim	Kim	PROPN	subst	_	9	nmod	_	_
@@ -4028,7 +4028,7 @@
 16	at	at	SCONJ	sbu	_	21	mark	_	_
 17	Nord-Koreas	Nord-Korea	PROPN	subst	Case=Gen	19	nmod	_	_
 18	omstridte	omstridt	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	19	amod	_	_
-19	atomprogram	atomprogram	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	21	nsubj	_	_
+19	atomprogram	atomprogram	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	21	nsubj:pass	_	_
 20	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	21	aux:pass	_	_
 21	diskutert	diskutere	VERB	verb	VerbForm=Part	15	csubj	_	SpaceAfter=No
 22	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -4046,7 +4046,7 @@
 9	på	på	ADP	prep	_	10	case	_	_
 10	slutten	slutt	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 11	av	av	ADP	prep	_	13	case	_	_
-12	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	13	det	_	_
+12	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 13	presidentskap	presidentskap	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	10	nmod	_	SpaceAfter=No
 14	,	$,	PUNCT	<komma>	_	16	punct	_	_
 15	i	i	ADP	prep	_	16	case	_	_
@@ -4055,7 +4055,7 @@
 18	,	$,	PUNCT	<komma>	_	23	punct	_	_
 19	men	men	CCONJ	konj	_	23	cc	_	_
 20	denne	denne	DET	det	Gender=Masc|Number=Sing|PronType=Dem	21	det	_	_
-21	turen	tur	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	23	nsubj	_	_
+21	turen	tur	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	23	nsubj:pass	_	_
 22	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	23	aux:pass	_	_
 23	innstilt	innstille	VERB	verb	VerbForm=Part	5	conj	_	_
 24	på	på	ADP	prep	_	25	case	_	_
@@ -4103,7 +4103,7 @@
 33	at	at	SCONJ	sbu	_	40	mark	_	_
 34	de	de	DET	det	Number=Plur|PronType=Art	36	det	_	_
 35	to	to	NUM	det	Number=Plur|NumType=Card	36	nummod	_	_
-36	journalistene	journalist	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	40	nsubj	_	_
+36	journalistene	journalist	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	40	nsubj:pass	_	_
 37	faktisk	faktisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	40	advmod	_	_
 38	ville	ville	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	40	aux	_	_
 39	bli	bli	AUX	verb	VerbForm=Inf	40	aux:pass	_	_
@@ -4119,7 +4119,7 @@
 # text = En kilde nær den amerikanske regjeringen sier til CNN at USA hadde fått bekreftelse på at de to ville bli løslatt før Clinton ble sendt av gårde.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	2	det	_	_
 2	kilde	kilde	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj	_	_
-3	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+3	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 4	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
 5	amerikanske	amerikansk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	6	amod	_	_
 6	regjeringen	regjering	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obj	_	_
@@ -4134,12 +4134,12 @@
 15	på	på	ADP	prep	_	21	case	_	_
 16	at	at	SCONJ	sbu	_	21	mark	_	_
 17	de	de	DET	det	Number=Plur|PronType=Art	18	det	_	_
-18	to	to	NUM	det	Number=Plur|NumType=Card	21	nsubj	_	_
+18	to	to	NUM	det	Number=Plur|NumType=Card	21	nsubj:pass	_	_
 19	ville	ville	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	21	aux	_	_
 20	bli	bli	AUX	verb	VerbForm=Inf	21	aux:pass	_	_
 21	løslatt	løslate	VERB	verb	VerbForm=Part	14	acl	_	_
 22	før	før	SCONJ	sbu	_	25	mark	_	_
-23	Clinton	Clinton	PROPN	subst	_	25	nsubj	_	_
+23	Clinton	Clinton	PROPN	subst	_	25	nsubj:pass	_	_
 24	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	25	aux:pass	_	_
 25	sendt	sende	VERB	verb	VerbForm=Part	21	advcl	_	_
 26	av	av	ADP	prep	_	27	case	_	_
@@ -4156,7 +4156,7 @@
 6	ikke	ikke	PART	adv	Polarity=Neg	10	advmod	_	_
 7	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	_	_
 8	av	av	ADP	prep	_	10	case	_	_
-9	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	karakter	karakter	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	ccomp	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	15	punct	_	_
 12	men	men	CCONJ	konj	_	15	cc	_	_
@@ -4226,7 +4226,7 @@
 
 # sent_id = 015886
 # text = De ble arrestert 17. juni, og tiltalt for å ulovlig ha krysset grensen til Nord-Korea.
-1	De	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	_	_
+1	De	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	arrestert	arrestere	VERB	verb	VerbForm=Part	0	root	_	_
 4	17.	17.	ADJ	adj	Number=Plur|NumType=Ord	5	amod	_	_
@@ -4268,7 +4268,7 @@
 20	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	25	aux:pass	_	_
 21	de	de	DET	det	Number=Plur|PronType=Art	23	det	_	_
 22	to	to	NUM	det	Number=Plur|NumType=Card	23	nummod	_	_
-23	journalistene	journalist	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	25	nsubj	_	_
+23	journalistene	journalist	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	25	nsubj:pass	_	_
 24	likevel	likevel	ADV	adv	_	25	advmod	_	_
 25	dømt	dømme	VERB	verb	VerbForm=Part	0	root	_	_
 26	til	til	ADP	prep	_	29	case	_	_
@@ -4322,7 +4322,7 @@
 12	hjem	hjem	ADP	prep	_	14	case	_	_
 13	til	til	ADP	prep	_	14	case	_	_
 14	familiene	familie	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	11	obl	_	_
-15	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	14	det	_	SpaceAfter=No
+15	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	14	nmod:poss	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 015890
@@ -4341,7 +4341,7 @@
 12	ville	ville	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	aux	_	_
 13	slippe	slippe	VERB	verb	VerbForm=Inf	8	acl	_	_
 14	dem	de	PRON	pron	Case=Acc|Number=Plur|Person=3|PronType=Prs	13	obj	_	_
-15	fri	fri	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	xcomp	_	_
+15	fri	fri	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	xcomp	_	_
 16	om	om	SCONJ	sbu	_	19	mark	_	_
 17	Bill	Bill	PROPN	subst	_	19	nsubj	_	_
 18	Clinton	Clinton	PROPN	subst	_	17	flat:name	_	_
@@ -4452,7 +4452,7 @@
 2	Clinton	Clinton	PROPN	subst	_	3	nsubj	_	_
 3	ga	gi	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	31	ccomp	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	ektefølt	ektefølt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	ektefølt	ektefølt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	unnskyldning	unnskyldning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 7	til	til	ADP	prep	_	8	case	_	_
 8	Kim	Kim	PROPN	subst	_	3	obl	_	_
@@ -4504,7 +4504,7 @@
 5	ut	ut	ADV	prep	_	3	advmod	_	_
 6	som	som	ADP	prep	_	9	case	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	skolejente	skolejente	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	xcomp	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	15	punct	_	_
 11	andre	annen	DET	det	Number=Plur|PronType=Dem	12	det	_	_
@@ -4518,7 +4518,7 @@
 
 # sent_id = 015898
 # text = Nordkoreansk talsmann om Hillary Clinton
-1	Nordkoreansk	nordkoreansk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Nordkoreansk	nordkoreansk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	talsmann	talsmann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 3	om	om	ADP	prep	_	4	case	_	_
 4	Hillary	Hillary	PROPN	subst	_	2	obl	_	_
@@ -4542,7 +4542,7 @@
 13	kraftig	kraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	14	amod	_	_
 14	personangrep	personangrep	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	10	obl	_	_
 15	på	på	ADP	prep	_	17	case	_	_
-16	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	17	det	_	_
+16	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
 17	kone	kone	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
 18	,	$,	PUNCT	<komma>	_	19	punct	_	_
 19	utenriksminister	utenriksminister	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	appos	_	_
@@ -4572,7 +4572,7 @@
 18	oppførselen	oppførsel	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	16	obl	_	_
 19	til	til	ADP	prep	_	22	case	_	_
 20	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-21	oppmerksomhetssyk	oppmerksomhetssyk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	amod	_	_
+21	oppmerksomhetssyk	oppmerksomhetssyk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	amod	_	_
 22	tenåring	tenåring	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	nmod	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -4595,16 +4595,16 @@
 15	Clinton	Clinton	PROPN	subst	_	14	obj	_	_
 16	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
 17	«	$"	PUNCT	<anf>	_	19	punct	_	SpaceAfter=No
-18	rar	rar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	rar	rar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	dame	dame	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	xcomp	_	SpaceAfter=No
 20	»	$"	PUNCT	<anf>	_	19	punct	_	_
 21	som	som	SCONJ	sbu	_	24	mark	_	_
 22	hverken	hverken	CCONJ	konj	_	24	cc	_	_
 23	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	24	cop	_	_
-24	intelligent	intelligent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+24	intelligent	intelligent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 25	eller	eller	CCONJ	konj	_	27	cc	_	_
 26	særlig	særlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	27	advmod	_	_
-27	diplomatisk	diplomatisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	24	conj	_	SpaceAfter=No
+27	diplomatisk	diplomatisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	24	conj	_	SpaceAfter=No
 28	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 015902
@@ -4617,7 +4617,7 @@
 6	ut	ut	ADV	prep	_	4	advmod	_	_
 7	som	som	ADP	prep	_	10	case	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-9	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	skolejente	skolejente	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	xcomp	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	16	punct	_	_
 12	andre	annen	DET	det	Number=Plur|PronType=Dem	13	det	_	_
@@ -4652,10 +4652,10 @@
 13	og	og	CCONJ	konj	_	18	cc	_	_
 14	de	de	DET	det	Number=Plur|PronType=Art	16	det	_	_
 15	to	to	NUM	det	Number=Plur|NumType=Card	16	nummod	_	_
-16	journalistene	journalist	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	18	nsubj	_	_
+16	journalistene	journalist	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	18	nsubj:pass	_	_
 17	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	18	aux:pass	_	_
 18	satt	sette	VERB	verb	VerbForm=Part	11	conj	_	_
-19	fri	fri	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	advmod	_	SpaceAfter=No
+19	fri	fri	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	advmod	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	11	punct	_	_
 
 # sent_id = 015904
@@ -4769,7 +4769,7 @@
 5	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 6	snakket	snakke	VERB	verb	VerbForm=Part	2	xcomp	_	_
 7	med	med	ADP	prep	_	9	case	_	_
-8	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	det	_	_
+8	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 9	ektemann	ektemann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	11	punct	_	_
 11	ekspresidenten	ekspresident	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	appos	_	SpaceAfter=No
@@ -4782,7 +4782,7 @@
 18	bord	bord	NOUN	subst	_	16	obl	_	_
 19	i	i	ADP	prep	_	20	case	_	_
 20	privatjetflyet	privatjetfly	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	18	nmod	_	_
-21	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	20	det	_	_
+21	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	20	nmod:poss	_	_
 22	sammen	sammen	ADV	adv	_	24	advmod	_	_
 23	med	med	ADP	prep	_	24	case	_	_
 24	journalistene	journalist	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	16	obl	_	SpaceAfter=No
@@ -4797,13 +4797,13 @@
 33	at	at	SCONJ	sbu	_	39	mark	_	_
 34	de	de	DET	det	Number=Plur|PronType=Art	36	det	_	_
 35	to	to	NUM	det	Number=Plur|NumType=Card	36	nummod	_	_
-36	journalistene	journalist	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	39	nsubj	_	_
+36	journalistene	journalist	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	39	nsubj:pass	_	_
 37	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	39	aux	_	_
 38	bli	bli	AUX	verb	VerbForm=Inf	39	aux:pass	_	_
 39	gjenforent	gjenforene	VERB	verb	VerbForm=Part	16	advcl	_	_
 40	med	med	ADP	prep	_	41	case	_	_
 41	familiene	familie	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	39	obl	_	_
-42	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	41	det	_	_
+42	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	41	nmod:poss	_	_
 43	med	med	ADP	prep	_	45	case	_	_
 44	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	45	det	_	_
 45	gang	gang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	39	obl	_	SpaceAfter=No
@@ -4816,9 +4816,9 @@
 3	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
 4	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	_	_
 5	både	både	CCONJ	konj	_	6	cc	_	_
-6	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	ccomp	_	_
+6	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	ccomp	_	_
 7	og	og	CCONJ	konj	_	8	cc	_	_
-8	lettet	lette	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	6	conj	_	_
+8	lettet	lette	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	6	conj	_	_
 9	for	for	ADP	prep	_	14	case	_	_
 10	at	at	SCONJ	sbu	_	14	mark	_	_
 11	de	de	DET	det	Number=Plur|PronType=Art	12	det	_	_
@@ -4839,7 +4839,7 @@
 # newpar
 # sent_id = 015911
 # text = Høy pris.
-1	Høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	pris	pris	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 3	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -4869,7 +4869,7 @@
 2	av	av	ADP	prep	_	3	case	_	_
 3	Høyre-velgerne	Høyre-velger	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	1	nmod	_	_
 4	mener	mene	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-5	deres	deres	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+5	deres	deres	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 6	parti	parti	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	8	nsubj	_	_
 7	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 8	danne	danne	VERB	verb	VerbForm=Inf	4	xcomp	_	_
@@ -4901,7 +4901,7 @@
 4	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 5	være	være	AUX	verb	VerbForm=Inf	8	cop	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	blandet	blande	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	8	amod	_	_
+7	blandet	blande	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	8	amod	_	_
 8	følelse	følelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 9	for	for	ADP	prep	_	10	case	_	_
 10	Høyre	Høyre	PROPN	subst	_	8	obl	_	SpaceAfter=No
@@ -4916,14 +4916,14 @@
 5	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	4	obj	_	_
 6	å	å	PART	inf-merke	_	8	mark	_	_
 7	være	være	AUX	verb	VerbForm=Inf	8	cop	_	_
-8	stolt	stolt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+8	stolt	stolt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 9	av	av	ADV	prep	_	8	advmod	_	_
 10	fra	fra	ADP	prep	_	13	case	_	_
 11	de	de	DET	det	Number=Plur|PronType=Art	13	det	_	_
 12	beste	god	ADJ	adj	Definite=Def|Degree=Sup	13	amod	_	_
 13	periodene	periode	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	8	obl	_	_
 14	i	i	ADP	prep	_	16	case	_	_
-15	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	16	det	_	_
+15	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	16	nmod:poss	_	_
 16	historie	historie	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nmod	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -4944,7 +4944,7 @@
 13	ansvarlighet	ansvarlighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	conj	_	_
 14	til	til	ADP	prep	_	17	case	_	_
 15	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-16	praktisk	praktisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	praktisk	praktisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obl	_	_
 18	som	som	SCONJ	sbu	_	21	mark	_	_
 19	folk	folk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	21	nsubj	_	_
@@ -4969,7 +4969,7 @@
 4	skjedde	skje	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 5	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 6	under	under	ADP	prep	_	9	case	_	_
-7	Kåre	Kåre	PROPN	subst	Gender=Masc	9	nmod	_	_
+7	Kåre	Kåre	PROPN	subst	Gender=Masc	9	nmod:poss	_	_
 8	Willochs	Willoch	PROPN	subst	Case=Gen	7	flat:name	_	_
 9	regjering	regjering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	obl	_	_
 10	på	på	ADP	prep	_	11	case	_	_
@@ -4986,7 +4986,7 @@
 21	og	og	CCONJ	konj	_	23	cc	_	_
 22	boligmarkedet	boligmarked	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	23	nsubj	_	_
 23	sluppet	slippe	VERB	verb	VerbForm=Part	15	conj	_	_
-24	fri	fri	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	advmod	_	_
+24	fri	fri	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	advmod	_	_
 25	på	på	ADP	prep	_	27	case	_	_
 26	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	27	det	_	_
 27	måte	måte	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	23	obl	_	_
@@ -5013,11 +5013,11 @@
 # text = Men dagens jubileum feires i en vanskelig situasjon for Høyre.
 1	Men	men	CCONJ	konj	_	4	cc	_	_
 2	dagens	dag	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
-3	jubileum	jubileum	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	4	nsubj	_	_
+3	jubileum	jubileum	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	4	nsubj:pass	_	_
 4	feires	feire	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 5	i	i	ADP	prep	_	8	case	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	vanskelig	vanskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	vanskelig	vanskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	situasjon	situasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 9	for	for	ADP	prep	_	10	case	_	_
 10	Høyre	Høyre	PROPN	subst	_	8	nmod	_	SpaceAfter=No
@@ -5036,7 +5036,7 @@
 9	risikerer	risikere	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	ccomp	_	_
 10	å	å	PART	inf-merke	_	11	mark	_	_
 11	få	få	VERB	verb	VerbForm=Inf	9	xcomp	_	_
-12	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	14	det	_	_
+12	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	14	nmod:poss	_	_
 13	dårligste	dårlig	ADJ	adj	Definite=Def|Degree=Sup	14	amod	_	_
 14	resultat	resultat	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	11	obj	_	_
 15	siden	siden	ADP	prep	_	16	case	_	_
@@ -5070,7 +5070,7 @@
 10	med	med	ADP	prep	_	12	case	_	_
 11	å	å	PART	inf-merke	_	12	mark	_	_
 12	miste	miste	VERB	verb	VerbForm=Inf	9	acl	_	_
-13	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	14	det	_	_
+13	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	14	nmod:poss	_	_
 14	posisjon	posisjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obj	_	_
 15	som	som	ADP	prep	_	18	case	_	_
 16	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
@@ -5081,7 +5081,7 @@
 21	borgerlige	borgerlig	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	22	amod	_	_
 22	side	side	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	18	nmod	_	_
 23	i	i	ADP	prep	_	25	case	_	_
-24	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	22	nmod	_	SpaceAfter=No
 26	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -5110,9 +5110,9 @@
 21	hverken	hverken	CCONJ	konj	_	24	cc	_	_
 22	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	23	aux	_	_
 23	kalles	kalle	VERB	verb	VerbForm=Inf|Voice=Pass	16	acl:relcl	_	_
-24	borgerlig	borgerlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	xcomp	_	_
+24	borgerlig	borgerlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	xcomp	_	_
 25	eller	eller	CCONJ	konj	_	26	cc	_	_
-26	konservativ	konservativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	24	conj	_	_
+26	konservativ	konservativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	24	conj	_	_
 27	-	$-	PUNCT	<strek>	_	34	punct	_	_
 28	i	i	ADP	prep	_	30	case	_	_
 29	alle	all	DET	det	Number=Plur|PronType=Tot	30	det	_	_
@@ -5125,7 +5125,7 @@
 36	Høyre-ideologer	Høyre-ideolog	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	38	nsubj	_	_
 37	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	38	aux	_	_
 38	definert	definere	VERB	verb	VerbForm=Part	34	acl:relcl	_	_
-39	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	41	det	_	_
+39	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	41	nmod:poss	_	_
 40	liberale	liberal	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	41	amod	_	_
 41	konservatisme	konservatisme	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	38	obj	_	_
 42	gjennom	gjennom	ADP	prep	_	44	case	_	_
@@ -5141,7 +5141,7 @@
 3	nummer	nummer	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	4	obl	_	_
 4	to	to	NUM	det	Number=Plur|NumType=Card	11	csubj	_	_
 5	på	på	ADP	prep	_	7	case	_	_
-6	ikke-sosialistisk	ikke-sosialistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	ikke-sosialistisk	ikke-sosialistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	side	side	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	obl	_	_
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	_	_
 9	ikke	ikke	PART	adv	Polarity=Neg	10	advmod	_	_
@@ -5196,7 +5196,7 @@
 33	som	som	SCONJ	sbu	_	36	mark	_	_
 34	Høyre	Høyre	PROPN	subst	_	36	nsubj	_	_
 35	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	36	cop	_	_
-36	villig	villig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	32	amod	_	_
+36	villig	villig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	32	amod	_	_
 37	til	til	ADP	prep	_	39	case	_	_
 38	å	å	PART	inf-merke	_	39	mark	_	_
 39	gjenopplive	gjenopplive	VERB	verb	VerbForm=Inf	36	advcl	_	_
@@ -5376,7 +5376,7 @@
 14	opposisjonspartiene	opposisjonsparti	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	10	nmod	_	_
 15	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	cop	_	_
 16	så	så	ADV	adv	_	17	advmod	_	_
-17	begrenset	begrenset	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	advcl	_	_
+17	begrenset	begrenset	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	advcl	_	_
 18	at	at	SCONJ	sbu	_	28	mark	_	_
 19	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	20	det	_	_
 20	regjeringssamarbeid	regjeringssamarbeid	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	28	nsubj	_	_
@@ -5408,7 +5408,7 @@
 13	definere	definere	VERB	verb	VerbForm=Inf	10	acl	_	_
 14	hvordan	hvordan	ADV	adv	_	18	advmod	_	_
 15	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
-16	opposisjonspolitikk	opposisjonspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	nsubj	_	_
+16	opposisjonspolitikk	opposisjonspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	nsubj:pass	_	_
 17	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	aux	_	_
 18	omformes	omforme	VERB	verb	VerbForm=Inf|Voice=Pass	13	xcomp	_	_
 19	til	til	ADP	prep	_	21	case	_	_
@@ -5420,7 +5420,7 @@
 # text = Både under John Lyngs ledelse på 1950- og 1960-tallet og i det svært effektive samarbeidet mellom den politiske strategen Kåre Willoch og den unike velgerververen Erling Norvik på slutten av 1970- og begynnelsen av 1980-tallet var Høyre den ledende kraft i å samle alle ikke-sosialistiske partier i en felles front mot Arbeiderpartiet i kampen om regjeringsmakten.
 1	Både	både	CCONJ	konj	_	5	cc	_	_
 2	under	under	ADP	prep	_	5	case	_	_
-3	John	John	PROPN	subst	Gender=Masc	5	nmod	_	_
+3	John	John	PROPN	subst	Gender=Masc	5	nmod:poss	_	_
 4	Lyngs	Lyng	PROPN	subst	Case=Gen	3	flat:name	_	_
 5	ledelse	ledelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	40	obl	_	_
 6	på	på	ADP	prep	_	7	case	_	_
@@ -5466,7 +5466,7 @@
 46	partier	parti	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	43	obj	_	_
 47	i	i	ADP	prep	_	50	case	_	_
 48	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	50	det	_	_
-49	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	50	amod	_	_
+49	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	50	amod	_	_
 50	front	front	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	43	obl	_	_
 51	mot	mot	ADP	prep	_	52	case	_	_
 52	Arbeiderpartiet	Arbeiderpartiet	PROPN	subst	_	50	nmod	_	_
@@ -5487,7 +5487,7 @@
 7	at	at	SCONJ	sbu	_	14	mark	_	_
 8	veien	vei	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	_
 9	til	til	ADP	prep	_	11	case	_	_
-10	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	innflytelse	innflytelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nmod	_	_
 12	for	for	ADP	prep	_	13	case	_	_
 13	Høyre	Høyre	PROPN	subst	_	11	nmod	_	_
@@ -5559,7 +5559,7 @@
 7	til	til	ADP	prep	_	9	case	_	_
 8	å	å	PART	inf-merke	_	9	mark	_	_
 9	opprettholde	opprettholde	VERB	verb	VerbForm=Inf	6	acl	_	_
-10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	posisjon	posisjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obj	_	_
 12	som	som	ADP	prep	_	13	case	_	_
 13	drivkraft	drivkraft	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	nmod	_	_
@@ -5574,7 +5574,7 @@
 22	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	26	expl	_	_
 23	også	også	ADV	adv	_	26	advmod	_	_
 24	til	til	ADP	prep	_	26	case	_	_
-25	begrenset	begrenset	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	amod	_	_
+25	begrenset	begrenset	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	amod	_	_
 26	trøst	trøst	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	0	root	_	_
 27	at	at	SCONJ	sbu	_	36	mark	_	_
 28	flertallet	flertall	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	36	nsubj	_	_
@@ -5627,7 +5627,7 @@
 17	Høyre-velgerne	Høyre-velger	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	18	nsubj	_	_
 18	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	conj	_	_
 19	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
-20	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	amod	_	_
+20	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	amod	_	_
 21	overbevisning	overbevisning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	obj	_	_
 22	om	om	ADP	prep	_	23	case	_	_
 23	fortreffeligheten	fortreffelighet	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	_
@@ -5786,7 +5786,7 @@
 18	for	for	ADV	prep	_	16	advmod	_	_
 19	at	at	SCONJ	sbu	_	33	mark	_	_
 20	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	21	det	_	_
-21	verdigrunnlaget	verdigrunnlag	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	33	nsubj	_	_
+21	verdigrunnlaget	verdigrunnlag	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	33	nsubj:pass	_	_
 22	Høyre	Høyre	PROPN	subst	_	26	nsubj	_	_
 23	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	26	aux	_	_
 24	vært	være	AUX	verb	VerbForm=Part	26	cop	_	_
@@ -5881,7 +5881,7 @@
 2	Solberg	Solberg	PROPN	subst	_	1	flat:name	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	ryddig	ryddig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	ryddig	ryddig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	politiker	politiker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -5921,7 +5921,7 @@
 32	til	til	ADP	prep	_	34	case	_	_
 33	å	å	PART	inf-merke	_	34	mark	_	_
 34	holde	holde	VERB	verb	VerbForm=Inf	30	advcl	_	_
-35	fast	fast	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	34	advmod	_	_
+35	fast	fast	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	34	advmod	_	_
 36	på	på	ADP	prep	_	37	case	_	_
 37	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	34	obl	_	_
 38	gjennom	gjennom	ADP	prep	_	40	case	_	_
@@ -5988,7 +5988,7 @@
 38	urealistiske	urealistisk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	39	amod	_	_
 39	regjeringsalternativet	regjeringsalternativ	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	33	obl	_	_
 40	på	på	ADP	prep	_	42	case	_	_
-41	ikke-sosialistisk	ikke-sosialistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	42	amod	_	_
+41	ikke-sosialistisk	ikke-sosialistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	42	amod	_	_
 42	side	side	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	39	nmod	_	SpaceAfter=No
 43	.	$.	PUNCT	clb	_	17	punct	_	_
 
@@ -6066,7 +6066,7 @@
 6	slik	slik	ADV	adv	_	7	advmod	_	_
 7	konstellasjon	konstellasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nsubj	_	_
 8	bare	bare	ADV	adv	_	9	advmod	_	_
-9	tenkelig	tenkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+9	tenkelig	tenkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 10	hvis	hvis	SCONJ	sbu	_	14	mark	_	_
 11	de	de	DET	det	Number=Plur|PronType=Art	13	det	_	_
 12	to	to	NUM	det	Number=Plur|NumType=Card	13	nummod	_	_
@@ -6201,7 +6201,7 @@
 22	,	$,	PUNCT	<komma>	_	17	punct	_	_
 23	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	26	cop	_	_
 24	sikkert	sikker	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	26	advmod	_	_
-25	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	amod	_	_
+25	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	amod	_	_
 26	musikk	musikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 27	i	i	ADP	prep	_	28	case	_	_
 28	ørene	øre	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	26	nmod	_	_
@@ -6218,7 +6218,7 @@
 4	som	som	SCONJ	sbu	_	7	mark	_	_
 5	primært	primær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	advmod	_	_
 6	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
-7	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+7	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 8	av	av	ADP	prep	_	13	case	_	_
 9	at	at	SCONJ	sbu	_	13	mark	_	_
 10	de	de	DET	det	Number=Plur|PronType=Art	11	det	_	_
@@ -6231,7 +6231,7 @@
 17	denne	denne	DET	det	Gender=Fem|Number=Sing|PronType=Dem	18	det	_	_
 18	form	form	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	23	nsubj	_	_
 19	for	for	ADP	prep	_	21	case	_	_
-20	intern	intern	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	amod	_	_
+20	intern	intern	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	amod	_	_
 21	krigføring	krigføring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	18	nmod	_	_
 22	kunne	kunne	AUX	verb	VerbForm=Inf	23	aux	_	_
 23	virke	virke	VERB	verb	VerbForm=Inf	0	root	_	_
@@ -6267,7 +6267,7 @@
 23	meningsfylt	meningsfylt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	21	obj	_	_
 24	i	i	ADP	prep	_	25	case	_	_
 25	ordet	ord	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	21	obl	_	_
-26	borgerlig	borgerlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	appos	_	SpaceAfter=No
+26	borgerlig	borgerlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	appos	_	SpaceAfter=No
 27	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # newpar
@@ -6290,7 +6290,7 @@
 15	likevel	likevel	ADV	adv	_	16	advmod	_	_
 16	fått	få	VERB	verb	VerbForm=Part	0	root	_	_
 17	fra	fra	ADP	prep	_	19	case	_	_
-18	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	19	det	_	_
+18	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 19	egne	egen	DET	det	Number=Plur|PronType=Prs	16	obl	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	16	punct	_	_
 
@@ -6311,7 +6311,7 @@
 13	Frp	Frp	PROPN	subst	Abbr=Yes	11	nmod	_	_
 14	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	cop	_	_
 15	så	så	ADV	adv	_	16	advmod	_	_
-16	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	conj	_	_
+16	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	conj	_	_
 17	at	at	SCONJ	sbu	_	20	mark	_	_
 18	18	18	NUM	det	Number=Plur|NumType=Card	19	nummod	_	_
 19	prosent	prosent	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	20	nsubj	_	_
@@ -6321,7 +6321,7 @@
 23	alternativet	alternativ	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	27	nsubj	_	_
 24	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	27	cop	_	_
 25	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	27	det	_	_
-26	ren	ren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	27	amod	_	_
+26	ren	ren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	27	amod	_	_
 27	Høyre-regjering	Høyre-regjering	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	20	ccomp	_	SpaceAfter=No
 28	,	$,	PUNCT	<komma>	_	16	punct	_	_
 29	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	34	cop	_	_
@@ -6329,7 +6329,7 @@
 31	Solberg	Solberg	PROPN	subst	_	34	nsubj	_	_
 32	lenger	lenge	ADJ	adj	Degree=Cmp	34	advmod	_	_
 33	så	så	ADV	adv	_	34	advmod	_	_
-34	svinebundet	svinebinde	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	_
+34	svinebundet	svinebinde	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	_
 35	som	som	SCONJ	sbu	_	37	mark	_	_
 36	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	37	nsubj	_	_
 37	var	være	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	33	advcl	_	_
@@ -6344,11 +6344,11 @@
 3	risikoen	risiko	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	_
 4	for	for	ADP	prep	_	7	case	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	dyp	dyp	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	dyp	dyp	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	splittelse	splittelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nmod	_	_
 8	i	i	ADP	prep	_	9	case	_	_
 9	partiet	parti	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	nmod	_	_
-10	overhengende	overhengende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+10	overhengende	overhengende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 11	hvis	hvis	SCONJ	sbu	_	14	mark	_	_
 12	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
 13	ikke	ikke	PART	adv	Polarity=Neg	14	advmod	_	_
@@ -6491,7 +6491,7 @@
 5	regjeringsalternativer	regjeringsalternativ	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	2	nmod	_	_
 6	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 7	vært	være	AUX	verb	VerbForm=Part	8	cop	_	_
-8	nødvendig	nødvendig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+8	nødvendig	nødvendig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	15	punct	_	_
 10	men	men	CCONJ	konj	_	15	cc	_	_
 11	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
@@ -6507,7 +6507,7 @@
 2	fikk	få	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	panikk	panikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 4	da	da	SCONJ	sbu	_	19	mark	_	_
-5	bildet	bilde	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	19	nsubj	_	_
+5	bildet	bilde	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	19	nsubj:pass	_	_
 6	av	av	ADP	prep	_	7	case	_	_
 7	Erna	Erna	PROPN	subst	_	5	nmod	_	_
 8	Solberg	Solberg	PROPN	subst	_	7	flat:name	_	_
@@ -6594,7 +6594,7 @@
 # text = Men da bildet endelig ble tatt i Stortingets vandrehall, benyttet Jensen anledningen til å spille forurettet på en måte som antagelig skadet Frp mer enn Høyre.
 1	Men	men	CCONJ	konj	_	11	cc	_	_
 2	da	da	SCONJ	sbu	_	6	mark	_	_
-3	bildet	bilde	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	nsubj	_	_
+3	bildet	bilde	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	nsubj:pass	_	_
 4	endelig	endelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
 5	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 6	tatt	ta	VERB	verb	VerbForm=Part	11	advcl	_	_
@@ -6608,7 +6608,7 @@
 14	til	til	ADP	prep	_	16	case	_	_
 15	å	å	PART	inf-merke	_	16	mark	_	_
 16	spille	spille	VERB	verb	VerbForm=Inf	11	advcl	_	_
-17	forurettet	forurette	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	16	xcomp	_	_
+17	forurettet	forurette	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	16	xcomp	_	_
 18	på	på	ADP	prep	_	20	case	_	_
 19	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
 20	måte	måte	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	obl	_	_
@@ -6636,7 +6636,7 @@
 11	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	14	cop	_	_
 12	tonen	tone	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	_
 13	mer	mye	ADJ	adj	Degree=Cmp	14	advmod	_	_
-14	saklig	saklig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+14	saklig	saklig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	14	punct	_	_
 
 # sent_id = 015988
@@ -6763,7 +6763,7 @@
 10	ikke	ikke	PART	adv	Polarity=Neg	11	advmod	_	_
 11	bare	bare	ADV	adv	_	8	advmod	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-13	overhengende	overhengende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	overhengende	overhengende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	fare	fare	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nsubj	_	_
 15	for	for	ADP	prep	_	18	case	_	_
 16	å	å	PART	inf-merke	_	18	mark	_	_
@@ -6820,7 +6820,7 @@
 4	se	se	VERB	verb	VerbForm=Inf	0	root	_	_
 5	slutten	slutt	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	obj	_	_
 6	på	på	ADP	prep	_	9	case	_	_
-7	Kristin	Kristin	PROPN	subst	Gender=Fem	9	nmod	_	_
+7	Kristin	Kristin	PROPN	subst	Gender=Fem	9	nmod:poss	_	_
 8	Halvorsens	Halvorsen	PROPN	subst	Case=Gen	7	flat:name	_	_
 9	karrière	karriere	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nmod	_	_
 10	som	som	ADP	prep	_	11	case	_	_
@@ -6878,7 +6878,7 @@
 8	når	når	SCONJ	sbu	_	16	mark	_	_
 9	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
 10	i	i	ADP	prep	_	13	case	_	_
-11	VG	VG	PROPN	subst	_	13	nmod	_	_
+11	VG	VG	PROPN	subst	_	13	nmod:poss	_	_
 12	TVs	TV	NOUN	subst	Case=Gen|Definite=Ind|Gender=Masc|Number=Sing	11	flat:name	_	_
 13	partilederdebatt	partilederdebatt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	obl	_	_
 14	i	i	ADP	prep	_	15	case	_	_
@@ -6954,14 +6954,14 @@
 2	stemmer	stemme	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	2	advmod	_	_
 4	med	med	ADP	prep	_	6	case	_	_
-5	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+5	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 6	visjon	visjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	_
 7	om	om	ADP	prep	_	9	case	_	_
 8	å	å	PART	inf-merke	_	9	mark	_	_
 9	gjøre	gjøre	VERB	verb	VerbForm=Inf	6	acl	_	_
 10	integrering	integrering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	obj	_	_
 11	til	til	ADP	prep	_	14	case	_	_
-12	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	14	det	_	_
+12	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	14	nmod:poss	_	_
 13	politiske	politisk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	14	amod	_	_
 14	hovedprosjekt	hovedprosjekt	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	obl	_	_
 15	når	når	SCONJ	sbu	_	18	mark	_	_
@@ -6993,7 +6993,7 @@
 8	hjemmebane	hjemmebane	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nmod	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	8	punct	_	_
 10	hemmes	hemme	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
-11	Stoltenberg	Stoltenberg	PROPN	subst	_	10	nsubj	_	_
+11	Stoltenberg	Stoltenberg	PROPN	subst	_	10	nsubj:pass	_	_
 12	av	av	ADP	prep	_	13	case	_	_
 13	frykten	frykt	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	obl	_	_
 14	for	for	ADP	prep	_	16	case	_	_
@@ -7022,7 +7022,7 @@
 37	legger	legge	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	28	csubj	_	_
 38	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	37	obj	_	_
 39	snublende	snuble	ADJ	adj	VerbForm=Part	40	amod	_	_
-40	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	37	advmod	_	_
+40	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	37	advmod	_	_
 41	Frps	Frp	PROPN	subst	Abbr=Yes|Case=Gen	42	nmod	_	_
 42	retorikk	retorikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	40	obj	_	SpaceAfter=No
 43	.	$.	PUNCT	clb	_	10	punct	_	_
@@ -7038,7 +7038,7 @@
 6	igjen	igjen	ADV	adv	_	9	advmod	_	_
 7	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	_	_
 8	farlig	farlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
-9	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	ccomp	_	_
+9	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	ccomp	_	_
 10	sperregrensen	sperregrense	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	obj	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	19	punct	_	_
 12	og	og	CCONJ	konj	_	19	cc	_	_
@@ -7056,7 +7056,7 @@
 24	Lars	Lars	PROPN	subst	Gender=Masc	27	nsubj	_	_
 25	Sponheim	Sponheim	PROPN	subst	_	24	flat:name	_	_
 26	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	27	cop	_	_
-27	avhengig	avhengig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	amod	_	_
+27	avhengig	avhengig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	amod	_	_
 28	av	av	ADP	prep	_	29	case	_	_
 29	utjevningsmandat	utjevningsmandat	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	27	obl	_	_
 30	for	for	ADP	prep	_	33	case	_	_
@@ -7109,18 +7109,18 @@
 38	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	39	aux	_	_
 39	virke	virke	VERB	verb	VerbForm=Inf	2	conj	_	_
 40	farlig	farlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	41	advmod	_	_
-41	defensiv	defensiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	39	xcomp	_	_
+41	defensiv	defensiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	39	xcomp	_	_
 42	for	for	ADP	prep	_	44	case	_	_
 43	potensielle	potensiell	ADJ	adj	Degree=Pos|Number=Plur	44	amod	_	_
 44	venstrevelgere	venstrevelger	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	41	obl	_	_
 45	som	som	SCONJ	sbu	_	48	mark	_	_
 46	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	48	cop	_	_
 47	mest	mye	ADJ	adj	Definite=Ind|Degree=Sup	48	advmod	_	_
-48	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	44	amod	_	_
+48	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	44	amod	_	_
 49	av	av	ADP	prep	_	51	case	_	_
 50	å	å	PART	inf-merke	_	51	mark	_	_
 51	bli	bli	VERB	verb	VerbForm=Inf	48	advcl	_	_
-52	kvitt	kvitt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	51	xcomp	_	_
+52	kvitt	kvitt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	51	xcomp	_	_
 53	de	de	DET	det	Number=Plur|PronType=Art	54	det	_	_
 54	rødgrønne	rødgrønn	ADJ	adj	Degree=Pos|Number=Plur	52	obj	_	SpaceAfter=No
 55	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -7133,7 +7133,7 @@
 4	å	å	PART	inf-merke	_	5	mark	_	_
 5	gjøre	gjøre	VERB	verb	VerbForm=Inf	3	xcomp	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	innsats	innsats	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obj	_	_
 9	i	i	ADP	prep	_	11	case	_	_
 10	kveldens	kveld	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	_
@@ -7257,7 +7257,7 @@
 9	første	første	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing|NumType=Ord	10	amod	_	_
 10	arbeidsdag	arbeidsdag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 11	med	med	ADP	prep	_	13	case	_	_
-12	ommøblert	ommøblere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	13	amod	_	_
+12	ommøblert	ommøblere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	13	amod	_	_
 13	regjering	regjering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	nmod	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -7288,7 +7288,7 @@
 23	selv	selv	DET	det	PronType=Prs	22	det	_	_
 24	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	25	aux	_	_
 25	lagt	legge	VERB	verb	VerbForm=Part	21	acl:relcl	_	_
-26	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	27	amod	_	_
+26	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	27	amod	_	_
 27	vekt	vekt	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	25	obj	_	_
 28	på	på	ADV	prep	_	25	advmod	_	_
 29	-	$-	PUNCT	<strek>	_	30	punct	_	_
@@ -7319,7 +7319,7 @@
 9	Strøm-Erichsen	Strøm-Erichsen	PROPN	subst	_	7	flat:name	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	7	punct	_	_
 11	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	12	cop	_	_
-12	bortreist	bortreist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+12	bortreist	bortreist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	21	punct	_	_
 14	til	til	ADP	prep	_	21	case	_	_
 15	tross	tross	ADP	prep	_	21	case	_	_
@@ -7355,7 +7355,7 @@
 1	I	i	ADP	prep	_	2	case	_	_
 2	mellomtiden	mellomtid	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
 3	bestyres	bestyre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
-4	departementet	departement	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	nsubj	_	_
+4	departementet	departement	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	nsubj:pass	_	_
 5	av	av	ADP	prep	_	6	case	_	_
 6	fornyings-	fornyings-	NOUN	subst	_	3	obl	_	_
 7	og	og	CCONJ	konj	_	8	cc	_	_
@@ -7401,9 +7401,9 @@
 2	Strøm-Erichsen	Strøm-Erichsen	PROPN	subst	_	3	nsubj	_	_
 3	tok	ta	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	12	csubj	_	_
 4	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	3	obj	_	_
-5	fri	fri	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	xcomp	_	_
+5	fri	fri	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	xcomp	_	_
 6	på	på	ADP	prep	_	8	case	_	_
-7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	60-årsdag	60-årsdag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	3	punct	_	_
 10	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	_	_
@@ -7413,7 +7413,7 @@
 
 # sent_id = 016026
 # text = Hennes samvittighetsfulle virke som forsvarsminister, blant annet med jevnlige besøk til norske soldater i Afghanistan, tyder på at det ikke vil bli arbeidsinnsatsen som hindrer henne i å oppnå gode resultater i sitt nye krevende departement.
-1	Hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	_
+1	Hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	_
 2	samvittighetsfulle	samvittighetsfull	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	3	amod	_	_
 3	virke	virke	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	18	nsubj	_	_
 4	som	som	ADP	prep	_	5	case	_	_
@@ -7447,7 +7447,7 @@
 32	gode	god	ADJ	adj	Degree=Pos|Number=Plur	33	amod	_	_
 33	resultater	resultat	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	31	obj	_	_
 34	i	i	ADP	prep	_	38	case	_	_
-35	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	38	det	_	_
+35	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	38	nmod:poss	_	_
 36	nye	ny	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	38	amod	_	_
 37	krevende	kreve	ADJ	adj	VerbForm=Part	38	amod	_	_
 38	departement	departement	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	31	obl	_	SpaceAfter=No
@@ -7456,7 +7456,7 @@
 # sent_id = 016027
 # text = Som erfaren kommunepolitiker, både som ordfører og byrådsleder i Bergen, burde hun ha bedre forutsetning enn de fleste til å gjennomføre den omfattende samhandlingsreformen som forgjengeren, Bjarne Håkon Hanssen, satte i gang.
 1	Som	som	ADP	prep	_	3	case	_	_
-2	erfaren	erfaren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	erfaren	erfaren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	kommunepolitiker	kommunepolitiker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obl	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	7	punct	_	_
 5	både	både	CCONJ	konj	_	7	cc	_	_
@@ -7496,7 +7496,7 @@
 # sent_id = 016028
 # text = En vellykket gjennomføring av denne reformen vil bli en avgjørende prøve på Regjeringens handlekraft.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	vellykket	vellykket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	vellykket	vellykket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	gjennomføring	gjennomføring	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nsubj	_	_
 4	av	av	ADP	prep	_	6	case	_	_
 5	denne	denne	DET	det	Gender=Masc|Number=Sing|PronType=Dem	6	det	_	_
@@ -7504,7 +7504,7 @@
 7	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 8	bli	bli	VERB	verb	VerbForm=Inf	0	root	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-10	avgjørende	avgjørende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	avgjørende	avgjørende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	prøve	prøve	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	xcomp	_	_
 12	på	på	ADP	prep	_	14	case	_	_
 13	Regjeringens	Regjeringen	PROPN	subst	Case=Gen	14	nmod	_	_
@@ -7539,7 +7539,7 @@
 # text = Ingen er uenig med statsminister Stoltenberg i at det offentlige må og skal ha hovedansvaret for helsetilbudet i Norge.
 1	Ingen	ingen	PRON	pron	Number=Plur|Person=3|PronType=Prs	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	uenig	uenig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	uenig	uenig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	med	med	ADP	prep	_	5	case	_	_
 5	statsminister	statsminister	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 6	Stoltenberg	Stoltenberg	PROPN	subst	_	5	flat:name	_	_
@@ -7577,7 +7577,7 @@
 15	fra	fra	ADP	prep	_	17	case	_	_
 16	å	å	PART	inf-merke	_	17	mark	_	_
 17	bruke	bruke	VERB	verb	VerbForm=Inf	14	advcl	_	_
-18	ledig	ledig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	ledig	ledig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	kapasitet	kapasitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	obj	_	_
 20	i	i	ADP	prep	_	22	case	_	_
 21	privat	privat	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	22	amod	_	_
@@ -7631,11 +7631,11 @@
 6	på	på	ADP	prep	_	14	case	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
 8	menneskelig	menneskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
-9	forståelig	forståelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	SpaceAfter=No
+9	forståelig	forståelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	13	punct	_	_
 11	men	men	CCONJ	konj	_	13	cc	_	_
 12	prinsipielt	prinsipiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	13	advmod	_	_
-13	kontroversiell	kontroversiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	conj	_	_
+13	kontroversiell	kontroversiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	conj	_	_
 14	måte	måte	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -7711,7 +7711,7 @@
 # sent_id = 016038
 # text = Og statsministeren skal så absolutt ikke forskånes fra å møte representanter for dem som blir påvirket av Regjeringens prinsipper og beslutninger.
 1	Og	og	CCONJ	konj	_	7	cc	_	_
-2	statsministeren	statsminister	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
+2	statsministeren	statsminister	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nsubj:pass	_	_
 3	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 4	så	så	ADV	adv	_	5	advmod	_	_
 5	absolutt	absolutt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
@@ -7777,7 +7777,7 @@
 13	til	til	ADP	prep	_	15	case	_	_
 14	å	å	PART	inf-merke	_	15	mark	_	_
 15	presentere	presentere	VERB	verb	VerbForm=Inf	12	acl	_	_
-16	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	det	_	_
+16	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
 17	sak	sak	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obj	_	_
 18	direkte	direkte	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	15	advmod	_	_
 19	til	til	ADP	prep	_	20	case	_	_
@@ -7881,7 +7881,7 @@
 6	sykefraværet	sykefravær	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	4	nmod	_	_
 7	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	_	_
 8	foruroligende	foruroligende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
-9	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	ccomp	_	SpaceAfter=No
+9	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	ccomp	_	SpaceAfter=No
 10	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 016044
@@ -7890,7 +7890,7 @@
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 3	langt	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	4	advmod	_	_
 4	fra	fra	ADV	prep	_	5	advmod	_	_
-5	gjennomført	gjennomført	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+5	gjennomført	gjennomført	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	12	punct	_	_
 7	og	og	CCONJ	konj	_	12	cc	_	_
 8	i	i	ADP	prep	_	9	case	_	_
@@ -7937,12 +7937,12 @@
 7	får	få	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	advcl	_	_
 8	følelsen	følelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	obj	_	_
 9	av	av	ADP	prep	_	11	case	_	_
-10	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	likegyldighet	likegyldighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	8	nmod	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	7	punct	_	_
 13	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 14	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	expl	_	_
-15	overhengende	overhengende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	overhengende	overhengende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	fare	fare	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nsubj	_	_
 17	for	for	ADP	prep	_	22	case	_	_
 18	at	at	SCONJ	sbu	_	22	mark	_	_
@@ -7964,7 +7964,7 @@
 8	på	på	ADP	prep	_	12	case	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
 10	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	11	advmod	_	_
-11	uerfaren	uerfaren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	uerfaren	uerfaren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	statsråd	statsråd	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obl	_	_
 13	i	i	ADP	prep	_	14	case	_	_
 14	Arbeidsdepartementet	Arbeidsdepartementet	PROPN	subst	_	12	nmod	_	SpaceAfter=No
@@ -7981,12 +7981,12 @@
 7	la	la	VERB	verb	VerbForm=Inf	5	csubj	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
 9	like	like	ADV	adv	_	10	advmod	_	_
-10	uerfaren	uerfaren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	uerfaren	uerfaren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	vikarstatsråd	vikarstatsråd	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	iobj	_	_
 12	styre	styre	VERB	verb	VerbForm=Inf	7	xcomp	_	_
 13	departementet	departement	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	12	obj	_	_
 14	med	med	ADP	prep	_	16	case	_	_
-15	venstre	venstre	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	venstre	venstre	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	hånd	hånd	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	12	obl	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -8000,7 +8000,7 @@
 6	Stoltenberg	Stoltenberg	PROPN	subst	_	7	nsubj	_	_
 7	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-9	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	grunn	grunn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	_
 11	til	til	ADP	prep	_	13	case	_	_
 12	å	å	PART	inf-merke	_	13	mark	_	_
@@ -8008,7 +8008,7 @@
 14	Hanne	Hanne	PROPN	subst	Gender=Fem	13	obj	_	_
 15	Bjurstrøm	Bjurstrøm	PROPN	subst	_	14	flat:name	_	_
 16	unna	unna	ADP	prep	_	19	case	_	_
-17	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	19	det	_	_
+17	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 18	nye	ny	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	19	amod	_	_
 19	departement	departement	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	13	obl	_	_
 20	i	i	ADP	prep	_	22	case	_	_
@@ -8028,7 +8028,7 @@
 8	som	som	ADP	prep	_	9	case	_	_
 9	forhandlingsleder	forhandlingsleder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	xcomp	_	_
 10	med	med	ADP	prep	_	12	case	_	_
-11	nyslått	nyslått	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	nyslått	nyslått	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	statsrådsautoritet	statsrådsautoritet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nmod	_	_
 13	i	i	ADP	prep	_	16	case	_	_
 14	de	de	DET	det	Number=Plur|PronType=Art	16	det	_	_
@@ -8077,7 +8077,7 @@
 # text = Fallhøyden blir enorm for en statsråd som i statsministerens øyne fremstår som så eksepsjonell at han frivillig velger å la et så viktig departement gå for halv maskin i to måneder.
 1	Fallhøyden	fallhøyde	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 2	blir	bli	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	enorm	enorm	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	xcomp	_	_
+3	enorm	enorm	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	xcomp	_	_
 4	for	for	ADP	prep	_	6	case	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
 6	statsråd	statsråd	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	_
@@ -8088,7 +8088,7 @@
 11	fremstår	fremstå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	_	_
 12	som	som	ADP	prep	_	14	case	_	_
 13	så	så	ADV	adv	_	14	advmod	_	_
-14	eksepsjonell	eksepsjonell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	xcomp	_	_
+14	eksepsjonell	eksepsjonell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	xcomp	_	_
 15	at	at	SCONJ	sbu	_	18	mark	_	_
 16	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	nsubj	_	_
 17	frivillig	frivillig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	18	advmod	_	_
@@ -8101,7 +8101,7 @@
 24	departement	departement	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	20	iobj	_	_
 25	gå	gå	VERB	verb	VerbForm=Inf	20	xcomp	_	_
 26	for	for	ADP	prep	_	28	case	_	_
-27	halv	halv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	28	amod	_	_
+27	halv	halv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	28	amod	_	_
 28	maskin	maskin	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	25	obl	_	_
 29	i	i	ADP	prep	_	31	case	_	_
 30	to	to	NUM	det	Number=Plur|NumType=Card	31	nummod	_	_
@@ -8117,7 +8117,7 @@
 5	derfor	derfor	ADV	adv	_	6	advmod	_	_
 6	bli	bli	VERB	verb	VerbForm=Inf	0	root	_	_
 7	ekstra	ekstra	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	8	advmod	_	_
-8	brutal	brutal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	xcomp	_	_
+8	brutal	brutal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	xcomp	_	_
 9	for	for	ADP	prep	_	10	case	_	_
 10	Hanne	Hanne	PROPN	subst	Gender=Fem	6	obl	_	_
 11	Bjurstrøm	Bjurstrøm	PROPN	subst	_	10	flat:name	_	SpaceAfter=No
@@ -8136,7 +8136,7 @@
 
 # sent_id = 016056
 # text = Pinefull død for den irske pub?
-1	Pinefull	pinefull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Pinefull	pinefull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	død	død	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 3	for	for	ADP	prep	_	6	case	_	_
 4	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
@@ -8226,7 +8226,7 @@
 7	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	8	nsubj	_	_
 8	kjenner	kjenne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	_	_
 9	røyken	røyk	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	obj	_	_
-10	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	vei	vei	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -8282,7 +8282,7 @@
 
 # sent_id = 016068
 # text = Masse røyk.
-1	Masse	masse	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Masse	masse	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	røyk	røyk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 3	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -8303,7 +8303,7 @@
 # sent_id = 016070
 # text = En ung mann prøver å gjøre inntrykk på kveldens utkårede.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	ung	ung	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	ung	ung	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	mann	mann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj	_	_
 4	prøver	prøve	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 5	å	å	PART	inf-merke	_	6	mark	_	_
@@ -8321,7 +8321,7 @@
 3	følger	følge	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	de	de	DET	det	Number=Plur|PronType=Art	5	det	_	_
 5	fotballinteresserte	fotballinteressert	ADJ	adj	Degree=Pos|Number=Plur	3	nsubj	_	_
-6	Manchester	Manchester	PROPN	subst	_	9	nmod	_	_
+6	Manchester	Manchester	PROPN	subst	_	9	nmod:poss	_	_
 7	Uniteds	United	PROPN	subst	Case=Gen	6	flat:name	_	_
 8	bitre	bitter	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	9	amod	_	_
 9	ferd	ferd	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obj	_	_
@@ -8338,7 +8338,7 @@
 3	tappes	tappe	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 4	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	_
 5	ustanselig	ustanselig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	3	advmod	_	_
-6	mørkebrun	mørkebrun	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	mørkebrun	mørkebrun	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	Guinness	Guinness	PROPN	subst	_	3	obj	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -8412,7 +8412,7 @@
 7	og	og	CCONJ	konj	_	9	cc	_	_
 8	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 9	vite	vite	VERB	verb	VerbForm=Inf	3	conj	_	_
-10	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	ærend	ærend	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	obj	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -8421,7 +8421,7 @@
 1	-	$-	PUNCT	<strek>	_	5	punct	_	_
 2	Aha	aha	INTJ	interj	_	5	discourse	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	2	punct	_	_
-4	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	journalist	journalist	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -8510,7 +8510,7 @@
 4	at	at	SCONJ	sbu	_	7	mark	_	_
 5	røyking	røyking	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	nsubj	_	_
 6	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
-7	farlig	farlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	ccomp	_	SpaceAfter=No
+7	farlig	farlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	ccomp	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 016086
@@ -8551,7 +8551,7 @@
 10	regjeringen	regjering	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	12	nsubj	_	_
 11	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	_	_
 12	gjennomføre	gjennomføre	VERB	verb	VerbForm=Inf	7	advcl	_	_
-13	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	14	det	_	_
+13	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	14	nmod:poss	_	_
 14	forbud	forbud	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	12	obj	_	_
 15	mot	mot	ADP	prep	_	16	case	_	_
 16	røyking	røyking	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
@@ -8560,7 +8560,7 @@
 # sent_id = 016088
 # text = Alle arbeidssteder omfattes av den nye loven, for å gi arbeidstagerne tilstrekkelig beskyttelse mot de skader som følger av passiv røyking.
 1	Alle	all	DET	det	Number=Plur|PronType=Tot	2	det	_	_
-2	arbeidssteder	arbeidssted	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	3	nsubj	_	_
+2	arbeidssteder	arbeidssted	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	3	nsubj:pass	_	_
 3	omfattes	omfatte	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 4	av	av	ADP	prep	_	7	case	_	_
 5	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
@@ -8571,7 +8571,7 @@
 10	å	å	PART	inf-merke	_	11	mark	_	_
 11	gi	gi	VERB	verb	VerbForm=Inf	3	advcl	_	_
 12	arbeidstagerne	arbeidstager	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	11	iobj	_	_
-13	tilstrekkelig	tilstrekkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	tilstrekkelig	tilstrekkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	beskyttelse	beskyttelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obj	_	_
 15	mot	mot	ADP	prep	_	17	case	_	_
 16	de	de	DET	det	Number=Plur|PronType=Art	17	det	_	_
@@ -8579,7 +8579,7 @@
 18	som	som	SCONJ	sbu	_	19	mark	_	_
 19	følger	følge	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	acl:relcl	_	_
 20	av	av	ADP	prep	_	22	case	_	_
-21	passiv	passiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	amod	_	_
+21	passiv	passiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	amod	_	_
 22	røyking	røyking	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	19	obl	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -8596,7 +8596,7 @@
 9	innfører	innføre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	acl:relcl	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
 11	så	så	ADV	adv	_	12	advmod	_	_
-12	drastisk	drastisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	drastisk	drastisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	lovgivning	lovgivning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obj	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -8616,7 +8616,7 @@
 12	spør	spørre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 13	Brian	Brian	PROPN	subst	_	12	nsubj	_	_
 14	Gormley	Gormley	PROPN	subst	_	13	flat:name	_	_
-15	innhyllet	innhylle	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	12	xcomp	_	_
+15	innhyllet	innhylle	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	12	xcomp	_	_
 16	i	i	ADP	prep	_	17	case	_	_
 17	røyk	røyk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obl	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	12	punct	_	_
@@ -8624,7 +8624,7 @@
 # sent_id = 016091
 # text = En ny pint med Guinness lander på bardisken foran ham, generøst fylt til godt over randen.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	pint	pint	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nsubj	_	_
 4	med	med	ADP	prep	_	5	case	_	_
 5	Guinness	Guinness	PROPN	subst	_	3	nmod	_	_
@@ -8635,7 +8635,7 @@
 10	ham	han	PRON	pron	Animacy=Hum|Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nmod	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	13	punct	_	_
 12	generøst	generøs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	13	advmod	_	_
-13	fylt	fylle	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	6	xcomp	_	_
+13	fylt	fylle	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	6	xcomp	_	_
 14	til	til	ADP	prep	_	17	case	_	_
 15	godt	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	17	advmod	_	_
 16	over	over	ADP	prep	_	17	case	_	_
@@ -8675,7 +8675,7 @@
 1	Veien	vei	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	ikke	ikke	PART	adv	Polarity=Neg	4	advmod	_	_
-4	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	til	til	ADP	prep	_	7	case	_	_
 6	neste	neste	DET	det	Definite=Def|PronType=Dem	7	det	_	_
 7	pub	pub	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
@@ -8689,7 +8689,7 @@
 4	Agnes	Agnes	PROPN	subst	_	6	nsubj	_	_
 5	Duffy	Duffy	PROPN	subst	_	4	flat:name	_	_
 6	trekker	trekke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-7	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	9	det	_	_
+7	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 8	dype	dyp	ADJ	adj	Degree=Pos|Number=Plur	9	amod	_	_
 9	drag	drag	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	6	obj	_	_
 10	inne	inne	ADP	prep	_	12	case	_	_
@@ -8808,7 +8808,7 @@
 1	Kanskje	kanskje	ADV	adv	_	5	advmod	_	_
 2	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 3	mange	mange	ADJ	adj	Degree=Pos|Number=Plur	4	amod	_	_
-4	puber	pub	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	nsubj	_	_
+4	puber	pub	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	nsubj:pass	_	_
 5	legges	legge	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 6	ned	ned	ADV	prep	_	5	advmod	_	_
 7	som	som	ADP	prep	_	9	case	_	_
@@ -8837,7 +8837,7 @@
 14	til	til	ADP	prep	_	18	case	_	_
 15	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
 16	så	så	ADV	adv	_	17	advmod	_	_
-17	dramatisk	dramatisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	dramatisk	dramatisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	forandring	forandring	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obl	_	SpaceAfter=No
 19	,	$,	PUNCT	<komma>	_	2	punct	_	_
 20	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -8849,7 +8849,7 @@
 # text = Agnes er enig.
 1	Agnes	Agnes	PROPN	subst	_	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+3	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 4	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 016107
@@ -8860,7 +8860,7 @@
 4	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
 6	ikke	ikke	PART	adv	Polarity=Neg	7	advmod	_	_
-7	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+7	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 8	for	for	ADP	prep	_	10	case	_	_
 9	dette	dette	DET	det	Gender=Neut|Number=Sing|PronType=Dem	10	det	_	_
 10	forbudet	forbud	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	obl	_	SpaceAfter=No
@@ -8948,7 +8948,7 @@
 # text = - Men det innføres jo for å beskytte dere som jobber her?
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
 2	Men	men	CCONJ	konj	_	4	cc	_	_
-3	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
+3	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj:pass	_	_
 4	innføres	innføre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 5	jo	jo	ADV	adv	_	4	advmod	_	_
 6	for	for	ADP	prep	_	8	case	_	_
@@ -8969,7 +8969,7 @@
 5	alle	alle	PRON	pron	Number=Plur|Person=3|PronType=Prs,Tot	10	nsubj	_	_
 6	som	som	SCONJ	sbu	_	8	mark	_	_
 7	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
-8	ansatt	ansatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+8	ansatt	ansatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 9	her	her	ADV	prep	_	8	advmod	_	_
 10	røyker	røyke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 11	selv	selv	ADV	adv	_	10	advmod	_	SpaceAfter=No
@@ -9019,7 +9019,7 @@
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 5	særdeles	særdeles	ADV	adv	_	6	advmod	_	_
-6	upopulær	upopulær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	upopulær	upopulær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	mann	mann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 8	på	på	ADP	prep	_	10	case	_	_
 9	irske	irsk	ADJ	adj	Degree=Pos|Number=Plur	10	amod	_	_
@@ -9052,7 +9052,7 @@
 6	vei	vei	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 7	på	på	ADP	prep	_	8	case	_	_
 8	sigaretten	sigarett	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
-9	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	SpaceAfter=No
+9	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	13	punct	_	_
 11	men	men	CCONJ	konj	_	13	cc	_	_
 12	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
@@ -9084,7 +9084,7 @@
 # text = Jeg er glad for forbudet.
 1	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	for	for	ADP	prep	_	5	case	_	_
 5	forbudet	forbud	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	obl	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -9132,7 +9132,7 @@
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
 5	overhodet	overhodet	ADV	adv	_	6	advmod	_	_
 6	ikke	ikke	PART	adv	Polarity=Neg	7	advmod	_	_
-7	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+7	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	7	punct	_	_
 
 # sent_id = 016126
@@ -9141,7 +9141,7 @@
 2	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 3	elsker	elske	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	røyken	røyk	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obj	_	_
-5	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	SpaceAfter=No
+5	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 016127
@@ -9149,7 +9149,7 @@
 1	Og	og	CCONJ	konj	_	5	cc	_	_
 2	hvordan	hvordan	ADV	adv	_	5	advmod	_	_
 3	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
-4	dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
+4	dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj:pass	_	_
 5	gjennomføres	gjennomføre	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	SpaceAfter=No
 6	?	$?	PUNCT	clb	_	5	punct	_	_
 
@@ -9166,7 +9166,7 @@
 9	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	_	_
 10	anmelde	anmelde	VERB	verb	VerbForm=Inf	6	xcomp	_	_
 11	gjestene	gjest	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	10	obj	_	_
-12	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	det	_	_
+12	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 13	til	til	ADP	prep	_	14	case	_	_
 14	politiet	politi	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	10	obl	_	SpaceAfter=No
 15	?	$?	PUNCT	clb	_	1	punct	_	_
@@ -9293,9 +9293,9 @@
 2	Corgartys	Corgartys	PROPN	subst	_	3	obl	_	_
 3	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	_
-5	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	SpaceAfter=No
+5	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	5	punct	_	_
-7	irsk	irsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	irsk	irsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	folkemusikk	folkemusikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nsubj	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	10	punct	_	_
 10	jubel	jubel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	conj	_	_
@@ -9338,7 +9338,7 @@
 9	,	$,	PUNCT	<komma>	_	12	punct	_	_
 10	og	og	CCONJ	konj	_	12	cc	_	_
 11	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	_	_
-12	innhyllet	innhylle	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	4	conj	_	_
+12	innhyllet	innhylle	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	4	conj	_	_
 13	i	i	ADP	prep	_	14	case	_	_
 14	røyk	røyk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obl	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	4	punct	_	_
@@ -9349,7 +9349,7 @@
 2	Martin	Martin	PROPN	subst	Gender=Masc	1	flat:name	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	modig	modig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	modig	modig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	mann	mann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -9369,7 +9369,7 @@
 1	Aldri	aldri	ADV	adv	_	9	advmod	_	_
 2	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 3	så	så	ADV	adv	_	4	advmod	_	_
-4	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	fortid	fortid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	nsubj	_	_
 6	og	og	CCONJ	konj	_	7	cc	_	_
 7	samtid	samtid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	conj	_	_
@@ -9382,7 +9382,7 @@
 # sent_id = 016143
 # text = Selve vår sivilisasjon er blitt det museet vi bor i.
 1	Selve	selve	DET	det	Definite=Def|PronType=Prs	3	det	_	_
-2	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	_
+2	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	_
 3	sivilisasjon	sivilisasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 5	blitt	bli	VERB	verb	VerbForm=Part	0	root	_	_
@@ -9397,7 +9397,7 @@
 # text = Hvorfor preges vi da av historieløshet?
 1	Hvorfor	hvorfor	ADV	adv	_	2	advmod	_	_
 2	preges	prege	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
-3	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
+3	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj:pass	_	_
 4	da	da	ADV	adv	_	2	advmod	_	_
 5	av	av	ADP	prep	_	6	case	_	_
 6	historieløshet	historieløshet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
@@ -9413,7 +9413,7 @@
 5	meg	jeg	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=1|PronType=Prs	4	obj	_	_
 6	inn	inn	ADP	prep	_	9	case	_	_
 7	i	i	ADP	prep	_	9	case	_	_
-8	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	museumsdebatt	museumsdebatt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	12	punct	_	_
 11	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	12	nsubj	_	_
@@ -9585,7 +9585,7 @@
 1	Ofte	ofte	ADJ	adj	Degree=Pos	4	advmod	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	museumsbygningen	museumsbygning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
-4	interessant	interessant	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	interessant	interessant	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	i	i	ADP	prep	_	6	case	_	_
 6	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	4	obl	_	_
 7	selv	selv	DET	det	PronType=Prs	6	det	_	SpaceAfter=No
@@ -9673,7 +9673,7 @@
 33	hvor	hvor	ADV	adv	_	38	advmod	_	_
 34	munkene	munk	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	38	nsubj	_	_
 35	i	i	ADP	prep	_	37	case	_	_
-36	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	37	det	_	_
+36	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	37	nmod:poss	_	_
 37	tid	tid	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	38	obl	_	_
 38	satt	sitte	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	32	acl:relcl	_	_
 39	til	til	ADP	prep	_	40	case	_	_
@@ -9726,7 +9726,7 @@
 10	,	$,	PUNCT	<komma>	_	16	punct	_	_
 11	ikke	ikke	PART	adv	Polarity=Neg	12	advmod	_	_
 12	fordi	fordi	SCONJ	sbu	_	16	mark	_	_
-13	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
+13	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	16	nsubj:pass	_	_
 14	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	16	cop	_	_
 15	blitt	bli	AUX	verb	VerbForm=Part	16	aux:pass	_	_
 16	restaurert	restaurere	VERB	verb	VerbForm=Part	3	conj	_	_
@@ -9763,7 +9763,7 @@
 
 # sent_id = 016165
 # text = Billetter må bestilles minst én måned i forveien, sa damen i luken.
-1	Billetter	billett	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	nsubj	_	_
+1	Billetter	billett	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	nsubj:pass	_	_
 2	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	bestilles	bestille	VERB	verb	VerbForm=Inf|Voice=Pass	10	ccomp	_	_
 4	minst	liten	ADJ	adj	Definite=Ind|Degree=Sup	5	advmod	_	_
@@ -9781,7 +9781,7 @@
 # sent_id = 016166
 # text = De skuelystne slippes nøye planlagt inn til klenodiet i puljer på 25, hvert 45. minutt, syntes jeg hun sa.
 1	De	de	DET	det	Number=Plur|PronType=Art	2	det	_	_
-2	skuelystne	skuelysten	ADJ	adj	Degree=Pos|Number=Plur	3	nsubj	_	_
+2	skuelystne	skuelysten	ADJ	adj	Degree=Pos|Number=Plur	3	nsubj:pass	_	_
 3	slippes	slippe	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	18	ccomp	_	_
 4	nøye	nøye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
 5	planlagt	planlegge	ADJ	adj	Definite=Ind|Gender=Neut|Number=Sing|VerbForm=Part	3	advmod	_	_
@@ -9821,7 +9821,7 @@
 
 # sent_id = 016168
 # text = De måtte fordeles på to puljer.
-1	De	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	_	_
+1	De	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj:pass	_	_
 2	måtte	måtte	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux	_	_
 3	fordeles	fordele	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 4	på	på	ADP	prep	_	6	case	_	_
@@ -9900,7 +9900,7 @@
 4	restaureringen	restaurering	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
 5	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 6	vært	være	AUX	verb	VerbForm=Part	7	cop	_	_
-7	kontroversiell	kontroversiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+7	kontroversiell	kontroversiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	7	punct	_	_
 
 # sent_id = 016174
@@ -9926,7 +9926,7 @@
 6	kulturbevaringens	kulturbevaring	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	_
 7	paradokser	paradoks	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	4	nmod	_	_
 8	at	at	SCONJ	sbu	_	14	mark	_	_
-9	meningen	mening	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	_
+9	meningen	mening	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	14	nsubj:pass	_	_
 10	med	med	ADP	prep	_	12	case	_	_
 11	å	å	PART	inf-merke	_	12	mark	_	_
 12	fremvise	fremvise	VERB	verb	VerbForm=Inf	9	acl	_	_
@@ -10020,7 +10020,7 @@
 11	og	og	CCONJ	konj	_	12	cc	_	_
 12	oppleve	oppleve	VERB	verb	VerbForm=Inf	10	conj	_	_
 13	som	som	ADP	prep	_	15	case	_	_
-14	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	kulturarv	kulturarv	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	xcomp	_	SpaceAfter=No
 16	?	$?	PUNCT	clb	_	2	punct	_	_
 
@@ -10039,7 +10039,7 @@
 # text = De er vår hukommelse.
 1	De	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
-3	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	_
+3	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 4	hukommelse	hukommelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 5	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -10072,7 +10072,7 @@
 
 # sent_id = 016186
 # text = Vår tid går fortere enn tidligere tider.
-1	Vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	2	det	_	_
+1	Vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 2	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	nsubj	_	_
 3	går	gå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	fortere	fort	ADJ	adj	Degree=Cmp	3	advmod	_	_
@@ -10150,7 +10150,7 @@
 20	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	22	cop	_	_
 21	ferske	fersk	ADJ	adj	Degree=Pos|Number=Plur	22	amod	_	_
 22	merkevarer	merkevare	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	4	obl	_	_
-23	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	25	nsubj	_	_
+23	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	25	nsubj:pass	_	_
 24	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	25	aux:pass	_	_
 25	tilbudt	tilby	VERB	verb	VerbForm=Part	22	acl:relcl	_	SpaceAfter=No
 26	,	$,	PUNCT	<komma>	_	31	punct	_	_
@@ -10190,7 +10190,7 @@
 25	levende	levende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	26	amod	_	_
 26	liv	liv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	23	conj	_	_
 27	være	være	AUX	verb	VerbForm=Inf	28	cop	_	_
-28	utradert	utradere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	3	conj	_	SpaceAfter=No
+28	utradert	utradere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	3	conj	_	SpaceAfter=No
 29	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 016192
@@ -10248,7 +10248,7 @@
 7	land	land	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	conj	_	_
 8	som	som	SCONJ	sbu	_	12	mark	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	_	_
-10	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	det	_	_
+10	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 11	vitale	vital	ADJ	adj	Degree=Pos|Number=Plur	12	amod	_	_
 12	museer	museum	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	7	nmod	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -10285,14 +10285,14 @@
 27	sten	sten	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	25	nmod	_	_
 28	tilbake	tilbake	ADV	prep	_	24	advmod	_	_
 29	av	av	ADP	prep	_	31	case	_	_
-30	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	31	amod	_	_
+30	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	31	amod	_	_
 31	kulturerfaring	kulturerfaring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	25	nmod	_	SpaceAfter=No
 32	,	$,	PUNCT	<komma>	_	33	punct	_	_
-33	egyptisk	egyptisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	31	dislocated	_	SpaceAfter=No
+33	egyptisk	egyptisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	31	dislocated	_	SpaceAfter=No
 34	,	$,	PUNCT	<komma>	_	35	punct	_	_
-35	gresk	gresk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	33	conj	_	SpaceAfter=No
+35	gresk	gresk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	33	conj	_	SpaceAfter=No
 36	,	$,	PUNCT	<komma>	_	37	punct	_	_
-37	romersk	romersk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	33	conj	_	SpaceAfter=No
+37	romersk	romersk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	33	conj	_	SpaceAfter=No
 38	,	$,	PUNCT	<komma>	_	37	punct	_	_
 39	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	40	det	_	_
 40	museum	museum	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	10	dislocated	_	_
@@ -10302,7 +10302,7 @@
 # sent_id = 016197
 # text = Plaffes det ned, er det også av historiske grunner.
 1	Plaffes	plaffe	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	10	advcl	_	_
-2	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	1	nsubj	_	_
+2	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	1	nsubj:pass	_	_
 3	ned	ned	ADV	prep	_	1	advmod	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	1	punct	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	_	_
@@ -10340,7 +10340,7 @@
 2	dag	dag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 3	fører	føre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
-5	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+5	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 6	personlige	personlig	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	7	amod	_	_
 7	museumsliv	museumsliv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	obj	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -10488,7 +10488,7 @@
 1	Passerer	passere	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 2	fragmenter	fragment	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	1	obj	_	_
 3	av	av	ADP	prep	_	5	case	_	_
-4	lombardisk	lombardisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	lombardisk	lombardisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	middelalder	middelalder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	nmod	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	8	punct	_	_
 7	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
@@ -10496,7 +10496,7 @@
 9	her	her	ADV	prep	_	8	advmod	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	8	punct	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-12	gotisk	gotisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	gotisk	gotisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	figur	figur	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	appos	_	_
 14	der	der	ADV	prep	_	13	advmod	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	1	punct	_	_
@@ -10570,7 +10570,7 @@
 11	Michelangelos	Michelangelo	PROPN	subst	Case=Gen	12	nmod	_	_
 12	svanesang	svanesang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	15	punct	_	_
-14	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	15	det	_	_
+14	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 15	Pietá	Pietá	PROPN	subst	_	12	appos	_	_
 16	Rondanini	Rondanini	PROPN	subst	_	15	flat:name	_	SpaceAfter=No
 17	,	$,	PUNCT	<komma>	_	15	punct	_	_
@@ -10585,7 +10585,7 @@
 26	arbeidet	arbeide	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	20	acl:relcl	_	_
 27	på	på	ADV	prep	_	26	advmod	_	_
 28	i	i	ADP	prep	_	32	case	_	_
-29	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	32	det	_	_
+29	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	32	nmod:poss	_	_
 30	fem	fem	NUM	det	Number=Plur|NumType=Card	32	nummod	_	_
 31	siste	sist	ADJ	adj	Degree=Pos|Number=Plur	32	amod	_	_
 32	leveår	leveår	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	26	obl	_	SpaceAfter=No
@@ -10593,7 +10593,7 @@
 34	trolig	trolig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	35	advmod	_	_
 35	også	også	ADV	adv	_	40	advmod	_	_
 36	i	i	ADP	prep	_	40	case	_	_
-37	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	40	det	_	_
+37	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	40	nmod:poss	_	_
 38	aller	aller	ADV	adv	_	39	advmod	_	_
 39	siste	sist	ADJ	adj	Degree=Pos|Number=Plur	40	amod	_	_
 40	dager	dag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	32	appos	_	SpaceAfter=No
@@ -10604,7 +10604,7 @@
 45	nesten	nesten	ADV	adv	_	46	advmod	_	_
 46	89	89	NUM	det	Number=Plur|NumType=Card	47	nummod	_	_
 47	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	48	obl	_	_
-48	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	44	xcomp	_	SpaceAfter=No
+48	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	44	xcomp	_	SpaceAfter=No
 49	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 016217
@@ -10649,17 +10649,17 @@
 3	,	$,	PUNCT	<komma>	_	4	punct	_	_
 4	forsker	forske	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	_	_
 5	for	for	ADP	prep	_	8	case	_	_
-6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 7	egen	egen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Prs	8	det	_	_
 8	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 9	i	i	ADP	prep	_	11	case	_	_
-10	lutter	lutter	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	lutter	lutter	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	kamp	kamp	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 12	med	med	ADP	prep	_	13	case	_	_
 13	materien	materie	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 14	,	$,	PUNCT	<komma>	_	18	punct	_	_
 15	med	med	ADP	prep	_	18	case	_	_
-16	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	18	det	_	_
+16	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	18	nmod:poss	_	_
 17	eget	egen	DET	det	Definite=Ind|Gender=Neut|Number=Sing|PronType=Prs	18	det	_	_
 18	talent	talent	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	13	conj	_	SpaceAfter=No
 19	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -10699,7 +10699,7 @@
 16	bli	bli	VERB	verb	VerbForm=Inf	13	acl:relcl	_	_
 17	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
 18	altfor	altfor	ADV	adv	_	19	advmod	_	_
-19	sped	sped	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	amod	_	_
+19	sped	sped	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	amod	_	_
 20	jomfrumor	jomfrumor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	xcomp	_	SpaceAfter=No
 21	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -10713,7 +10713,7 @@
 
 # sent_id = 016223
 # text = Vårt varige museumsliv.
-1	Vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	_
+1	Vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	_
 2	varige	varig	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	3	amod	_	_
 3	museumsliv	museumsliv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	0	root	_	SpaceAfter=No
 4	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -10737,7 +10737,7 @@
 # text = En " norsk " reaksjon.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
 2	"	$"	PUNCT	<anf>	_	3	punct	_	_
-3	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+3	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 4	"	$"	PUNCT	<anf>	_	3	punct	_	_
 5	reaksjon	reaksjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	5	punct	_	_
@@ -10805,7 +10805,7 @@
 2	ville	ville	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	aux	_	_
 3	ikke	ikke	PART	adv	Polarity=Neg	9	advmod	_	_
 4	utenlandske	utenlandsk	ADJ	adj	Degree=Pos|Number=Plur	5	amod	_	_
-5	komikere	komiker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	9	nsubj	_	_
+5	komikere	komiker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	9	nsubj:pass	_	_
 6	blitt	bli	AUX	verb	VerbForm=Part	9	aux:pass	_	_
 7	like	like	ADV	adv	_	8	advmod	_	_
 8	godt	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
@@ -10858,7 +10858,7 @@
 3	Kasakhstan	Kasakhstan	PROPN	subst	_	6	obl	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 5	harmen	harme	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
-6	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+6	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	6	punct	_	_
 
 # sent_id = 016236
@@ -10866,7 +10866,7 @@
 1	Folk	folk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	2	nsubj	_	_
 2	skjønner	skjønne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	at	at	SCONJ	sbu	_	6	mark	_	_
-4	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	_	_
+4	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj:pass	_	_
 5	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux:pass	_	_
 6	ledd	le	VERB	verb	VerbForm=Part	2	xcomp	_	_
 7	av	av	ADV	prep	_	6	advmod	_	_
@@ -10897,7 +10897,7 @@
 10	aldri	aldri	ADV	adv	_	12	advmod	_	_
 11	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	_	_
 12	satt	sette	VERB	verb	VerbForm=Part	8	acl:relcl	_	_
-13	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	14	det	_	_
+13	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	14	nmod:poss	_	_
 14	ben	ben	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	12	obj	_	_
 15	utenfor	utenfor	ADP	prep	_	20	case	_	_
 16	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	20	det	_	_
@@ -10978,8 +10978,8 @@
 18	vantro	vantro	ADJ	adj	Degree=Pos|Number=Plur	17	xcomp	_	_
 19	på	på	ADP	prep	_	24	case	_	_
 20	at	at	SCONJ	sbu	_	24	mark	_	_
-21	landet	land	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	24	nsubj	_	_
-22	deres	deres	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	21	det	_	_
+21	landet	land	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	24	nsubj:pass	_	_
+22	deres	deres	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	21	nmod:poss	_	_
 23	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	24	aux:pass	_	_
 24	revet	rive	VERB	verb	VerbForm=Part	17	advcl	_	_
 25	i	i	ADP	prep	_	26	case	_	_
@@ -11029,8 +11029,8 @@
 5	om	om	ADP	prep	_	11	case	_	_
 6	at	at	SCONJ	sbu	_	11	mark	_	_
 7	"	$"	PUNCT	<anf>	_	11	punct	_	SpaceAfter=No
-8	nasjonalsymbolet	nasjonalsymbol	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	11	nsubj	_	_
-9	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+8	nasjonalsymbolet	nasjonalsymbol	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	11	nsubj:pass	_	_
+9	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 10	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	11	aux:pass	_	_
 11	misbrukt	misbruke	VERB	verb	VerbForm=Part	2	advcl	_	SpaceAfter=No
 12	"	$"	PUNCT	<anf>	_	11	punct	_	SpaceAfter=No
@@ -11060,7 +11060,7 @@
 3	elsker	elske	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	ccomp	_	_
 4	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 5	presidenten	president	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obj	_	_
-6	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	SpaceAfter=No
+6	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	3	punct	_	_
 8	sa	si	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 9	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
@@ -11076,7 +11076,7 @@
 4	)	$)	PUNCT	<parentes-slutt>	_	3	punct	_	_
 5	satt	sitte	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 6	som	som	ADP	prep	_	7	case	_	_
-7	forstenet	forstenet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	xcomp	_	_
+7	forstenet	forstenet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	xcomp	_	_
 8	og	og	CCONJ	konj	_	9	cc	_	_
 9	så	se	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	_	_
 10	filmen	film	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	obj	_	_
@@ -11126,7 +11126,7 @@
 1	At	at	SCONJ	sbu	_	3	mark	_	_
 2	kasakhstanere	kasakhstaner	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	nsubj	_	_
 3	mangler	mangle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	humoristisk	humoristisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	humoristisk	humoristisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	sans	sans	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	SpaceAfter=No
 6	?	$?	PUNCT	clb	_	3	punct	_	_
 
@@ -11152,7 +11152,7 @@
 # newpar
 # sent_id = 016252
 # text = Såret nasjonalstolthet er en følelse vi her i Norge burde kjenne meget godt.
-1	Såret	såre	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	2	amod	_	_
+1	Såret	såre	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	2	amod	_	_
 2	nasjonalstolthet	nasjonalstolthet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
@@ -11172,7 +11172,7 @@
 1	I	i	ADP	prep	_	2	case	_	_
 2	mesteparten	mestepart	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	obl	_	_
 3	av	av	ADP	prep	_	5	case	_	_
-4	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+4	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	historie	historie	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	nmod	_	_
 6	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux	_	_
 7	Norge	Norge	PROPN	subst	_	13	nsubj	_	_
@@ -11305,7 +11305,7 @@
 # sent_id = 016262
 # text = All kritikk blir straks oppfattet som hån, sier Atabajev.
 1	All	all	DET	det	Gender=Masc|Number=Sing|PronType=Tot	2	det	_	_
-2	kritikk	kritikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj	_	_
+2	kritikk	kritikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj:pass	_	_
 3	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux:pass	_	_
 4	straks	straks	ADV	adv	_	5	advmod	_	_
 5	oppfattet	oppfatte	VERB	verb	VerbForm=Part	9	ccomp	_	_
@@ -11367,9 +11367,9 @@
 12	Almaty	Almaty	PROPN	subst	_	10	appos	_	_
 13	(	$(	PUNCT	<parentes-beg>	_	15	punct	_	SpaceAfter=No
 14	bedre	god	ADJ	adj	Degree=Cmp	15	advmod	_	_
-15	kjent	kjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+15	kjent	kjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 16	under	under	ADP	prep	_	20	case	_	_
-17	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	19	det	_	_
+17	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 18	gamle	gammel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	19	amod	_	_
 19	navn	navn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	15	obl	_	_
 20	Alma-Ata	Alma-Ata	PROPN	subst	_	19	appos	_	SpaceAfter=No
@@ -11416,7 +11416,7 @@
 5	Cohen	Cohen	PROPN	subst	_	4	obj	_	_
 6	til	til	ADP	prep	_	9	case	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	Kasakhstan-rundtur	Kasakhstan-rundtur	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
 10	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -11429,7 +11429,7 @@
 5	drive	drive	VERB	verb	VerbForm=Inf	10	ccomp	_	_
 6	med	med	ADP	prep	_	7	case	_	_
 7	påfunnene	påfunn	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	5	obl	_	_
-8	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	7	det	_	SpaceAfter=No
+8	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	7	nmod:poss	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	5	punct	_	_
 10	lover	love	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 11	Atabajev	Atabajev	PROPN	subst	_	10	nsubj	_	SpaceAfter=No
@@ -11489,7 +11489,7 @@
 7	siste	sist	ADJ	adj	Degree=Pos|Number=Plur	8	amod	_	_
 8	ukene	uke	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	9	obl	_	_
 9	hatt	ha	VERB	verb	VerbForm=Part	0	root	_	_
-10	bred	bred	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	bred	bred	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	omtale	omtale	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obj	_	_
 12	av	av	ADP	prep	_	13	case	_	_
 13	landet	land	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	11	nmod	_	SpaceAfter=No
@@ -11536,7 +11536,7 @@
 6	egentlig	egentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	10	advmod	_	_
 7	være	være	AUX	verb	VerbForm=Inf	10	cop	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-9	velkommen	velkommen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	velkommen	velkommen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	gjest	gjest	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	10	punct	_	_
 
@@ -11545,7 +11545,7 @@
 1	Atabajev	Atabajev	PROPN	subst	_	2	nsubj	_	_
 2	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	serveringen	servering	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	obj	_	_
-4	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	xcomp	_	SpaceAfter=No
+4	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	xcomp	_	SpaceAfter=No
 5	:	$:	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 016278
@@ -11572,7 +11572,7 @@
 2	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 4	drikke	drikke	VERB	verb	VerbForm=Inf	0	root	_	_
-5	gjæret	gjære	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	6	amod	_	_
+5	gjæret	gjære	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	6	amod	_	_
 6	hestemelk	hestemelk	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	obj	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -11592,7 +11592,7 @@
 3	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
 4	kursted	kursted	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	2	obj	_	_
 5	der	der	SCONJ	sbu	_	8	mark	_	_
-6	tuberkulose	tuberkulose	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nsubj	_	_
+6	tuberkulose	tuberkulose	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nsubj:pass	_	_
 7	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux:pass	_	_
 8	behandlet	behandle	VERB	verb	VerbForm=Part	4	acl:relcl	_	_
 9	med	med	ADP	prep	_	11	case	_	_
@@ -11621,7 +11621,7 @@
 
 # sent_id = 016284
 # text = Svak tenkning
-1	Svak	svak	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Svak	svak	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	tenkning	tenkning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	0	root	_	_
 
 # newpar
@@ -11682,7 +11682,7 @@
 5	med	med	ADP	prep	_	7	case	_	_
 6	å	å	PART	inf-merke	_	7	mark	_	_
 7	bli	bli	VERB	verb	VerbForm=Inf	4	acl	_	_
-8	underlig	underlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	xcomp	_	SpaceAfter=No
+8	underlig	underlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	xcomp	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 016291
@@ -11730,7 +11730,7 @@
 3	ikke	ikke	PART	adv	Polarity=Neg	7	advmod	_	_
 4	bare	bare	ADV	adv	_	7	advmod	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	uskyldig	uskyldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	uskyldig	uskyldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	anakronisme	anakronisme	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	12	punct	_	_
 9	men	men	CCONJ	konj	_	12	cc	_	_
@@ -11741,7 +11741,7 @@
 
 # sent_id = 016294
 # text = Ordningen bør revideres.
-1	Ordningen	ordning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
+1	Ordningen	ordning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj:pass	_	_
 2	bør	burde	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	revideres	revidere	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	SpaceAfter=No
 4	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -11758,8 +11758,8 @@
 7	og	og	CCONJ	konj	_	8	cc	_	_
 8	Kirkemøtet	Kirkemøtet	PROPN	subst	_	6	conj	_	_
 9	til	til	ADP	prep	_	12	case	_	_
-10	prinsipiell	prinsipiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
-11	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+10	prinsipiell	prinsipiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
+11	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	debatt	debatt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 13	om	om	ADP	prep	_	14	case	_	_
 14	teokrati	teokrati	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	12	nmod	_	SpaceAfter=No
@@ -11852,7 +11852,7 @@
 25	fordel	fordel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obl	_	_
 26	for	for	ADP	prep	_	29	case	_	_
 27	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	29	det	_	_
-28	kvasiteologisk	kvasiteologisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	29	amod	_	_
+28	kvasiteologisk	kvasiteologisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	29	amod	_	_
 29	diskusjon	diskusjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	25	nmod	_	_
 30	om	om	ADP	prep	_	36	case	_	_
 31	hva	hva	PRON	pron	PronType=Int	32	det	_	_
@@ -11913,7 +11913,7 @@
 # newpar
 # sent_id = 016302
 # text = Sist fredag var det høringsfrist, og avsluttet dermed første akt i dette underlige skuespillet.
-1	Sist	sist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Sist	sist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	fredag	fredag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 3	var	være	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	_
@@ -11973,7 +11973,7 @@
 9	altså	altså	ADV	adv	_	8	advmod	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
 11	meget	meget	ADV	adv	_	12	advmod	_	_
-12	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	beskjed	beskjed	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obj	_	_
 14	om	om	ADP	prep	_	17	case	_	_
 15	hva	hva	PRON	pron	PronType=Int	17	obl	_	_
@@ -12003,7 +12003,7 @@
 1	"	$"	PUNCT	<anf>	_	4	punct	_	SpaceAfter=No
 2	Giske	Giske	PROPN	subst	_	4	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	reaksjonær	reaksjonær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	ccomp	_	SpaceAfter=No
+4	reaksjonær	reaksjonær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	ccomp	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	4	punct	_	SpaceAfter=No
 6	"	$"	PUNCT	<anf>	_	4	punct	_	_
 7	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -12075,9 +12075,9 @@
 # text = Å være selvstyrt eller statsstyrt.
 1	Å	å	PART	inf-merke	_	3	mark	_	_
 2	være	være	AUX	verb	VerbForm=Inf	3	cop	_	_
-3	selvstyrt	selvstyrt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	selvstyrt	selvstyrt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	eller	eller	CCONJ	konj	_	5	cc	_	_
-5	statsstyrt	statsstyrt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	conj	_	SpaceAfter=No
+5	statsstyrt	statsstyrt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	conj	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # newpar
@@ -12098,7 +12098,7 @@
 13	å	å	PART	inf-merke	_	14	mark	_	_
 14	føre	føre	VERB	verb	VerbForm=Inf	11	acl	_	_
 15	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-16	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	debatt	debatt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	obj	_	_
 18	om	om	ADP	prep	_	19	case	_	_
 19	forholdet	forhold	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	17	nmod	_	_
@@ -12114,9 +12114,9 @@
 2	tilhører	tilhøre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
 4	meget	meget	ADV	adv	_	5	advmod	_	_
-5	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+5	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 6	og	og	CCONJ	konj	_	7	cc	_	_
-7	pussig	pussig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	_
+7	pussig	pussig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	_
 8	gruppe	gruppe	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nmod	_	_
 9	land	land	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	2	obj	_	_
 10	som	som	SCONJ	sbu	_	11	mark	_	_
@@ -12154,7 +12154,7 @@
 8	denne	denne	DET	det	Gender=Masc|Number=Sing|PronType=Dem	9	det	_	_
 9	posisjonen	posisjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	obj	_	_
 10	som	som	ADP	prep	_	11	case	_	_
-11	progressiv	progressiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	xcomp	_	SpaceAfter=No
+11	progressiv	progressiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	xcomp	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	17	punct	_	_
 13	hvor	hvor	ADV	adv	_	14	advmod	_	_
 14	gjerne	gjerne	ADV	adv	_	17	advmod	_	_
@@ -12175,7 +12175,7 @@
 8	statskirken	statskirke	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	obj	_	_
 9	som	som	ADP	prep	_	14	case	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-11	åpen	åpen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+11	åpen	åpen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 12	og	og	CCONJ	konj	_	13	cc	_	_
 13	inkluderende	inkludere	ADJ	adj	VerbForm=Part	11	conj	_	_
 14	ordning	ordning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	xcomp	_	_
@@ -12223,7 +12223,7 @@
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
 4	statskirken	statskirke	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	konservativ	konservativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	konservativ	konservativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	innretning	innretning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 8	uten	uten	ADP	prep	_	9	case	_	_
 9	dekning	dekning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	nmod	_	_
@@ -12245,7 +12245,7 @@
 3	,	$,	PUNCT	<komma>	_	2	punct	_	_
 4	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
-6	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+6	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 7	mål	mål	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	0	root	_	_
 
 # newpar
@@ -12346,9 +12346,9 @@
 7	Eiendom	Eiendom	PROPN	subst	_	6	flat:name	_	_
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	_	_
 9	ikke	ikke	PART	adv	Polarity=Neg	10	advmod	_	_
-10	snau	snau	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+10	snau	snau	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 11	med	med	ADP	prep	_	13	case	_	_
-12	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	det	_	_
+12	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 13	løfter	løfte	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	10	obl	_	_
 14	eller	eller	CCONJ	konj	_	15	cc	_	_
 15	trusler	trussel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	13	conj	_	SpaceAfter=No
@@ -12406,7 +12406,7 @@
 16	vist	vise	VERB	verb	VerbForm=Part	7	advcl	_	_
 17	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	16	obj	_	_
 18	så	så	ADV	adv	_	19	advmod	_	_
-19	fåfengt	fåfengt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	xcomp	_	SpaceAfter=No
+19	fåfengt	fåfengt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	xcomp	_	SpaceAfter=No
 20	,	$,	PUNCT	<komma>	_	25	punct	_	_
 21	først	først	ADV	adv	_	25	advmod	_	_
 22	mot	mot	ADP	prep	_	25	case	_	_
@@ -12522,7 +12522,7 @@
 4	,	$,	PUNCT	<komma>	_	3	punct	_	_
 5	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
 6	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
-7	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+7	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	mål	mål	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	0	root	_	SpaceAfter=No
 9	"	$"	PUNCT	<anf>	_	8	punct	_	SpaceAfter=No
 10	.	$.	PUNCT	clb	_	8	punct	_	_
@@ -12544,7 +12544,7 @@
 13	som	som	SCONJ	sbu	_	15	mark	_	_
 14	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	_	_
 15	latt	la	VERB	verb	VerbForm=Part	10	acl:relcl	_	_
-16	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	det	_	_
+16	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
 17	by	by	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obj	_	_
 18	i	i	ADP	prep	_	19	case	_	_
 19	stikken	stikken	NOUN	subst	_	15	obl	_	SpaceAfter=No
@@ -12558,7 +12558,7 @@
 3	ikke	ikke	PART	adv	Polarity=Neg	4	advmod	_	_
 4	alene	alene	ADV	adv	_	0	root	_	_
 5	om	om	ADP	prep	_	7	case	_	_
-6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 7	svikt	svikt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -12626,7 +12626,7 @@
 30	der	der	SCONJ	sbu	_	34	mark	_	_
 31	forbildet	forbilde	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	34	nsubj	_	_
 32	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	34	cop	_	_
-33	nonfigurativ	nonfigurativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	34	amod	_	_
+33	nonfigurativ	nonfigurativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	34	amod	_	_
 34	skulptur	skulptur	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	28	nmod	_	SpaceAfter=No
 35	.	$.	PUNCT	clb	_	14	punct	_	_
 
@@ -12652,7 +12652,7 @@
 18	eiendomsbaroner	eiendomsbaron	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	16	nmod	_	_
 19	og	og	CCONJ	konj	_	22	cc	_	_
 20	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-21	toneangivende	toneangivende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	amod	_	_
+21	toneangivende	toneangivende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	amod	_	_
 22	retning	retning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	conj	_	_
 23	blant	blant	ADP	prep	_	25	case	_	_
 24	dagens	dag	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	_
@@ -12685,7 +12685,7 @@
 12	vanlig	vanlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	13	amod	_	_
 13	menneske	menneske	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	nmod	_	_
 14	og	og	CCONJ	konj	_	16	cc	_	_
-15	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	16	det	_	_
+15	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	16	nmod:poss	_	_
 16	sanser	sans	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	9	conj	_	_
 17	trives	trives	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 18	med	med	ADP	prep	_	8	case	_	SpaceAfter=No
@@ -12766,7 +12766,7 @@
 3	merker	merke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 5	i	i	ADP	prep	_	7	case	_	_
-6	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+6	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 7	glasshus	glasshus	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	obl	_	_
 8	rett	rett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
 9	ved	ved	ADP	prep	_	7	nmod	_	SpaceAfter=No
@@ -12794,9 +12794,9 @@
 31	solstrålene	solstråle	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	33	nsubj	_	_
 32	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	33	aux	_	_
 33	gjøre	gjøre	VERB	verb	VerbForm=Inf	17	conj	_	_
-34	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	35	det	_	_
+34	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	35	nmod:poss	_	_
 35	dataskjerm	dataskjerm	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	33	obj	_	_
-36	uleselig	uleselig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	33	xcomp	_	SpaceAfter=No
+36	uleselig	uleselig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	33	xcomp	_	SpaceAfter=No
 37	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 016345
@@ -12815,7 +12815,7 @@
 12	inngå	inngå	VERB	verb	VerbForm=Inf	2	xcomp	_	_
 13	i	i	ADP	prep	_	16	case	_	_
 14	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
-15	uovervinnelig	uovervinnelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	uovervinnelig	uovervinnelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	treenighet	treenighet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obl	_	SpaceAfter=No
 17	,	$,	PUNCT	<komma>	_	20	punct	_	_
 18	fordi	fordi	SCONJ	sbu	_	20	mark	_	_
@@ -12887,7 +12887,7 @@
 10	landskapet	landskap	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	8	nmod	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	14	punct	_	_
 12	mens	mens	SCONJ	sbu	_	14	mark	_	_
-13	harmoni	harmoni	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nsubj	_	_
+13	harmoni	harmoni	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nsubj:pass	_	_
 14	oppfattes	oppfatte	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	2	advcl	_	_
 15	av	av	ADP	prep	_	16	case	_	_
 16	byggeideologene	byggeideolog	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	14	obl	_	_
@@ -12895,7 +12895,7 @@
 18	som	som	ADP	prep	_	19	case	_	_
 19	uttrykk	uttrykk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	14	xcomp	_	_
 20	for	for	ADP	prep	_	22	case	_	_
-21	artistisk	artistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	amod	_	_
+21	artistisk	artistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	amod	_	_
 22	feighet	feighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	19	nmod	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -12903,10 +12903,10 @@
 # text = Utfordringen er akutt, fordi vår tid er i stand til å sette et vesensforskjellig kraftigere stempel på omgivelsene enn alle tidligere epoker.
 1	Utfordringen	utfordring	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	akutt	akutt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+3	akutt	akutt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	10	punct	_	_
 5	fordi	fordi	SCONJ	sbu	_	10	mark	_	_
-6	vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+6	vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 7	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	nsubj	_	_
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	_	_
 9	i	i	ADP	prep	_	10	case	_	_
@@ -12931,14 +12931,14 @@
 1	Vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
 2	overgår	overgå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	alle	all	DET	det	Number=Plur|PronType=Tot	5	det	_	_
-4	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	5	det	_	_
+4	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	forfedre	forfader	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	2	obj	_	_
 6	gjennom	gjennom	ADP	prep	_	7	case	_	_
 7	overlegenhet	overlegenhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	obl	_	_
 8	i	i	ADP	prep	_	9	case	_	_
 9	byggekapasitet	byggekapasitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nmod	_	_
 10	og	og	CCONJ	konj	_	12	cc	_	_
-11	teknisk	teknisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	teknisk	teknisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	rekkevidde	rekkevidde	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	conj	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	16	punct	_	_
 14	med	med	ADP	prep	_	16	case	_	_
@@ -12982,7 +12982,7 @@
 8	unnsetning	unnsetning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	obj	_	_
 9	for	for	ADP	prep	_	12	case	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-11	stakket	stakket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	stakket	stakket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	stund	stund	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -12991,7 +12991,7 @@
 # text = Dermed etterlater vår slekt mer hemningsløse økologiske fingeravtrykk omkring oss enn noen før oss i historien.
 1	Dermed	dermed	ADV	adv	_	2	advmod	_	_
 2	etterlater	etterlate	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	_
+3	vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 4	slekt	slekt	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	nsubj	_	_
 5	mer	mye	ADJ	adj	Degree=Cmp	6	advmod	_	_
 6	hemningsløse	hemningsløs	ADJ	adj	Degree=Pos|Number=Plur	8	amod	_	_
@@ -13048,12 +13048,12 @@
 9	store	stor	ADJ	adj	Degree=Pos|Number=Plur	10	amod	_	_
 10	oppdragene	oppdrag	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	6	nmod	_	_
 11	og	og	CCONJ	konj	_	13	cc	_	_
-12	deres	deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	det	_	_
+12	deres	deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 13	støttespillere	støttespiller	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	2	conj	_	_
 14	synes	synes	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 15	å	å	PART	inf-merke	_	17	mark	_	_
 16	være	være	AUX	verb	VerbForm=Inf	17	cop	_	_
-17	utdannet	utdanne	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	14	xcomp	_	_
+17	utdannet	utdanne	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	14	xcomp	_	_
 18	på	på	ADP	prep	_	21	case	_	_
 19	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
 20	slik	slik	DET	det	Gender=Masc|Number=Sing|PronType=Dem	21	det	_	_
@@ -13668,7 +13668,7 @@
 4	inne	inne	ADP	prep	_	6	case	_	_
 5	på	på	ADP	prep	_	6	case	_	_
 6	rommet	rom	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	obl	_	_
-7	hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	SpaceAfter=No
+7	hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	1	punct	_	_
 
 # sent_id = 016427
@@ -13698,7 +13698,7 @@
 3	står	stå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	fortsatt	fortsatt	ADV	adv	_	3	advmod	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	grønn	grønn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	grønn	grønn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	kopp	kopp	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nsubj	_	_
 8	fra	fra	ADP	prep	_	10	case	_	_
 9	samme	samme	DET	det	Definite=Def|PronType=Dem	10	det	_	_
@@ -13718,7 +13718,7 @@
 9	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	obj	_	_
 10	utenfor	utenfor	ADP	prep	_	11	case	_	_
 11	rommet	rom	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	8	obl	_	_
-12	hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	SpaceAfter=No
+12	hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 016431
@@ -13951,7 +13951,7 @@
 3	på	på	ADP	prep	_	7	case	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	1	reparandum	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	gul	gul	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	gul	gul	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	legoløve	legoløve	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	obl	_	_
 8	oppi	oppi	ADP	prep	_	9	case	_	_
 9	lysholderen	lysholder	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
@@ -13989,7 +13989,7 @@
 # sent_id = 016457
 # text = Hører oppvaksmaskinen lukkes.
 1	Hører	høre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	oppvaksmaskinen	oppvaksmaskin	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
+2	oppvaksmaskinen	oppvaksmaskin	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj:pass	_	_
 3	lukkes	lukke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	1	ccomp	_	SpaceAfter=No
 4	.	$.	PUNCT	clb	_	1	punct	_	_
 
@@ -14174,7 +14174,7 @@
 6	kaffen	kaffe	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	_
 7	være	være	AUX	verb	VerbForm=Inf	9	cop	_	_
 8	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
-9	kald	kald	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+9	kald	kald	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 10	.	$.	PUNCT	clb	_	9	punct	_	_
 
 # sent_id = 016478
@@ -14257,8 +14257,8 @@
 11	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	12	nsubj	_	_
 12	trenger	trenge	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	acl:relcl	_	_
 13	før	før	SCONJ	sbu	_	19	mark	_	_
-14	total	total	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
-15	fargekoordinering	fargekoordinering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	19	nsubj	_	_
+14	total	total	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
+15	fargekoordinering	fargekoordinering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	19	nsubj:pass	_	_
 16	av	av	ADP	prep	_	17	case	_	_
 17	leiligheten	leilighet	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	_
 18	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux	_	_
@@ -14317,7 +14317,7 @@
 9	på	på	ADP	prep	_	17	case	_	_
 10	at	at	SCONJ	sbu	_	17	mark	_	_
 11	hjemmet	hjem	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	17	nsubj	_	_
-12	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	SpaceAfter=No
+12	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	14	punct	_	_
 14	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	appos	_	_
 15	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	cop	_	_
@@ -14362,7 +14362,7 @@
 6	hele	hel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	7	amod	_	_
 7	Instagram	Instagram	PROPN	subst	_	8	nsubj	_	_
 8	ble	bli	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	_	_
-9	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	xcomp	_	_
+9	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	xcomp	_	_
 10	av	av	ADP	prep	_	12	case	_	_
 11	hvite	hvit	ADJ	adj	Degree=Pos|Number=Plur	12	amod	_	_
 12	fjell	fjell	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	9	obl	_	_
@@ -14430,7 +14430,7 @@
 7	tok	ta	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	20	advcl	_	_
 8	med	med	ADP	prep	_	9	case	_	_
 9	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	7	obl	_	_
-10	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	det	_	_
+10	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	barn	barn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	7	obj	_	_
 12	ut	ut	ADP	prep	_	14	case	_	_
 13	i	i	ADP	prep	_	14	case	_	_
@@ -14456,7 +14456,7 @@
 # text = Uten noen stor plan for dagen.
 1	Uten	uten	ADP	prep	_	4	case	_	_
 2	noen	noen	DET	det	Gender=Masc|Number=Sing|PronType=Ind	4	det	_	_
-3	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	plan	plan	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 5	for	for	ADP	prep	_	6	case	_	_
 6	dagen	dag	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	SpaceAfter=No
@@ -14542,7 +14542,7 @@
 
 # sent_id = 016509
 # text = Klar for årets første utelunsj.
-1	Klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+1	Klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 2	for	for	ADP	prep	_	5	case	_	_
 3	årets	år	NOUN	subst	Case=Gen|Definite=Def|Gender=Neut|Number=Sing	5	nmod	_	_
 4	første	første	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing|NumType=Ord	5	amod	_	_
@@ -14564,11 +14564,11 @@
 11	,	$,	PUNCT	<komma>	_	14	punct	_	_
 12	kaffen	kaffe	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	_
 13	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	14	cop	_	_
-14	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	_
+14	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	_
 15	og	og	CCONJ	konj	_	18	cc	_	_
 16	mannen	mann	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	18	nsubj	_	_
 17	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	18	cop	_	_
-18	kjekk	kjekk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	SpaceAfter=No
+18	kjekk	kjekk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	SpaceAfter=No
 19	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 016511
@@ -14608,7 +14608,7 @@
 6	like	like	ADV	adv	_	7	advmod	_	_
 7	pent	pen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	3	advmod	_	_
 8	med	med	ADP	prep	_	10	case	_	_
-9	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	samvittighet	samvittighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -14636,7 +14636,7 @@
 6	Instagramfolket	Instagramfolk	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	4	nmod	_	_
 7	pakket	pakke	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	11	advcl	_	_
 8	skiboksene	skiboks	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	7	obj	_	_
-9	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	det	_	SpaceAfter=No
+9	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	nmod:poss	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	7	punct	_	_
 11	stod	stå	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 12	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	_	_
@@ -14693,7 +14693,7 @@
 11	satt	sitte	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	acl:relcl	_	_
 12	på	på	ADP	prep	_	15	case	_	_
 13	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
-14	slitt	slite	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	15	amod	_	_
+14	slitt	slite	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	15	amod	_	_
 15	veikro	veikro	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obl	_	_
 16	og	og	CCONJ	konj	_	17	cc	_	_
 17	knasket	knaske	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	11	conj	_	_
@@ -14796,7 +14796,7 @@
 4	at	at	SCONJ	sbu	_	7	mark	_	_
 5	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
 6	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	_	_
-7	gravid	gravid	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	ccomp	_	_
+7	gravid	gravid	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	ccomp	_	_
 8	samtidig	samtidig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	advmod	_	_
 9	som	som	ADP	prep	_	10	case	_	_
 10	meg	jeg	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=1|PronType=Prs	8	obl	_	SpaceAfter=No
@@ -14822,7 +14822,7 @@
 3	bar	bære	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	på	på	ADP	prep	_	7	case	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	utålmodig	utålmodig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	utålmodig	utålmodig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	jente	jente	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 8	som	som	SCONJ	sbu	_	9	mark	_	_
 9	kom	komme	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	acl:relcl	_	_
@@ -14846,7 +14846,7 @@
 # sent_id = 016530
 # text = Passelig klar.
 1	Passelig	passelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	2	advmod	_	_
-2	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+2	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 3	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 016531
@@ -14883,13 +14883,13 @@
 # sent_id = 016535
 # text = Så vakker.
 1	Så	så	ADV	adv	_	2	advmod	_	_
-2	vakker	vakker	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+2	vakker	vakker	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 3	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 016536
 # text = Så perfekt.
 1	Så	så	ADV	adv	_	2	advmod	_	_
-2	perfekt	perfekt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+2	perfekt	perfekt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 3	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 016537
@@ -14980,13 +14980,13 @@
 4	kroppen	kropp	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
 5	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	_	_
 6	for	for	ADV	adv	_	7	advmod	_	_
-7	tung	tung	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	ccomp	_	SpaceAfter=No
+7	tung	tung	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	ccomp	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 016544
 # text = For trett, etter null søvn natten før.
 1	For	for	ADV	adv	_	2	advmod	_	_
-2	trett	trett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+2	trett	trett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	6	punct	_	_
 4	etter	etter	ADP	prep	_	6	case	_	_
 5	null	null	NUM	det	Number=Plur|NumType=Card	6	nummod	_	_
@@ -15033,7 +15033,7 @@
 3	kroppen	kropp	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 4	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	_	_
 5	ekstra	ekstra	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
-6	tung	tung	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	1	ccomp	_	_
+6	tung	tung	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	1	ccomp	_	_
 7	i	i	ADP	prep	_	8	case	_	_
 8	dag	dag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	1	punct	_	_
@@ -15075,7 +15075,7 @@
 # text = Frem til jeg ble vekket av mannen som kom fra trening.
 1	Frem	frem	ADP	prep	_	5	case	_	_
 2	til	til	SCONJ	sbu	_	5	mark	_	_
-3	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
+3	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj:pass	_	_
 4	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	vekket	vekke	VERB	verb	VerbForm=Part	0	root	_	_
 6	av	av	ADP	prep	_	7	case	_	_
@@ -15156,7 +15156,7 @@
 4	at	at	SCONJ	sbu	_	6	mark	_	_
 5	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
 6	brukte	bruke	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	csubj	_	_
-7	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	kjeft	kjeft	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -15176,7 +15176,7 @@
 # text = Den står klar i kjøleskapet, skriver pappaen.
 1	Den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	står	stå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	ccomp	_	_
-3	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	xcomp	_	_
+3	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	xcomp	_	_
 4	i	i	ADP	prep	_	5	case	_	_
 5	kjøleskapet	kjøleskap	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	obl	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	2	punct	_	_
@@ -15231,7 +15231,7 @@
 12	og	og	CCONJ	konj	_	15	cc	_	_
 13	tilstanden	tilstand	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	nsubj	_	_
 14	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
-15	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	conj	_	SpaceAfter=No
+15	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	conj	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	7	punct	_	_
 
 # sent_id = 016565
@@ -15279,7 +15279,7 @@
 1	I	i	ADP	prep	_	2	case	_	_
 2	syvtiden	syvtid	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
 3	vekkes	vekke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
-4	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+4	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj:pass	_	_
 5	av	av	ADP	prep	_	7	case	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 7	telefon	telefon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
@@ -15364,7 +15364,7 @@
 5	moped	moped	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	_
 6	som	som	SCONJ	sbu	_	7	mark	_	_
 7	sto	stå	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl:relcl	_	_
-8	parkert	parkere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	7	xcomp	_	_
+8	parkert	parkere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	7	xcomp	_	_
 9	i	i	ADP	prep	_	10	case	_	_
 10	bakgården	bakgård	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -15435,7 +15435,7 @@
 27	ambulansepersonalet	ambulansepersonale	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	28	nsubj	_	_
 28	jobbet	jobbe	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	_	_
 29	med	med	ADP	prep	_	30	case	_	_
-30	vedkommende	vedkommende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	28	advmod	_	_
+30	vedkommende	vedkommende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	28	advmod	_	_
 31	på	på	ADP	prep	_	32	case	_	_
 32	stedet	sted	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	28	obl	_	SpaceAfter=No
 33	.	$.	PUNCT	clb	_	4	punct	_	_
@@ -15450,18 +15450,18 @@
 6	,	$,	PUNCT	<komma>	_	9	punct	_	_
 7	men	men	CCONJ	konj	_	9	cc	_	_
 8	hardt	hard	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
-9	skadet	skade	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	5	conj	_	SpaceAfter=No
+9	skadet	skade	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	5	conj	_	SpaceAfter=No
 10	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 016580
 # text = Personen ble fraktet vekk av ambulansen kort tid etter.
-1	Personen	person	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
+1	Personen	person	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	fraktet	frakte	VERB	verb	VerbForm=Part	0	root	_	_
 4	vekk	vekk	ADV	prep	_	3	advmod	_	_
 5	av	av	ADP	prep	_	6	case	_	_
 6	ambulansen	ambulanse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
-7	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	obl	_	_
 9	etter	etter	ADV	prep	_	3	advmod	_	SpaceAfter=No
 10	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -15702,7 +15702,7 @@
 3	at	at	SCONJ	sbu	_	7	mark	_	_
 4	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
 5	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	_	_
-6	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	melding	melding	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	ccomp	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -15794,7 +15794,7 @@
 13	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	17	nsubj	_	_
 14	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	cop	_	_
 15	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-16	dyktig	dyktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	dyktig	dyktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	nevrokirurg	nevrokirurg	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	conj	_	SpaceAfter=No
 18	,	$,	PUNCT	<komma>	_	17	punct	_	_
 19	sies	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
@@ -15844,7 +15844,7 @@
 7	på	på	ADP	prep	_	12	case	_	_
 8	at	at	SCONJ	sbu	_	12	mark	_	_
 9	gutten	gutt	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	12	nsubj	_	_
-10	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	det	_	_
+10	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 11	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	_	_
 12	dø	dø	VERB	verb	VerbForm=Inf	6	advcl	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -15880,7 +15880,7 @@
 5	i	i	ADP	prep	_	6	case	_	_
 6	hodet	hode	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	4	nmod	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	10	punct	_	_
-8	blødningen	blødning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	_
+8	blødningen	blødning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	nsubj:pass	_	_
 9	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	aux:pass	_	_
 10	fjernet	fjerne	VERB	verb	VerbForm=Part	3	conj	_	_
 11	under	under	ADP	prep	_	12	case	_	_
@@ -15894,7 +15894,7 @@
 3	av	av	ADP	prep	_	4	case	_	_
 4	beinet	bein	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	nmod	_	_
 5	på	på	ADP	prep	_	7	case	_	_
-6	høyre	høyre	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	høyre	høyre	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	side	side	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	nmod	_	_
 8	av	av	ADP	prep	_	9	case	_	_
 9	hodet	hode	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	nmod	_	_
@@ -15923,7 +15923,7 @@
 # sent_id = 016612
 # text = En ny hjerneblødningoppdages på venstresiden neste dag.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	2	det	_	_
-2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	nsubj	_	_
+2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	nsubj	_	_
 3	hjerneblødningoppdages	hjerneblødningoppdages	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	på	på	ADP	prep	_	5	case	_	_
 5	venstresiden	venstreside	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
@@ -16000,7 +16000,7 @@
 3	synes	synes	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	legene	lege	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	5	nsubj	_	_
 5	virker	virke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
-6	oppglødd	oppglødd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	xcomp	_	SpaceAfter=No
+6	oppglødd	oppglødd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	xcomp	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	9	punct	_	_
 8	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	expl	_	_
 9	ser	se	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	_	_
@@ -16125,7 +16125,7 @@
 2	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	expl	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	jo	jo	ADV	adv	_	5	advmod	_	_
-5	kritisk	kritisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+5	kritisk	kritisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 6	likevel	likevel	ADV	adv	_	5	advmod	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -16136,7 +16136,7 @@
 3	at	at	SCONJ	sbu	_	7	mark	_	_
 4	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
 5	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	_	_
-6	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	melding	melding	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	ccomp	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -16180,7 +16180,7 @@
 7	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
 8	ligger	ligge	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	_	_
 9	på	på	ADP	prep	_	11	case	_	_
-10	nevrokirurgisk	nevrokirurgisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	nevrokirurgisk	nevrokirurgisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	avdeling	avdeling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	8	obl	_	_
 12	på	på	ADP	prep	_	13	case	_	_
 13	Haukeland	Haukeland	PROPN	subst	_	11	nmod	_	SpaceAfter=No
@@ -16210,7 +16210,7 @@
 
 # sent_id = 016631
 # text = Han overføres etter hvert til rehabiliteringsavdelingen på Nordås.
-1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
+1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj:pass	_	_
 2	overføres	overføre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 3	etter	etter	ADP	prep	_	4	case	_	_
 4	hvert	hver	DET	det	Gender=Neut|Number=Sing|PronType=Tot	2	obl	_	_
@@ -16236,7 +16236,7 @@
 11	tilbakeslag	tilbakeslag	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	10	obj	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	16	punct	_	_
 13	og	og	CCONJ	konj	_	16	cc	_	_
-14	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
+14	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	nsubj:pass	_	_
 15	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	aux:pass	_	_
 16	rammet	ramme	VERB	verb	VerbForm=Part	10	conj	_	_
 17	av	av	ADP	prep	_	19	case	_	_
@@ -16257,7 +16257,7 @@
 9	Nordås	Nordås	PROPN	subst	_	7	nmod	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	5	punct	_	_
 11	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	_	_
-12	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
+12	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	nsubj:pass	_	_
 13	derfor	derfor	ADV	adv	_	14	advmod	_	_
 14	legges	legge	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 15	inn	inn	ADV	prep	_	14	advmod	_	_
@@ -16284,7 +16284,7 @@
 12	familie	familie	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	nsubj	_	_
 13	og	og	CCONJ	konj	_	14	cc	_	_
 14	leger	lege	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	12	conj	_	_
-15	bekymret	bekymre	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	2	conj	_	_
+15	bekymret	bekymre	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	2	conj	_	_
 16	for	for	ADP	prep	_	20	case	_	_
 17	hvordan	hvordan	ADV	adv	_	20	advmod	_	_
 18	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	20	nsubj	_	_
@@ -16345,7 +16345,7 @@
 # text = Han er klar til å kjempe seg tilbake.
 1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	til	til	ADP	prep	_	6	case	_	_
 5	å	å	PART	inf-merke	_	6	mark	_	_
 6	kjempe	kjempe	VERB	verb	VerbForm=Inf	3	advcl	_	_
@@ -16360,7 +16360,7 @@
 3	15	15	NUM	det	Number=Plur|NumType=Card	2	obj	_	_
 4	og	og	CCONJ	konj	_	7	cc	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	halv	halv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	halv	halv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	måned	måned	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	conj	_	_
 8	på	på	ADP	prep	_	9	case	_	_
 9	Haukeland	Haukeland	PROPN	subst	_	2	obl	_	_
@@ -16448,7 +16448,7 @@
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 3	fortsatt	fortsatt	ADV	adv	_	6	advmod	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	gutt	gutt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -16480,7 +16480,7 @@
 4	Battery	Battery	PROPN	subst	_	2	conj	_	_
 5	ødela	ødelegge	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	ccomp	_	_
 6	livet	liv	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	5	obj	_	_
-7	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	SpaceAfter=No
+7	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	5	punct	_	_
 9	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 10	Espen	Espen	PROPN	subst	Gender=Masc	9	nsubj	_	SpaceAfter=No
@@ -16517,7 +16517,7 @@
 10	krøller	krølle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	_	_
 11	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	10	obj	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	14	punct	_	_
-13	setninger	setning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	14	nsubj	_	_
+13	setninger	setning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	14	nsubj:pass	_	_
 14	slukes	sluke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	10	conj	_	SpaceAfter=No
 15	,	$,	PUNCT	<komma>	_	19	punct	_	_
 16	spesielt	spesiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	17	advmod	_	_
@@ -16535,7 +16535,7 @@
 
 # sent_id = 016650
 # text = Pannelappene ble hardest rammet hos Espen, den delen av hjernen som styrer vår personlighet, blant annet følelser og hemninger.
-1	Pannelappene	pannelapp	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	4	nsubj	_	_
+1	Pannelappene	pannelapp	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	4	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	_	_
 3	hardest	hard	ADJ	adj	Definite=Ind|Degree=Sup	4	advmod	_	_
 4	rammet	ramme	VERB	verb	VerbForm=Part	0	root	_	_
@@ -16548,7 +16548,7 @@
 11	hjernen	hjerne	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
 12	som	som	SCONJ	sbu	_	13	mark	_	_
 13	styrer	styre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	acl:relcl	_	_
-14	vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	15	det	_	_
+14	vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 15	personlighet	personlighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	13	obj	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	19	punct	_	_
 17	blant	blant	ADP	prep	_	18	case	_	_
@@ -16563,7 +16563,7 @@
 1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	ble	bli	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	også	også	ADV	adv	_	2	advmod	_	_
-4	blind	blind	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	xcomp	_	_
+4	blind	blind	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	xcomp	_	_
 5	på	på	ADP	prep	_	7	case	_	_
 6	venstre	venstre	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	amod	_	_
 7	øye	øye	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	4	obl	_	_
@@ -16643,7 +16643,7 @@
 # sent_id = 016657
 # text = Gjensynsgledener uhemmet, Espen håndhilser mange ganger når vi kommer på besøk.
 1	Gjensynsgledener	Gjensynsgledener	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	uhemmet	uhemmet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	1	xcomp	_	SpaceAfter=No
+2	uhemmet	uhemmet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	1	xcomp	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	5	punct	_	_
 4	Espen	Espen	PROPN	subst	Gender=Masc	5	nsubj	_	_
 5	håndhilser	håndhilse	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	1	conj	_	_
@@ -16663,7 +16663,7 @@
 3	mars	mars	NOUN	subst	Gender=Masc	0	root	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	7	punct	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	drøy	drøy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	drøy	drøy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	måned	måned	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	appos	_	_
 8	siden	siden	SCONJ	sbu	_	10	mark	_	_
 9	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	_	_
@@ -16684,7 +16684,7 @@
 7	,	$,	PUNCT	<komma>	_	11	punct	_	_
 8	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	_	_
-10	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	boltreplass	boltreplass	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	conj	_	_
 12	i	i	ADP	prep	_	13	case	_	_
 13	barndomshjemmet	barndomshjem	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	11	nmod	_	_
@@ -16700,7 +16700,7 @@
 4	ikke	ikke	PART	adv	Polarity=Neg	2	advmod	_	_
 5	lenger	lenge	ADJ	adj	Degree=Cmp	2	advmod	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	10	punct	_	_
-7	sykehussengen	sykehusseng	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	_
+7	sykehussengen	sykehusseng	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	nsubj:pass	_	_
 8	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	_	_
 9	snart	snar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	10	advmod	_	_
 10	byttes	bytte	VERB	verb	VerbForm=Inf|Voice=Pass	2	conj	_	_
@@ -16986,11 +16986,11 @@
 # text = Søsteren var rolig, Espen stikk motsatt.
 1	Søsteren	søster	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	cop	_	_
-3	rolig	rolig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+3	rolig	rolig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	5	punct	_	_
 5	Espen	Espen	PROPN	subst	Gender=Masc	3	conj	_	_
 6	stikk	stikk	ADV	adv	_	7	advmod	_	_
-7	motsatt	motsatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	xcomp	_	SpaceAfter=No
+7	motsatt	motsatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	xcomp	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 016684
@@ -17048,9 +17048,9 @@
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
 2	Du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	4	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	grei	grei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	ccomp	_	_
+4	grei	grei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	ccomp	_	_
 5	og	og	CCONJ	konj	_	6	cc	_	_
-6	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	conj	_	_
+6	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	conj	_	_
 7	av	av	ADP	prep	_	8	case	_	_
 8	humør	humør	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	6	nmod	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	10	punct	_	_
@@ -17066,12 +17066,12 @@
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	blitt	bli	VERB	verb	VerbForm=Part	12	ccomp	_	_
 4	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
-5	emosjonell	emosjonell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	xcomp	_	SpaceAfter=No
+5	emosjonell	emosjonell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	xcomp	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	8	punct	_	_
 7	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
 8	finnes	finnes	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	_	_
 9	ikke	ikke	PART	adv	Polarity=Neg	8	advmod	_	_
-10	sint	sint	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	xcomp	_	SpaceAfter=No
+10	sint	sint	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	xcomp	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	8	punct	_	_
 12	påpeker	påpeke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 13	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nsubj	_	SpaceAfter=No
@@ -17130,7 +17130,7 @@
 1	Espen	Espen	PROPN	subst	Gender=Masc	4	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	4	advmod	_	_
-4	tydelig	tydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	ccomp	_	_
+4	tydelig	tydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	ccomp	_	_
 5	på	på	ADP	prep	_	8	case	_	_
 6	at	at	SCONJ	sbu	_	8	mark	_	_
 7	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
@@ -17198,7 +17198,7 @@
 22	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	23	nsubj	_	_
 23	får	få	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	_	_
 24	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	25	advmod	_	_
-25	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	amod	_	_
+25	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	amod	_	_
 26	samvittighet	samvittighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	23	obj	_	_
 27	når	når	SCONJ	sbu	_	29	mark	_	_
 28	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	29	nsubj	_	_
@@ -17388,7 +17388,7 @@
 12	,	$,	PUNCT	<komma>	_	9	punct	_	_
 13	gjorde	gjøre	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	advcl	_	_
 14	ham	han	PRON	pron	Animacy=Hum|Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	obj	_	_
-15	overmodig	overmodig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	xcomp	_	SpaceAfter=No
+15	overmodig	overmodig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	xcomp	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 016708
@@ -17397,7 +17397,7 @@
 2	Mange	mange	ADJ	adj	Degree=Pos|Number=Plur	3	amod	_	_
 3	gutter	gutt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	7	nsubj	_	_
 4	på	på	ADP	prep	_	6	case	_	_
-5	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+5	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 6	alder	alder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nmod	_	_
 7	føler	føle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	ccomp	_	_
 8	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	7	obj	_	_
@@ -17502,7 +17502,7 @@
 # text = De har sine tunge stunder, Espens foreldre - selv om de klarer å se fremover.
 1	De	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	_	_
 2	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	5	det	_	_
+3	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 4	tunge	tung	ADJ	adj	Degree=Pos|Number=Plur	5	amod	_	_
 5	stunder	stund	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	2	obj	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	8	punct	_	_
@@ -17614,7 +17614,7 @@
 16	sammen	sammen	ADV	adv	_	18	advmod	_	_
 17	med	med	ADP	prep	_	18	case	_	_
 18	assistentene	assistent	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	3	obl	_	_
-19	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	18	det	_	SpaceAfter=No
+19	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	18	nmod:poss	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 016723
@@ -17730,7 +17730,7 @@
 3	føler	føle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	meg	jeg	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=1|PronType=Prs	3	obj	_	_
 5	jævlig	jævlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
-6	heldig	heldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	xcomp	_	SpaceAfter=No
+6	heldig	heldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	xcomp	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 016732
@@ -17750,7 +17750,7 @@
 3	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 4	bli	bli	VERB	verb	VerbForm=Inf	10	ccomp	_	_
 5	så	så	ADV	adv	_	6	advmod	_	_
-6	frisk	frisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	xcomp	_	_
+6	frisk	frisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	xcomp	_	_
 7	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	_	_
 8	kan	kunne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	advcl	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	4	punct	_	_
@@ -17777,7 +17777,7 @@
 1	-	$-	PUNCT	<strek>	_	3	punct	_	_
 2	Med	med	ADP	prep	_	3	case	_	_
 3	munnen	munn	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	ccomp	_	_
-4	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	SpaceAfter=No
+4	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	3	punct	_	_
 6	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 7	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	SpaceAfter=No
@@ -17799,15 +17799,15 @@
 # sent_id = 016738
 # text = Oppmerksomheten din, konsentrasjonen din.
 1	Oppmerksomheten	oppmerksomhet	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
-2	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	1	det	_	SpaceAfter=No
+2	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	1	nmod:poss	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	4	punct	_	_
 4	konsentrasjonen	konsentrasjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	1	conj	_	_
-5	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	SpaceAfter=No
+5	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	1	punct	_	_
 
 # sent_id = 016739
 # text = Du blir så lett forstyrret, sier pappa.
-1	Du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	5	nsubj	_	_
+1	Du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	5	nsubj:pass	_	_
 2	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux:pass	_	_
 3	så	så	ADV	adv	_	4	advmod	_	_
 4	lett	lett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
@@ -17822,7 +17822,7 @@
 1	-	$-	PUNCT	<strek>	_	7	punct	_	_
 2	Ja	ja	INTJ	interj	_	7	discourse	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	2	punct	_	_
-4	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	_	_
+4	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj:pass	_	_
 5	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux:pass	_	_
 6	lett	lett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	advmod	_	_
 7	distrahert	distrahere	VERB	verb	VerbForm=Part	0	root	_	_
@@ -17866,7 +17866,7 @@
 6	Espen	Espen	PROPN	subst	Gender=Masc	9	nsubj	_	_
 7	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	cop	_	_
 8	svært	svær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
-9	redusert	redusere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	3	amod	_	_
+9	redusert	redusere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	3	amod	_	_
 10	i	i	ADP	prep	_	11	case	_	_
 11	tiden	tid	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 12	etter	etter	ADP	prep	_	13	case	_	_
@@ -17922,14 +17922,14 @@
 3	persiennene	persienne	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	2	obj	_	_
 4	på	på	ADP	prep	_	5	case	_	_
 5	rommet	rom	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	obl	_	_
-6	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+6	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 7	selv	selv	ADV	adv	_	8	advmod	_	_
 8	da	da	SCONJ	sbu	_	13	mark	_	_
 9	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
 10	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	cop	_	_
 11	ti	ti	NUM	det	Number=Plur|NumType=Card	12	nummod	_	_
 12	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	13	obl	_	_
-13	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	advcl	_	SpaceAfter=No
+13	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	advcl	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 016747
@@ -17945,7 +17945,7 @@
 9	problemer	problem	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	8	obj	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	5	punct	_	_
 11	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	_	_
-12	redusert	redusere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	SpaceAfter=No
+12	redusert	redusere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	12	punct	_	_
 
 # sent_id = 016748
@@ -17953,7 +17953,7 @@
 1	Hukommelsen	hukommelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	bemerkelsesverdig	bemerkelsesverdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	4	advmod	_	_
-4	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+4	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 5	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 016749
@@ -18134,7 +18134,7 @@
 # sent_id = 016759
 # text = Fordypningsoppgaven hans på 2. trinnet er å lage en pianokrakk, sammen med assistenten Fredrik Breivik.
 1	Fordypningsoppgaven	fordypningsoppgave	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
-2	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	1	det	_	_
+2	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	1	nmod:poss	_	_
 3	på	på	ADP	prep	_	5	case	_	_
 4	2.	2.	ADJ	adj	Number=Plur|NumType=Ord	5	amod	_	_
 5	trinnet	trinn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	1	nmod	_	_
@@ -18196,7 +18196,7 @@
 3	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 4	hatt	ha	VERB	verb	VerbForm=Part	0	root	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	fantastisk	fantastisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	fantastisk	fantastisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	utvikling	utvikling	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 8	etter	etter	ADP	prep	_	11	case	_	_
 9	at	at	SCONJ	sbu	_	11	mark	_	_
@@ -18322,7 +18322,7 @@
 # text = Timeplanen er tett denne dagen.
 1	Timeplanen	timeplan	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	tett	tett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	tett	tett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	denne	denne	DET	det	Gender=Masc|Number=Sing|PronType=Dem	5	det	_	_
 5	dagen	dag	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -18538,7 +18538,7 @@
 2	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	1	obj	_	_
 3	rundt	rundt	ADP	prep	_	4	case	_	_
 4	halsen	hals	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
-5	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	SpaceAfter=No
+5	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	1	punct	_	_
 
 # sent_id = 016787
@@ -18547,7 +18547,7 @@
 2	Du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
 3	reddet	redde	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	ccomp	_	_
 4	livet	liv	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	obj	_	_
-5	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	SpaceAfter=No
+5	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	3	punct	_	_
 7	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	SpaceAfter=No
@@ -18565,7 +18565,7 @@
 8	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
 9	geniale	genial	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	10	amod	_	_
 10	hjernen	hjerne	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	obj	_	_
-11	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	10	det	_	SpaceAfter=No
+11	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	10	nmod:poss	_	SpaceAfter=No
 12	!	$!	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 016789
@@ -18578,7 +18578,7 @@
 6	«	$"	PUNCT	<anf>	_	7	punct	_	_
 7	hjelmen	hjelm	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	obj	_	_
 8	»	$"	PUNCT	<anf>	_	7	punct	_	_
-9	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	SpaceAfter=No
+9	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	SpaceAfter=No
 10	?	$?	PUNCT	clb	_	2	punct	_	_
 11	spør	spørre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 12	Espen	Espen	PROPN	subst	Gender=Masc	11	nsubj	_	SpaceAfter=No
@@ -18714,7 +18714,7 @@
 3	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	_	_
 4	støpe	støpe	VERB	verb	VerbForm=Inf	0	root	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	skalledel	skalledel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 8	til	til	ADP	prep	_	9	case	_	_
 9	deg	du	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=2|PronType=Prs	4	obl	_	SpaceAfter=No
@@ -18729,7 +18729,7 @@
 5	hvorfor	hvorfor	ADV	adv	_	7	advmod	_	_
 6	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	_	_
 7	fikk	få	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	ccomp	_	_
-8	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	karakter	karakter	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	_
 10	i	i	ADP	prep	_	11	case	_	_
 11	sløyd	sløyd	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nmod	_	SpaceAfter=No
@@ -18859,7 +18859,7 @@
 1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	expl	_	_
 2	gjelder	gjelde	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	avtalen	avtale	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	obj	_	_
-4	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	_
+4	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	_
 5	om	om	ADP	prep	_	7	case	_	_
 6	å	å	PART	inf-merke	_	7	mark	_	_
 7	treffes	treffes	VERB	verb	VerbForm=Inf	3	acl	_	_
@@ -18989,11 +18989,11 @@
 1	Espen	Espen	PROPN	subst	Gender=Masc	4	nsubj	_	_
 2	kunne	kunne	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	_	_
 3	være	være	AUX	verb	VerbForm=Inf	4	cop	_	_
-4	vilter	vilter	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+4	vilter	vilter	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	8	punct	_	_
 6	men	men	CCONJ	konj	_	8	cc	_	_
 7	også	også	ADV	adv	_	8	advmod	_	_
-8	omsorgsfull	omsorgsfull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	conj	_	SpaceAfter=No
+8	omsorgsfull	omsorgsfull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	conj	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 016816
@@ -19089,7 +19089,7 @@
 5	kjenner	kjenne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	acl:relcl	_	_
 6	Espen	Espen	PROPN	subst	Gender=Masc	5	obj	_	_
 7	og	og	CCONJ	konj	_	9	cc	_	_
-8	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	9	det	_	_
+8	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 9	historie	historie	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	conj	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	3	punct	_	_
 11	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	_	_
@@ -19163,7 +19163,7 @@
 7	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 8	lære	lære	VERB	verb	VerbForm=Inf	3	xcomp	_	_
 9	av	av	ADP	prep	_	11	case	_	_
-10	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	historie	historie	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 12	?	$?	PUNCT	clb	_	3	punct	_	_
 
@@ -19175,9 +19175,9 @@
 4	,	$,	PUNCT	<komma>	_	7	punct	_	_
 5	og	og	CCONJ	konj	_	7	cc	_	_
 6	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
-7	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	conj	_	_
+7	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	conj	_	_
 8	og	og	CCONJ	konj	_	9	cc	_	_
-9	tydelig	tydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	conj	_	SpaceAfter=No
+9	tydelig	tydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	conj	_	SpaceAfter=No
 10	:	$:	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 016829
@@ -19215,7 +19215,7 @@
 8	Tore	Tore	PROPN	subst	Gender=Masc	6	nmod	_	_
 9	Dale	Dale	PROPN	subst	_	8	flat:name	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	13	punct	_	_
-11	Espen	Espen	PROPN	subst	Gender=Masc	13	nmod	_	_
+11	Espen	Espen	PROPN	subst	Gender=Masc	13	nmod:poss	_	_
 12	Dales	Dale	PROPN	subst	Case=Gen	11	flat:name	_	_
 13	far	far	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	appos	_	_
 14	og	og	CCONJ	konj	_	15	cc	_	_
@@ -19232,7 +19232,7 @@
 25	Mulelid	Mulelid	PROPN	subst	_	24	flat:name	_	_
 26	Rondestveit	Rondestveit	PROPN	subst	_	24	flat:name	_	SpaceAfter=No
 27	,	$,	PUNCT	<komma>	_	30	punct	_	_
-28	Espen	Espen	PROPN	subst	Gender=Masc	30	nmod	_	_
+28	Espen	Espen	PROPN	subst	Gender=Masc	30	nmod:poss	_	_
 29	Dales	Dale	PROPN	subst	Case=Gen	28	flat:name	_	_
 30	sykehusdagbok	sykehusdagbok	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	1	conj	_	_
 31	og	og	CCONJ	konj	_	33	cc	_	_
@@ -19285,11 +19285,11 @@
 8	i	i	ADP	prep	_	9	case	_	_
 9	Bergen	Bergen	PROPN	subst	_	2	nmod	_	_
 10	tingrett	tingrett	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	flat:name	_	_
-11	usikket	uskikket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+11	usikket	uskikket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 12	til	til	ADP	prep	_	13	case	_	_
 13	jobben	jobb	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	obl	_	_
 14	og	og	CCONJ	konj	_	15	cc	_	_
-15	kvinnefiendtlig	kvinnefiendtlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	conj	_	SpaceAfter=No
+15	kvinnefiendtlig	kvinnefiendtlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	conj	_	SpaceAfter=No
 16	?	$?	PUNCT	clb	_	11	punct	_	_
 
 # sent_id = 016836
@@ -19349,7 +19349,7 @@
 2	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	endre	endre	VERB	verb	VerbForm=Inf	0	root	_	_
 4	livet	liv	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	obj	_	_
-5	ditt	din	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	SpaceAfter=No
+5	ditt	din	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 016840
@@ -19377,7 +19377,7 @@
 21	deg	du	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=2|PronType=Prs	20	obj	_	_
 22	ut	ut	ADP	prep	_	25	case	_	_
 23	i	i	ADP	prep	_	25	case	_	_
-24	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	ruin	ruin	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	20	obl	_	SpaceAfter=No
 26	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -19425,7 +19425,7 @@
 3	om	om	SCONJ	sbu	_	6	mark	_	_
 4	dommeren	dommer	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
-6	uskikket	uskikket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	advcl	_	_
+6	uskikket	uskikket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	advcl	_	_
 7	til	til	ADP	prep	_	8	case	_	_
 8	jobben	jobb	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
 9	?	$?	PUNCT	clb	_	2	punct	_	_
@@ -19438,7 +19438,7 @@
 4	som	som	SCONJ	sbu	_	6	mark	_	_
 5	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 6	avgjøre	avgjøre	VERB	verb	VerbForm=Inf	3	acl:relcl	_	_
-7	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+7	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	fremtid	fremtid	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	3	punct	_	_
 10	ikke	ikke	PART	adv	Polarity=Neg	13	advmod	_	_
@@ -19458,7 +19458,7 @@
 5	ham	han	PRON	pron	Animacy=Hum|Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nmod	_	_
 6	og	og	CCONJ	konj	_	7	cc	_	_
 7	sjefen	sjef	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	conj	_	_
-8	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+8	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	_	_
 10	så	så	ADV	adv	_	11	advmod	_	_
 11	betent	betent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	1	amod	_	_
@@ -19476,7 +19476,7 @@
 1	Tanken	tanke	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	åpenbart	åpenbar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	4	advmod	_	_
-4	usannsynlig	usannsynlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+4	usannsynlig	usannsynlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 5	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 016847
@@ -19503,13 +19503,13 @@
 8	telefon	telefon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
 9	fra	fra	ADP	prep	_	12	case	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-11	bekymret	bekymre	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	12	amod	_	_
+11	bekymret	bekymre	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	12	amod	_	_
 12	kvinne	kvinne	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	6	punct	_	_
 
 # sent_id = 016850
 # text = Hennes fraseparerte ektemann, som har hentet barnet deres noen dager tidligere, er ikke å få tak i.
-1	Hennes	hennes	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	_
+1	Hennes	hennes	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	_
 2	fraseparerte	fraseparert	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	3	amod	_	_
 3	ektemann	ektemann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	nsubj	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	7	punct	_	_
@@ -19517,7 +19517,7 @@
 6	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 7	hentet	hente	VERB	verb	VerbForm=Part	3	acl:relcl	_	_
 8	barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	obj	_	_
-9	deres	deres	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+9	deres	deres	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 10	noen	noen	DET	det	Number=Plur|PronType=Ind	11	det	_	_
 11	dager	dag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	12	obl	_	_
 12	tidligere	tidlig	ADJ	adj	Degree=Cmp	7	advmod	_	SpaceAfter=No
@@ -19581,7 +19581,7 @@
 11	nødssituasjon	nødssituasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	2	punct	_	_
 13	fastslår	fastslå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-14	daværende	daværende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	daværende	daværende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	politimester	politimester	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nsubj	_	_
 16	Rolf	Rolf	PROPN	subst	Gender=Masc	15	flat:name	_	_
 17	B.	B.	PROPN	subst	Abbr=Yes	15	flat:name	_	_
@@ -19589,7 +19589,7 @@
 19	senere	sen	ADJ	adj	Degree=Cmp	13	advmod	_	_
 20	i	i	ADP	prep	_	23	case	_	_
 21	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
-22	skriftlig	skriftlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	amod	_	_
+22	skriftlig	skriftlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	amod	_	_
 23	redegjørelse	redegjørelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	obl	_	SpaceAfter=No
 24	.	$.	PUNCT	clb	_	13	punct	_	_
 
@@ -19621,7 +19621,7 @@
 9	hatt	ha	VERB	verb	VerbForm=Part	6	acl:relcl	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
 11	så	så	ADV	adv	_	12	advmod	_	_
-12	vanskelig	vanskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	vanskelig	vanskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	arbeidssituasjon	arbeidssituasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obj	_	_
 14	i	i	ADP	prep	_	16	case	_	_
 15	16	16	NUM	det	Number=Plur|NumType=Card	16	nummod	_	_
@@ -19637,7 +19637,7 @@
 25	som	som	SCONJ	sbu	_	28	mark	_	_
 26	burde	burde	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	28	aux	_	_
 27	vært	være	AUX	verb	VerbForm=Part	28	cop	_	_
-28	ugjort	ugjort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	24	amod	_	SpaceAfter=No
+28	ugjort	ugjort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	24	amod	_	SpaceAfter=No
 29	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 016856
@@ -19645,7 +19645,7 @@
 1	Vaktsjefen	vaktsjef	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 2	skriver	skrive	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	i	i	ADP	prep	_	5	case	_	_
-4	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+4	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	rapport	rapport	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	_
 6	at	at	SCONJ	sbu	_	8	mark	_	_
 7	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
@@ -19653,7 +19653,7 @@
 9	situasjonen	situasjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	obj	_	_
 10	som	som	ADP	prep	_	12	case	_	_
 11	«	$"	PUNCT	<anf>	_	12	punct	_	SpaceAfter=No
-12	uklar	uklar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	xcomp	_	_
+12	uklar	uklar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	xcomp	_	_
 13	med	med	ADP	prep	_	14	case	_	_
 14	henblikk	henblikk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	12	obl	_	_
 15	på	på	ADP	prep	_	17	case	_	_
@@ -19709,7 +19709,7 @@
 9	begitt	begi	VERB	verb	VerbForm=Part	3	xcomp	_	_
 10	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	9	obj	_	_
 11	til	til	ADP	prep	_	13	case	_	_
-12	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	13	det	_	_
+12	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 13	arbeidssted	arbeidssted	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	obl	_	_
 14	i	i	ADP	prep	_	15	case	_	_
 15	Bergen	Bergen	PROPN	subst	_	13	nmod	_	_
@@ -19751,7 +19751,7 @@
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
 12	16	16	NUM	det	Number=Plur|NumType=Card	13	nummod	_	_
 13	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	14	obl	_	_
-14	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	konflikt	konflikt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nmod	_	_
 16	som	som	SCONJ	sbu	_	18	mark	_	_
 17	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	aux	_	_
@@ -19763,11 +19763,11 @@
 
 # sent_id = 016863
 # text = Uskikket, eller bare misforstått?
-1	Uskikket	uskikket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+1	Uskikket	uskikket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 2	,	$,	PUNCT	<komma>	_	5	punct	_	_
 3	eller	eller	CCONJ	konj	_	5	cc	_	_
 4	bare	bare	ADV	adv	_	5	advmod	_	_
-5	misforstått	misforstå	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	1	conj	_	SpaceAfter=No
+5	misforstått	misforstå	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	1	conj	_	SpaceAfter=No
 6	?	$?	PUNCT	clb	_	1	punct	_	_
 
 # sent_id = 016864
@@ -19804,7 +19804,7 @@
 
 # sent_id = 016866
 # text = Jeg blir tillagt en rekke egenskaper i lys av dette.
-1	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
+1	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj:pass	_	_
 2	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux:pass	_	_
 3	tillagt	tillegge	VERB	verb	VerbForm=Part	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
@@ -19859,7 +19859,7 @@
 7	på	på	ADP	prep	_	8	case	_	_
 8	Møhlenpris	Møhlenpris	PROPN	subst	_	6	nmod	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	_	_
-10	fyldig	fyldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+10	fyldig	fyldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	10	punct	_	_
 
 # sent_id = 016869
@@ -19872,7 +19872,7 @@
 6	nå	nå	ADV	adv	_	7	advmod	_	_
 7	avgjøres	avgjøre	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 8	om	om	SCONJ	sbu	_	11	mark	_	_
-9	Bertelsen	Bertelsen	PROPN	subst	_	11	nsubj	_	_
+9	Bertelsen	Bertelsen	PROPN	subst	_	11	nsubj:pass	_	_
 10	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	_	_
 11	fratas	frata	VERB	verb	VerbForm=Inf|Voice=Pass	7	xcomp	_	_
 12	dommerkappen	dommerkappe	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	obj	_	_
@@ -19928,7 +19928,7 @@
 4	nå	nå	ADV	adv	_	6	advmod	_	_
 5	ikke	ikke	PART	adv	Polarity=Neg	6	advmod	_	_
 6	gitt	gi	VERB	verb	VerbForm=Part	0	root	_	_
-7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	det	_	_
+7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 8	fulle	full	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	9	amod	_	_
 9	versjon	versjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
 10	av	av	ADP	prep	_	11	case	_	_
@@ -19963,14 +19963,14 @@
 # text = At sjefene hans i sin iver etter å bli kvitt ham, har brukt skitne triks og brutt personvernet.
 1	At	at	SCONJ	sbu	_	14	mark	_	_
 2	sjefene	sjef	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	14	nsubj	_	_
-3	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	2	det	_	_
+3	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 4	i	i	ADP	prep	_	6	case	_	_
-5	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+5	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 6	iver	iver	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	obl	_	_
 7	etter	etter	ADP	prep	_	9	case	_	_
 8	å	å	PART	inf-merke	_	9	mark	_	_
 9	bli	bli	VERB	verb	VerbForm=Inf	6	acl	_	_
-10	kvitt	kvitt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	xcomp	_	_
+10	kvitt	kvitt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	xcomp	_	_
 11	ham	han	PRON	pron	Animacy=Hum|Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	obj	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	6	punct	_	_
 13	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	_	_
@@ -20051,7 +20051,7 @@
 9	første	første	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing|NumType=Ord	10	amod	_	_
 10	dommeren	dommer	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	xcomp	_	_
 11	i	i	ADP	prep	_	13	case	_	_
-12	moderne	moderne	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	moderne	moderne	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	nmod	_	_
 14	som	som	SCONJ	sbu	_	16	mark	_	_
 15	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	aux:pass	_	_
@@ -20077,7 +20077,7 @@
 
 # sent_id = 016881
 # text = Bertelsen ble også i 2010 forsøkt fjernet av Bergen tingrett og Domstolsadministrasjonen (DA) i Trondheim - det administrative hovedsetet for domstolene i Norge - men da beholdt han jobben.
-1	Bertelsen	Bertelsen	PROPN	subst	_	6	nsubj	_	_
+1	Bertelsen	Bertelsen	PROPN	subst	_	6	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 3	også	også	ADV	adv	_	5	advmod	_	_
 4	i	i	ADP	prep	_	5	case	_	_
@@ -20117,7 +20117,7 @@
 3	i	i	ADP	prep	_	4	case	_	_
 4	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	2	nmod	_	_
 5	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
-6	Bertelsen	Bertelsen	PROPN	subst	_	7	nsubj	_	_
+6	Bertelsen	Bertelsen	PROPN	subst	_	7	nsubj:pass	_	_
 7	ilagt	ilegge	VERB	verb	VerbForm=Part	0	root	_	_
 8	advarsel	advarsel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	_
 9	fra	fra	ADP	prep	_	10	case	_	_
@@ -20131,18 +20131,18 @@
 17	tok	ta	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	conj	_	_
 18	saken	sak	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	17	nsubj	_	_
 19	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
-20	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	amod	_	_
+20	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	amod	_	_
 21	vending	vending	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	obj	_	SpaceAfter=No
 22	.	$.	PUNCT	clb	_	7	punct	_	_
 
 # sent_id = 016883
 # text = Dommeren ble suspendert fra stillingen sin, og utestengt fra Tinghuset i påvente av en eventuell rettssak.
-1	Dommeren	dommer	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
+1	Dommeren	dommer	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	suspendert	suspendere	VERB	verb	VerbForm=Part	0	root	_	_
 4	fra	fra	ADP	prep	_	5	case	_	_
 5	stillingen	stilling	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
-6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	SpaceAfter=No
+6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	9	punct	_	_
 8	og	og	CCONJ	konj	_	9	cc	_	_
 9	utestengt	utestenge	VERB	verb	VerbForm=Part	3	conj	_	_
@@ -20152,7 +20152,7 @@
 13	påvente	påvente	NOUN	subst	_	9	obl	_	_
 14	av	av	ADP	prep	_	17	case	_	_
 15	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-16	eventuell	eventuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	eventuell	eventuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	rettssak	rettssak	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nmod	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -20201,7 +20201,7 @@
 6	ved	ved	ADP	prep	_	8	case	_	_
 7	gjentatte	gjenta	ADJ	adj	Number=Plur|VerbForm=Part	8	amod	_	_
 8	anledninger	anledning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	5	obl	_	_
-9	avvikende	avvikende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	avvikende	avvikende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	virkelighetsoppfatning	virkelighetsoppfatning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	obj	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	13	punct	_	_
 12	sviktende	svikte	ADJ	adj	VerbForm=Part	13	amod	_	_
@@ -20230,7 +20230,7 @@
 11	å	å	PART	inf-merke	_	13	mark	_	_
 12	ikke	ikke	PART	adv	Polarity=Neg	13	advmod	_	_
 13	begrunne	begrunne	VERB	verb	VerbForm=Inf	2	advcl	_	_
-14	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	15	det	_	_
+14	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 15	avgjørelser	avgjørelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	13	obj	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	17	punct	_	_
 17	noen	noen	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Ind,Prs	2	dislocated	_	_
@@ -20251,7 +20251,7 @@
 5	å	å	PART	inf-merke	_	6	mark	_	_
 6	tro	tro	VERB	verb	VerbForm=Inf	3	acl	_	_
 7	at	at	SCONJ	sbu	_	19	mark	_	_
-8	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	det	_	_
+8	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 9	fastlåste	fastlåst	ADJ	adj	Degree=Pos|Number=Plur	12	amod	_	SpaceAfter=No
 10	/	$/	SYM	symb	_	11	cc	_	SpaceAfter=No
 11	rigide	rigid	ADJ	adj	Degree=Pos|Number=Plur	9	conj	_	_
@@ -20263,7 +20263,7 @@
 17	kvinner	kvinne	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	12	nmod	_	SpaceAfter=No
 18	,	$,	PUNCT	<komma>	_	17	punct	_	_
 19	påvirker	påvirke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	ccomp	_	_
-20	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	21	det	_	_
+20	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	21	nmod:poss	_	_
 21	behandling	behandling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	19	obj	_	_
 22	av	av	ADP	prep	_	23	case	_	_
 23	enkeltpersoner	enkeltperson	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	21	nmod	_	_
@@ -20271,7 +20271,7 @@
 25	retten	rett	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	23	nmod	_	SpaceAfter=No
 26	,	$,	PUNCT	<komma>	_	29	punct	_	_
 27	samt	samt	CCONJ	konj	_	29	cc	_	_
-28	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	29	det	_	_
+28	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	29	nmod:poss	_	_
 29	vurderingsevne	vurderingsevne	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	21	conj	_	_
 30	i	i	ADP	prep	_	31	case	_	_
 31	avgjørelser	avgjørelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	29	nmod	_	SpaceAfter=No
@@ -20292,7 +20292,7 @@
 11	til	til	ADP	prep	_	12	case	_	_
 12	partene	part	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	10	nmod	_	_
 13	under	under	ADP	prep	_	15	case	_	_
-14	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	15	det	_	_
+14	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 15	administrering	administrering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	obl	_	_
 16	av	av	ADP	prep	_	17	case	_	_
 17	sakene	sak	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	15	nmod	_	SpaceAfter=No
@@ -20326,7 +20326,7 @@
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
 5	mann	mann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nsubj	_	_
 6	med	med	ADP	prep	_	8	case	_	_
-7	avvikende	avvikende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	avvikende	avvikende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	virkelighetsoppfatning	virkelighetsoppfatning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	nmod	_	_
 9	og	og	CCONJ	konj	_	10	cc	_	_
 10	dømt	dømme	VERB	verb	VerbForm=Part	3	conj	_	_
@@ -20404,7 +20404,7 @@
 # sent_id = 016897
 # text = En uheldig kombinasjon, mente mange.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	uheldig	uheldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	uheldig	uheldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	kombinasjon	kombinasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	ccomp	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	3	punct	_	_
 5	mente	mene	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
@@ -20430,7 +20430,7 @@
 2	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 3	preget	prege	VERB	verb	VerbForm=Part	0	root	_	_
 4	av	av	ADP	prep	_	7	case	_	_
-5	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	7	det	_	_
+5	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 6	private	privat	ADJ	adj	Degree=Pos|Number=Plur	7	amod	_	_
 7	erfaringer	erfaring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	3	obl	_	SpaceAfter=No
 8	?	$?	PUNCT	clb	_	3	punct	_	_
@@ -20512,7 +20512,7 @@
 20	,	$,	PUNCT	<komma>	_	28	punct	_	_
 21	som	som	SCONJ	sbu	_	28	mark	_	_
 22	etter	etter	ADP	prep	_	24	case	_	_
-23	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	24	det	_	_
+23	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	24	nmod:poss	_	_
 24	mening	mening	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	28	obl	_	_
 25	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	28	cop	_	_
 26	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	28	det	_	_
@@ -20631,7 +20631,7 @@
 # sent_id = 016910
 # text = - Datteren ble tatt fra ham etter et akuttvedtak på grunn av anklager om incest, men han ble aldri siktet for noe straffbart.
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
-2	Datteren	datter	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
+2	Datteren	datter	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj:pass	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	_	_
 4	tatt	ta	VERB	verb	VerbForm=Part	0	root	_	_
 5	fra	fra	ADP	prep	_	6	case	_	_
@@ -20647,7 +20647,7 @@
 15	incest	incest	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nmod	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	21	punct	_	_
 17	men	men	CCONJ	konj	_	21	cc	_	_
-18	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	21	nsubj	_	_
+18	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	21	nsubj:pass	_	_
 19	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	21	aux:pass	_	_
 20	aldri	aldri	ADV	adv	_	21	advmod	_	_
 21	siktet	sikte	VERB	verb	VerbForm=Part	4	conj	_	_
@@ -20688,7 +20688,7 @@
 2	fryktet	frykte	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	16	ccomp	_	_
 3	at	at	SCONJ	sbu	_	8	mark	_	_
 4	hele	hel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	5	amod	_	_
-5	familien	familie	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
+5	familien	familie	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj:pass	_	_
 6	ville	ville	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	aux	_	_
 7	bli	bli	AUX	verb	VerbForm=Inf	8	aux:pass	_	_
 8	ødelagt	ødelegge	VERB	verb	VerbForm=Part	2	xcomp	_	_
@@ -20712,7 +20712,7 @@
 1	Slik	slik	ADV	adv	_	4	advmod	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	hendelsen	hendelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
-4	beskrevet	beskrive	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	_
+4	beskrevet	beskrive	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	_
 5	i	i	ADP	prep	_	6	case	_	_
 6	sakspapirene	sakspapir	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	4	obl	_	SpaceAfter=No
 7	:	$:	PUNCT	clb	_	4	punct	_	_
@@ -20737,7 +20737,7 @@
 16	bydelen	bydel	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
 17	der	der	SCONJ	sbu	_	21	mark	_	_
 18	vennens	venn	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	19	nmod	_	_
-19	sak	sak	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	21	nsubj	_	_
+19	sak	sak	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	21	nsubj:pass	_	_
 20	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	21	aux:pass	_	_
 21	behandlet	behandle	VERB	verb	VerbForm=Part	16	acl:relcl	_	SpaceAfter=No
 22	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -20786,7 +20786,7 @@
 2	fikk	få	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	fortalt	fortelle	ADJ	adj	Definite=Ind|Gender=Neut|Number=Sing|VerbForm=Part	2	xcomp	_	_
 4	at	at	SCONJ	sbu	_	11	mark	_	_
-5	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+5	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 6	klient	klient	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nsubj	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	8	punct	_	_
 8	barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	appos	_	SpaceAfter=No
@@ -20805,7 +20805,7 @@
 3	at	at	SCONJ	sbu	_	5	mark	_	_
 4	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
 5	brukte	bruke	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	ccomp	_	_
-6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 7	posisjon	posisjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obj	_	_
 8	som	som	ADP	prep	_	9	case	_	_
 9	dommer	dommer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nmod	_	_
@@ -20836,7 +20836,7 @@
 6	,	$,	PUNCT	<komma>	_	9	punct	_	_
 7	men	men	CCONJ	konj	_	9	cc	_	_
 8	fortsatt	fortsatt	ADV	adv	_	9	advmod	_	_
-9	kritisk	kritisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	_
+9	kritisk	kritisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	_
 10	til	til	ADP	prep	_	11	case	_	_
 11	Bertelsen	Bertelsen	PROPN	subst	_	9	obl	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	5	punct	_	_
@@ -20846,14 +20846,14 @@
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
 2	Saken	sak	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 3	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	cop	_	_
-4	spesiell	spesiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+4	spesiell	spesiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	12	punct	_	_
 6	og	og	CCONJ	konj	_	12	cc	_	_
 7	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	_	_
 8	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	12	cop	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
 10	ganske	ganske	ADV	adv	_	11	advmod	_	_
-11	ung	ung	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	ung	ung	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	advokat	advokat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	conj	_	_
 13	på	på	ADP	prep	_	15	case	_	_
 14	denne	denne	DET	det	Gender=Masc|Number=Sing|PronType=Dem	15	det	_	_
@@ -20868,7 +20868,7 @@
 4	fra	fra	ADP	prep	_	5	case	_	_
 5	Bertelsen	Bertelsen	PROPN	subst	_	3	nmod	_	_
 6	som	som	ADP	prep	_	7	case	_	_
-7	utidig	utidig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	xcomp	_	SpaceAfter=No
+7	utidig	utidig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	xcomp	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 016923
@@ -21007,7 +21007,7 @@
 2	mente	mene	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	saksbehandlingen	saksbehandling	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
 4	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	_	_
-5	uforsvarlig	uforsvarlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	ccomp	_	SpaceAfter=No
+5	uforsvarlig	uforsvarlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	ccomp	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	15	punct	_	_
 7	og	og	CCONJ	konj	_	15	cc	_	_
 8	at	at	SCONJ	sbu	_	15	mark	_	_
@@ -21020,7 +21020,7 @@
 15	be	be	VERB	verb	VerbForm=Inf	5	conj	_	_
 16	om	om	ADP	prep	_	20	case	_	_
 17	at	at	SCONJ	sbu	_	20	mark	_	_
-18	opplysningene	opplysning	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	20	nsubj	_	_
+18	opplysningene	opplysning	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	20	nsubj:pass	_	_
 19	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	20	aux:pass	_	_
 20	sjekket	sjekke	VERB	verb	VerbForm=Part	15	advcl	_	_
 21	grundig	grundig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	20	advmod	_	SpaceAfter=No
@@ -21033,7 +21033,7 @@
 3	tolket	tolke	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	obj	_	_
 5	som	som	ADP	prep	_	7	case	_	_
-6	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+6	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 7	plikt	plikt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	xcomp	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -21097,7 +21097,7 @@
 7	Bertelsen	Bertelsen	PROPN	subst	_	5	nmod	_	_
 8	lenge	lenge	ADJ	adj	Degree=Pos	10	advmod	_	_
 9	vært	være	AUX	verb	VerbForm=Part	10	cop	_	_
-10	fraværende	fraværende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+10	fraværende	fraværende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	10	punct	_	_
 
 # sent_id = 016935
@@ -21107,7 +21107,7 @@
 3	krevde	kreve	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	kommunen	kommune	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 5	at	at	SCONJ	sbu	_	11	mark	_	_
-6	tingrettsdommeren	tingrettsdommer	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	nsubj	_	_
+6	tingrettsdommeren	tingrettsdommer	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	nsubj:pass	_	_
 7	for	for	ADP	prep	_	9	case	_	_
 8	all	all	DET	det	Gender=Fem|Number=Sing|PronType=Tot	9	det	_	_
 9	fremtid	fremtid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	obl	_	_
@@ -21119,7 +21119,7 @@
 15	hvor	hvor	ADV	adv	_	18	advmod	_	_
 16	kommunen	kommune	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	18	nsubj	_	_
 17	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	cop	_	_
-18	involvert	involvere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	14	amod	_	SpaceAfter=No
+18	involvert	involvere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	14	amod	_	SpaceAfter=No
 19	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 016936
@@ -21145,7 +21145,7 @@
 19	Bertelsen	Bertelsen	PROPN	subst	_	21	nsubj	_	_
 20	ikke	ikke	PART	adv	Polarity=Neg	21	advmod	_	_
 21	hadde	ha	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	16	ccomp	_	_
-22	nødvendig	nødvendig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	amod	_	_
+22	nødvendig	nødvendig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	amod	_	_
 23	tillit	tillit	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	21	obj	_	SpaceAfter=No
 24	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -21159,7 +21159,7 @@
 # sent_id = 016938
 # text = En traumatisk opplevelse.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	traumatisk	traumatisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	traumatisk	traumatisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	opplevelse	opplevelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 4	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -21175,7 +21175,7 @@
 8	at	at	SCONJ	sbu	_	11	mark	_	_
 9	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
 10	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	_	_
-11	stilt	stille	VERB	verb	VerbForm=Part	5	csubj	_	_
+11	stilt	stille	VERB	verb	VerbForm=Part	5	csubj:pass	_	_
 12	opp	opp	ADV	prep	_	11	advmod	_	_
 13	for	for	ADP	prep	_	14	case	_	_
 14	bekjente	bekjent	ADJ	adj	Degree=Pos|Number=Plur	11	advmod	_	SpaceAfter=No
@@ -21214,7 +21214,7 @@
 18	bodde	bo	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	14	acl:relcl	_	_
 19	sammen	sammen	ADV	adv	_	22	advmod	_	_
 20	med	med	ADP	prep	_	22	case	_	_
-21	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	22	det	_	_
+21	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	22	nmod:poss	_	_
 22	barn	barn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	18	obl	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -21251,7 +21251,7 @@
 10	å	å	PART	inf-merke	_	14	mark	_	_
 11	være	være	AUX	verb	VerbForm=Inf	14	cop	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-13	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	mor	mor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nmod	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	3	punct	_	SpaceAfter=No
 16	»	$"	PUNCT	<anf>	_	3	punct	_	_
@@ -21281,7 +21281,7 @@
 3	at	at	SCONJ	sbu	_	13	mark	_	_
 4	Bertelsen	Bertelsen	PROPN	subst	_	13	nsubj	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	8	punct	_	_
-6	hennes	hennes	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+6	hennes	hennes	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 7	daværende	daværende	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	8	amod	_	_
 8	ektemann	ektemann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	conj	_	_
 9	og	og	CCONJ	konj	_	12	cc	_	_
@@ -21293,7 +21293,7 @@
 15	inn	inn	ADP	prep	_	17	case	_	_
 16	i	i	ADP	prep	_	17	case	_	_
 17	huset	hus	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	13	obl	_	_
-18	hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	17	det	_	SpaceAfter=No
+18	hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	17	nmod:poss	_	SpaceAfter=No
 19	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 016946
@@ -21322,7 +21322,7 @@
 5	at	at	SCONJ	sbu	_	8	mark	_	_
 6	opplevelsen	opplevelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
 7	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	cop	_	_
-8	traumatisk	traumatisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	ccomp	_	SpaceAfter=No
+8	traumatisk	traumatisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	ccomp	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	13	punct	_	_
 10	og	og	CCONJ	konj	_	13	cc	_	_
 11	at	at	SCONJ	sbu	_	13	mark	_	_
@@ -21332,7 +21332,7 @@
 15	stedet	sted	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	13	obl	_	_
 16	med	med	ADP	prep	_	17	case	_	_
 17	barna	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	13	obl	_	_
-18	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	20	obl	_	_
 20	etterpå	etterpå	ADV	adv	_	13	advmod	_	SpaceAfter=No
 21	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -21390,7 +21390,7 @@
 2	kjente	kjenne	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	ikke	ikke	PART	adv	Polarity=Neg	2	advmod	_	_
 4	konen	kone	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	obj	_	_
-5	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	SpaceAfter=No
+5	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	8	punct	_	_
 7	og	og	CCONJ	konj	_	8	cc	_	_
 8	snakket	snakke	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	_	_
@@ -21426,10 +21426,10 @@
 4	at	at	SCONJ	sbu	_	12	mark	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
 6	dommers	dommer	NOUN	subst	Case=Gen|Definite=Ind|Gender=Masc|Number=Sing	7	nmod	_	_
-7	besøk	besøk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	12	nsubj	_	_
+7	besøk	besøk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	12	nsubj:pass	_	_
 8	hos	hos	ADP	prep	_	10	case	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-10	bekjent	bekjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+10	bekjent	bekjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 11	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	_	_
 12	brukes	bruke	VERB	verb	VerbForm=Inf|Voice=Pass	3	csubj	_	_
 13	som	som	ADP	prep	_	14	case	_	_
@@ -21458,11 +21458,11 @@
 2	blir	bli	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	at	at	SCONJ	sbu	_	8	mark	_	_
 4	hele	hel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	5	amod	_	_
-5	Bergen	Bergen	PROPN	subst	_	8	nsubj	_	_
+5	Bergen	Bergen	PROPN	subst	_	8	nsubj:pass	_	_
 6	byrett	byrett	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	flat:name	_	_
 7	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux:pass	_	_
 8	funnet	finne	VERB	verb	VerbForm=Part	2	xcomp	_	_
-9	inhabil	inhabil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	xcomp	_	_
+9	inhabil	inhabil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	xcomp	_	_
 10	til	til	ADP	prep	_	12	case	_	_
 11	å	å	PART	inf-merke	_	12	mark	_	_
 12	behandle	behandle	VERB	verb	VerbForm=Inf	9	advcl	_	_
@@ -21502,11 +21502,11 @@
 1	Du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	4	nsubj	_	_
 2	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	være	være	AUX	verb	VerbForm=Inf	4	cop	_	_
-4	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	og	og	CCONJ	konj	_	6	cc	_	_
 6	slå	slå	VERB	verb	VerbForm=Inf	4	conj	_	_
 7	kona	kone	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	6	obj	_	_
-8	di	din	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+8	di	din	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 9	og	og	CCONJ	konj	_	13	cc	_	_
 10	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
 11	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	cop	_	_
@@ -21523,11 +21523,11 @@
 5	"	$"	PUNCT	<anf>	_	8	punct	_	SpaceAfter=No
 6	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	_	_
 7	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
-8	homofil	homofil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	ccomp	_	SpaceAfter=No
+8	homofil	homofil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	ccomp	_	SpaceAfter=No
 9	"	$"	PUNCT	<anf>	_	8	punct	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	4	punct	_	_
 11	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux:pass	_	_
-12	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
+12	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj:pass	_	_
 13	sett	se	VERB	verb	VerbForm=Part	0	root	_	_
 14	på	på	ADV	prep	_	13	advmod	_	_
 15	som	som	ADP	prep	_	16	case	_	_
@@ -21592,7 +21592,7 @@
 16	tvilsomme	tvilsom	ADJ	adj	Degree=Pos|Number=Plur	17	amod	_	_
 17	rykter	rykte	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	14	conj	_	_
 18	og	og	CCONJ	konj	_	20	cc	_	_
-19	ondsinnet	ondsinnet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	amod	_	_
+19	ondsinnet	ondsinnet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	amod	_	_
 20	mediesladder	mediesladder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	conj	_	SpaceAfter=No
 21	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -21652,7 +21652,7 @@
 # sent_id = 016967
 # text = Familiene deres har også opplevd å bli hetset på gata.»
 1	Familiene	familie	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	5	nsubj	_	_
-2	deres	deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	1	det	_	_
+2	deres	deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	1	nmod:poss	_	_
 3	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 4	også	også	ADV	adv	_	5	advmod	_	_
 5	opplevd	oppleve	VERB	verb	VerbForm=Part	0	root	_	_
@@ -21679,7 +21679,7 @@
 11	fotballarenaer	fotballarena	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	15	obl	_	_
 12	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux:pass	_	_
 13	homofobiske	homofobisk	ADJ	adj	Degree=Pos|Number=Plur	14	amod	_	_
-14	sanger	sang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	15	nsubj	_	_
+14	sanger	sang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	15	nsubj:pass	_	_
 15	hørt	høre	VERB	verb	VerbForm=Part	2	conj	_	_
 16	ukentlig	ukentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	15	advmod	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -21833,7 +21833,7 @@
 12	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	_	_
 13	bare	bare	ADV	adv	_	15	advmod	_	_
 14	vært	være	AUX	verb	VerbForm=Part	15	cop	_	_
-15	sjenert	sjenert	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+15	sjenert	sjenert	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 16	med	med	ADP	prep	_	17	case	_	_
 17	jenter	jente	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	15	obl	_	SpaceAfter=No
 18	"	$"	PUNCT	<anf>	_	15	punct	_	_
@@ -21948,7 +21948,7 @@
 4	ofte	ofte	ADJ	adj	Degree=Pos	8	advmod	_	_
 5	hjemme	hjemme	ADP	prep	_	8	case	_	_
 6	hos	hos	ADP	prep	_	8	case	_	_
-7	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+7	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	mor	mor	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	10	punct	_	_
 10	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	8	dislocated	_	_
@@ -22033,7 +22033,7 @@
 6	se	se	VERB	verb	VerbForm=Inf	0	root	_	_
 7	noen	noen	DET	det	Number=Plur|PronType=Ind	6	obj	_	_
 8	av	av	ADP	prep	_	11	case	_	_
-9	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	det	_	_
+9	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 10	fortryllende	fortrylle	ADJ	adj	VerbForm=Part	11	amod	_	_
 11	scoringer	scoring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	7	nmod	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	13	punct	_	_
@@ -22075,7 +22075,7 @@
 21	der	der	SCONJ	sbu	_	23	mark	_	_
 22	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	23	nsubj	_	_
 23	endte	ende	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	20	acl:relcl	_	_
-24	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	25	det	_	_
+24	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	25	nmod:poss	_	_
 25	liv	liv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	23	obj	_	SpaceAfter=No
 26	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -22255,7 +22255,7 @@
 22	innførte	innføre	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	12	acl:relcl	_	_
 23	trommesett	trommesett	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	22	obj	_	_
 24	i	i	ADP	prep	_	26	case	_	_
-25	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	amod	_	_
+25	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	amod	_	_
 26	skala	skala	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	22	obl	_	_
 27	til	til	ADP	prep	_	28	case	_	_
 28	spilluniverset	spillunivers	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	22	obl	_	SpaceAfter=No
@@ -22292,7 +22292,7 @@
 27	markedet	marked	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	obl	_	_
 28	med	med	ADP	prep	_	32	case	_	_
 29	hver	hver	DET	det	Gender=Fem|Number=Sing|PronType=Tot	32	det	_	_
-30	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	32	det	_	_
+30	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	32	nmod:poss	_	_
 31	tilhørende	tilhøre	ADJ	adj	VerbForm=Part	32	amod	_	_
 32	trommesett	trommesett	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	27	obl	_	SpaceAfter=No
 33	,	$,	PUNCT	<komma>	_	34	punct	_	_
@@ -22308,7 +22308,7 @@
 3	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	1	acl:relcl	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 5	noenlunde	noenlunde	ADV	adv	_	6	advmod	_	_
-6	normal	normal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	normal	normal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	bosituasjon	bosituasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 8	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 9	imidlertid	imidlertid	ADV	adv	_	8	advmod	_	_
@@ -22336,7 +22336,7 @@
 31	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	33	nsubj	_	_
 32	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	33	aux	_	_
 33	hamre	hamre	VERB	verb	VerbForm=Inf	26	advcl	_	_
-34	løs	løs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	33	advmod	_	_
+34	løs	løs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	33	advmod	_	_
 35	på	på	ADP	prep	_	36	case	_	_
 36	spilltrommesett	spilltrommesett	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	33	obl	_	_
 37	i	i	ADP	prep	_	38	case	_	_
@@ -22350,7 +22350,7 @@
 3	tatt	ta	VERB	verb	VerbForm=Part	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 5	såpass	såpass	ADV	adv	_	6	advmod	_	_
-6	nærgående	nærgående	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	nærgående	nærgående	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	kikk	kikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 8	på	på	ADP	prep	_	11	case	_	_
 9	både	både	CCONJ	konj	_	11	cc	_	_
@@ -22380,7 +22380,7 @@
 33	og	og	CCONJ	konj	_	34	cc	_	_
 34	her	her	ADV	prep	_	3	conj	_	_
 35	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	34	cop	_	_
-36	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	37	det	_	_
+36	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	37	nmod:poss	_	_
 37	inntrykk	inntrykk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	34	nsubj	_	SpaceAfter=No
 38	:	$:	PUNCT	clb	_	3	punct	_	_
 
@@ -22391,9 +22391,9 @@
 3	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	2	advmod	_	_
 4	på	på	ADP	prep	_	5	case	_	_
 5	egoet	ego	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	obl	_	_
-6	løs	løs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	advmod	_	_
+6	løs	løs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	advmod	_	_
 7	da	da	SCONJ	sbu	_	13	mark	_	_
-8	enmannsbandet	enmannsband	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	13	nsubj	_	_
+8	enmannsbandet	enmannsband	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	13	nsubj:pass	_	_
 9	«	$"	PUNCT	<anf>	_	10	punct	_	SpaceAfter=No
 10	Gjærbägst	Gjærbägst	PROPN	subst	_	8	appos	_	SpaceAfter=No
 11	»	$"	PUNCT	<anf>	_	10	punct	_	_
@@ -22414,7 +22414,7 @@
 6	rundt	rundt	ADP	prep	_	5	case	_	_
 7	med	med	ADP	prep	_	10	case	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-9	slitt	slite	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	10	amod	_	_
+9	slitt	slite	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	10	amod	_	_
 10	plastgitar	plastgitar	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 11	i	i	ADP	prep	_	13	case	_	_
 12	«	$"	PUNCT	<anf>	_	13	punct	_	SpaceAfter=No
@@ -22511,7 +22511,7 @@
 15	med	med	ADP	prep	_	16	case	_	_
 16	plast	plast	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nmod	_	_
 17	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	20	aux:pass	_	_
-18	stua	stue	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	20	nsubj	_	_
+18	stua	stue	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	20	nsubj:pass	_	_
 19	raskt	rask	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	20	advmod	_	_
 20	forvandlet	forvandle	VERB	verb	VerbForm=Part	0	root	_	_
 21	til	til	ADP	prep	_	24	case	_	_
@@ -22519,11 +22519,11 @@
 23	improvisert	improvisere	ADJ	adj	Definite=Ind|Gender=Neut|Number=Sing|VerbForm=Part	24	amod	_	_
 24	øvingslokale	øvingslokale	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	20	obl	_	_
 25	med	med	ADP	prep	_	27	case	_	_
-26	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	27	amod	_	_
+26	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	27	amod	_	_
 27	jallafaktor	jallafaktor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	24	nmod	_	_
 28	og	og	CCONJ	konj	_	29	cc	_	_
 29	lyden	lyd	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	27	conj	_	_
-30	skrudd	skru	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	29	amod	_	_
+30	skrudd	skru	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	29	amod	_	_
 31	opp	opp	ADP	prep	_	33	case	_	_
 32	til	til	ADP	prep	_	33	case	_	_
 33	11	11	NUM	det	Number=Plur|NumType=Card	30	obl	_	SpaceAfter=No
@@ -22573,7 +22573,7 @@
 5	utstyrt	utstyre	ADJ	adj	Definite=Ind|Gender=Neut|Number=Sing|VerbForm=Part	0	root	_	_
 6	med	med	ADP	prep	_	9	case	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	trykksensitiv	trykksensitiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	trykksensitiv	trykksensitiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	plate	plate	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 10	nederst	nederst	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	12	advmod	_	_
 11	på	på	ADP	prep	_	12	case	_	_
@@ -22601,7 +22601,7 @@
 3	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	gitaren	gitar	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	kjekk	kjekk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	kjekk	kjekk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	knapp	knapp	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 8	for	for	ADP	prep	_	9	case	_	_
 9	star	star	X	ukjent	Foreign=Yes	7	nmod	_	_
@@ -22666,7 +22666,7 @@
 1	Trommesettet	trommesett	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	5	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 3	også	også	ADV	adv	_	5	advmod	_	_
-4	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	advmod	_	_
+4	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	advmod	_	_
 5	identisk	identisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	0	root	_	_
 6	med	med	ADP	prep	_	8	case	_	_
 7	fire	fire	NUM	det	Number=Plur|NumType=Card	8	nummod	_	_
@@ -22689,11 +22689,11 @@
 3	ikke	ikke	PART	adv	Polarity=Neg	7	advmod	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 5	like	like	ADV	adv	_	6	advmod	_	_
-6	høylytt	høylytt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	høylytt	høylytt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	opplevelse	opplevelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 8	å	å	PART	inf-merke	_	9	mark	_	_
 9	hamre	hamre	VERB	verb	VerbForm=Inf	7	csubj	_	_
-10	løs	løs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	advmod	_	_
+10	løs	løs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	advmod	_	_
 11	på	på	ADP	prep	_	12	case	_	_
 12	trommene	tromme	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	9	obl	_	_
 13	siden	siden	SCONJ	sbu	_	15	mark	_	_
@@ -22709,7 +22709,7 @@
 23	basspedalen	basspedal	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	26	nsubj	_	_
 24	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	26	cop	_	_
 25	mer	mye	ADJ	adj	Degree=Cmp	26	advmod	_	_
-26	solid	solid	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	conj	_	SpaceAfter=No
+26	solid	solid	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	conj	_	SpaceAfter=No
 27	.	$.	PUNCT	clb	_	7	punct	_	_
 
 # sent_id = 017021
@@ -22724,7 +22724,7 @@
 8	som	som	SCONJ	sbu	_	12	mark	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-11	sann	sann	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	sann	sann	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	lettelse	lettelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	7	punct	_	_
 
@@ -22791,11 +22791,11 @@
 17	uten	uten	ADP	prep	_	19	case	_	_
 18	å	å	PART	inf-merke	_	19	mark	_	_
 19	denge	denge	VERB	verb	VerbForm=Inf	15	advcl	_	_
-20	løs	løs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	advmod	_	_
+20	løs	løs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	advmod	_	_
 21	til	til	SCONJ	sbu	_	23	mark	_	_
 22	man	man	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|PronType=Prs	23	nsubj	_	_
 23	blir	bli	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	advcl	_	_
-24	nummen	nummen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	xcomp	_	_
+24	nummen	nummen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	xcomp	_	_
 25	i	i	ADP	prep	_	26	case	_	_
 26	henda	hånd	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	24	obl	_	SpaceAfter=No
 27	.	$.	PUNCT	clb	_	13	punct	_	_
@@ -22857,7 +22857,7 @@
 3	ha	ha	AUX	verb	VerbForm=Inf	4	aux	_	_
 4	utsatt	utsette	VERB	verb	VerbForm=Part	15	advcl	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	betydelig	betydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	betydelig	betydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 8	av	av	ADP	prep	_	9	case	_	_
 9	vennekretsen	vennekrets	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	_
@@ -22899,7 +22899,7 @@
 11	i	i	ADP	prep	_	12	case	_	_
 12	skyggen	skygge	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	obl	_	_
 13	av	av	ADP	prep	_	15	case	_	_
-14	knalltøff	knalltøff	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	knalltøff	knalltøff	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	tromming	tromming	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	12	nmod	_	_
 16	og	og	CCONJ	konj	_	17	cc	_	_
 17	frontfigurhåndtering	frontfigurhåndtering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	15	conj	_	_
@@ -22914,7 +22914,7 @@
 26	og	og	CCONJ	konj	_	27	cc	_	_
 27	solo-karrierer	solo-karriere	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	25	conj	_	_
 28	i	i	ADP	prep	_	30	case	_	_
-29	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	30	amod	_	_
+29	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	30	amod	_	_
 30	fremtid	fremtid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	27	nmod	_	SpaceAfter=No
 31	.	$.	PUNCT	clb	_	21	punct	_	_
 
@@ -23104,7 +23104,7 @@
 39	samsvar	samsvar	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	35	nsubj	_	_
 40	mellom	mellom	ADP	prep	_	41	case	_	_
 41	musikkpreferansene	musikkpreferanse	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	39	nmod	_	_
-42	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	41	det	_	SpaceAfter=No
+42	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	41	nmod:poss	_	SpaceAfter=No
 43	,	$,	PUNCT	<komma>	_	45	punct	_	_
 44	Snorre	Snorre	PROPN	subst	Gender=Masc	45	compound	_	_
 45	anm.	anm.	NOUN	subst	Abbr=Yes|Gender=Fem	7	parataxis	_	SpaceAfter=No
@@ -23144,7 +23144,7 @@
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 4	eller	eller	CCONJ	konj	_	5	cc	_	_
 5	annen	annen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Dem	3	conj	_	_
-6	obskur	obskur	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	obskur	obskur	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	klassiker	klassiker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nsubj	_	_
 8	snike	snike	VERB	verb	VerbForm=Inf	0	root	_	_
 9	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	8	obj	_	_
@@ -23210,7 +23210,7 @@
 2	Nelson	Nelson	PROPN	subst	_	1	flat:name	_	_
 3	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 4	være	være	AUX	verb	VerbForm=Inf	5	cop	_	_
-5	grei	grei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+5	grei	grei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 6	å	å	PART	inf-merke	_	7	mark	_	_
 7	høre	høre	VERB	verb	VerbForm=Inf	5	advcl	_	_
 8	på	på	ADV	prep	_	7	advmod	_	SpaceAfter=No
@@ -23223,7 +23223,7 @@
 15	å	å	PART	inf-merke	_	16	mark	_	_
 16	spille	spille	VERB	verb	VerbForm=Inf	14	csubj	_	_
 17	låta	låt	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	16	obj	_	_
-18	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	17	det	_	SpaceAfter=No
+18	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	17	nmod:poss	_	SpaceAfter=No
 19	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 017042
@@ -23300,9 +23300,9 @@
 13	voksent	voksen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	14	amod	_	_
 14	publikum	publikum	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	obl	_	_
 15	med	med	ADP	prep	_	19	case	_	_
-16	sunn	sunn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+16	sunn	sunn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 17	og	og	CCONJ	konj	_	18	cc	_	_
-18	variert	variere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	16	conj	_	_
+18	variert	variere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	16	conj	_	_
 19	musikksmak	musikksmak	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 20	,	$,	PUNCT	<komma>	_	23	punct	_	_
 21	med	med	ADP	prep	_	23	case	_	_
@@ -23412,7 +23412,7 @@
 7	velge	velge	VERB	verb	VerbForm=Inf	3	xcomp	_	_
 8	vanskelighetsgrad	vanskelighetsgrad	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	_
 9	på	på	ADP	prep	_	11	case	_	_
-10	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	instrument	instrument	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	8	nmod	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	19	punct	_	_
 13	men	men	CCONJ	konj	_	19	cc	_	_
@@ -23427,7 +23427,7 @@
 22	»	$"	PUNCT	<anf>	_	19	punct	_	_
 23	at	at	SCONJ	sbu	_	31	mark	_	_
 24	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
-25	spiller	spiller	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	31	nsubj	_	_
+25	spiller	spiller	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	31	nsubj:pass	_	_
 26	som	som	SCONJ	sbu	_	27	mark	_	_
 27	faller	falle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	25	acl:relcl	_	_
 28	ut	ut	ADV	prep	_	27	advmod	_	_
@@ -23450,7 +23450,7 @@
 45	uten	uten	ADP	prep	_	50	case	_	_
 46	at	at	SCONJ	sbu	_	50	mark	_	_
 47	én	én	NUM	det	Gender=Masc|Number=Sing|NumType=Card	48	nummod	_	_
-48	person	person	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	50	nsubj	_	_
+48	person	person	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	50	nsubj:pass	_	_
 49	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	50	aux:pass	_	_
 50	gjort	gjøre	VERB	verb	VerbForm=Part	42	advcl	_	_
 51	til	til	ADP	prep	_	52	case	_	_
@@ -23494,13 +23494,13 @@
 8	»	$"	PUNCT	<anf>	_	7	punct	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
 10	overraskende	overraske	ADJ	adj	VerbForm=Part	11	advmod	_	_
-11	dyp	dyp	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	dyp	dyp	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	figurskaper	figurskaper	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obj	_	_
 13	der	der	SCONJ	sbu	_	16	mark	_	_
 14	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	16	nsubj	_	_
 15	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	aux	_	_
 16	lage	lage	VERB	verb	VerbForm=Inf	12	acl:relcl	_	_
-17	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	19	det	_	_
+17	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 18	egen	egen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Prs	19	det	_	_
 19	rockehelt	rockehelt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	obj	_	_
 20	med	med	ADP	prep	_	22	case	_	_
@@ -23510,7 +23510,7 @@
 24	gitarer	gitar	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	22	conj	_	_
 25	-	$-	PUNCT	<strek>	_	29	punct	_	_
 26	samt	samt	CCONJ	konj	_	29	cc	_	_
-27	ditt	din	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	29	det	_	_
+27	ditt	din	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	29	nmod:poss	_	_
 28	eget	egen	DET	det	Definite=Ind|Gender=Neut|Number=Sing|PronType=Prs	29	det	_	_
 29	opptaksstudio	opptaksstudio	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	19	conj	_	_
 30	med	med	ADP	prep	_	31	case	_	_
@@ -23536,7 +23536,7 @@
 9	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	11	nsubj	_	_
 10	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	_	_
 11	lage	lage	VERB	verb	VerbForm=Inf	7	xcomp	_	_
-12	dine	din	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	14	det	_	_
+12	dine	din	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	14	nmod:poss	_	_
 13	egne	egen	DET	det	Number=Plur|PronType=Prs	14	det	_	_
 14	låter	låt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	11	obj	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	5	punct	_	_
@@ -23587,7 +23587,7 @@
 1	Trommeentusiaster	trommeentusiast	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	6	nsubj	_	_
 2	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 3	på	på	ADP	prep	_	5	case	_	_
-4	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+4	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	side	side	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obl	_	_
 6	glede	glede	VERB	verb	VerbForm=Inf	0	root	_	_
 7	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	6	obj	_	_
@@ -23604,7 +23604,7 @@
 18	gir	gi	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	acl:relcl	_	_
 19	deg	du	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=2|PronType=Prs	18	iobj	_	_
 20	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-21	grei	grei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	amod	_	_
+21	grei	grei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	amod	_	_
 22	innføring	innføring	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	obj	_	_
 23	i	i	ADP	prep	_	25	case	_	_
 24	hvordan	hvordan	ADV	adv	_	25	advmod	_	_
@@ -23674,7 +23674,7 @@
 25	ha	ha	AUX	verb	VerbForm=Inf	26	aux	_	_
 26	blitt	bli	VERB	verb	VerbForm=Part	22	acl	_	_
 27	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	28	advmod	_	_
-28	tøysete	tøysete	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	xcomp	_	_
+28	tøysete	tøysete	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	xcomp	_	_
 29	-	$-	PUNCT	<strek>	_	31	punct	_	_
 30	låtutvalget	låtutvalg	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	31	nsubj	_	_
 31	passer	passe	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	20	conj	_	_
@@ -23718,7 +23718,7 @@
 # sent_id = 017057
 # text = Begge spillene kan imidlertid trygt anbefales som et sosialt samlingspunkt i stua - det er overraskende lett å få med selv dem som til vanlig fnyser av dataspill som sosial moro.
 1	Begge	begge	DET	det	Number=Plur|PronType=Tot	2	det	_	_
-2	spillene	spill	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	6	nsubj	_	_
+2	spillene	spill	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	6	nsubj:pass	_	_
 3	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 4	imidlertid	imidlertid	ADV	adv	_	6	advmod	_	_
 5	trygt	trygg	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
@@ -23746,7 +23746,7 @@
 27	av	av	ADP	prep	_	28	case	_	_
 28	dataspill	dataspill	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	26	obl	_	_
 29	som	som	ADP	prep	_	31	case	_	_
-30	sosial	sosial	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	31	amod	_	_
+30	sosial	sosial	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	31	amod	_	_
 31	moro	moro	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	26	xcomp	_	SpaceAfter=No
 32	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -23758,7 +23758,7 @@
 4	mens	mens	SCONJ	sbu	_	6	mark	_	_
 5	man	man	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|PronType=Prs	6	nsubj	_	_
 6	gyver	gyve	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	_	_
-7	løs	løs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	advmod	_	_
+7	løs	løs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	advmod	_	_
 8	på	på	ADP	prep	_	9	case	_	_
 9	låt	låt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obl	_	_
 10	etter	etter	ADP	prep	_	11	case	_	_
@@ -23839,7 +23839,7 @@
 
 # sent_id = 017061
 # text = Søvnløs Svindal knuste konkurrentene i super-G
-1	Søvnløs	søvnløs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Søvnløs	søvnløs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	Svindal	Svindal	PROPN	subst	_	3	nsubj	_	_
 3	knuste	knuse	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	konkurrentene	konkurrent	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	3	obj	_	_
@@ -23908,7 +23908,7 @@
 5	triumfen	triumf	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	nsubj	_	_
 6	på	på	ADP	prep	_	8	case	_	_
 7	langt	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	8	advmod	_	_
-8	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	advmod	_	_
+8	nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	advmod	_	_
 9	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	11	cop	_	_
 10	noe	noen	DET	det	Gender=Neut|Number=Sing|PronType=Ind	11	det	_	_
 11	blaff	blaff	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	2	ccomp	_	SpaceAfter=No
@@ -23924,7 +23924,7 @@
 21	dagen	dag	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	19	obl	_	_
 22	derpå	derpå	ADP	prep	_	21	nmod	_	_
 23	i	i	ADP	prep	_	25	case	_	_
-24	ren	ren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	ren	ren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	utklassingsstil	utklassingsstil	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	obl	_	SpaceAfter=No
 26	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -23952,7 +23952,7 @@
 20	alt	all	DET	det	Gender=Neut|Number=Sing|PronType=Tot	21	det	_	_
 21	annet	annen	DET	det	Definite=Ind|Gender=Neut|Number=Sing|PronType=Dem	5	conj	_	_
 22	enn	enn	ADP	prep	_	23	case	_	_
-23	ideell	ideell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	advmod	_	SpaceAfter=No
+23	ideell	ideell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	advmod	_	SpaceAfter=No
 24	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 017066
@@ -24040,9 +24040,9 @@
 # sent_id = 017071
 # text = - Smart og taktisk
 1	-	$-	PUNCT	<strek>	_	2	punct	_	_
-2	Smart	smart	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+2	Smart	smart	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 3	og	og	CCONJ	konj	_	4	cc	_	_
-4	taktisk	taktisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	conj	_	_
+4	taktisk	taktisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	conj	_	_
 
 # sent_id = 017072
 # text = Søvnproblemer til tross - Svindal så på ingen måter preget ut.
@@ -24055,7 +24055,7 @@
 7	på	på	ADP	prep	_	9	case	_	_
 8	ingen	ingen	DET	det	Number=Plur|Polarity=Neg	9	det	_	_
 9	måter	måte	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	6	obl	_	_
-10	preget	prege	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	6	xcomp	_	_
+10	preget	prege	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	6	xcomp	_	_
 11	ut	ut	ADV	prep	_	6	advmod	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -24063,7 +24063,7 @@
 # text = Romerikingen var utilnærmelig i den nedre delen av løypa og så nærmeste konkurrent Hermann Maier tape halvsekundet fra siste mellomtid og ned.
 1	Romerikingen	romeriking	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	cop	_	_
-3	utilnærmelig	utilnærmelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	utilnærmelig	utilnærmelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	i	i	ADP	prep	_	7	case	_	_
 5	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 6	nedre	nedre	ADJ	adj	Degree=Cmp	7	amod	_	_
@@ -24094,7 +24094,7 @@
 5	måtte	måtte	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux	_	_
 6	se	se	VERB	verb	VerbForm=Inf	0	root	_	_
 7	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	6	obj	_	_
-8	slått	slå	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	6	xcomp	_	_
+8	slått	slå	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	6	xcomp	_	_
 9	med	med	ADP	prep	_	11	case	_	_
 10	45	45	NUM	det	Number=Plur|NumType=Card	11	nummod	_	_
 11	hundredeler	hundredel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	obl	_	_
@@ -24107,7 +24107,7 @@
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
 2	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 3	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	cop	_	_
-4	smart	smart	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	smart	smart	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	gjennom	gjennom	ADP	prep	_	7	case	_	_
 6	hele	hel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	7	amod	_	_
 7	løypa	løype	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	4	obl	_	SpaceAfter=No
@@ -24180,11 +24180,11 @@
 33	overrasket	overraske	VERB	verb	VerbForm=Part	31	xcomp	_	_
 34	om	om	SCONJ	sbu	_	40	mark	_	_
 35	tiden	tid	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	40	nsubj	_	_
-36	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	35	det	_	_
+36	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	35	nmod:poss	_	_
 37	ikke	ikke	PART	adv	Polarity=Neg	40	advmod	_	_
 38	hadde	ha	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	40	aux	_	_
 39	vært	være	AUX	verb	VerbForm=Part	40	cop	_	_
-40	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	31	advcl	_	SpaceAfter=No
+40	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	31	advcl	_	SpaceAfter=No
 41	.	$.	PUNCT	clb	_	10	punct	_	_
 
 # sent_id = 017078
@@ -24224,7 +24224,7 @@
 11	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
 12	etter	etter	ADP	prep	_	15	case	_	_
 13	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
-14	vanvittig	vanvittig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	vanvittig	vanvittig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	sluttspurt	sluttspurt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 16	under	under	ADP	prep	_	17	case	_	_
 17	avslutningshelgen	avslutningshelg	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	_
@@ -24289,7 +24289,7 @@
 1	Storslalåmformen	storslalåmform	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	4	advmod	_	_
-4	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	og	og	CCONJ	konj	_	8	cc	_	_
 6	akkurat	akkurat	ADV	adv	_	7	advmod	_	_
 7	nå	nå	ADV	adv	_	8	advmod	_	_
@@ -24325,7 +24325,7 @@
 9	Marius	Marius	PROPN	subst	Gender=Masc	8	flat:name	_	_
 10	Arnesen	Arnesen	PROPN	subst	_	8	flat:name	_	_
 11	strålende	stråle	ADJ	adj	VerbForm=Part	12	advmod	_	_
-12	fornøyd	fornøyd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+12	fornøyd	fornøyd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 13	med	med	ADP	prep	_	14	case	_	_
 14	helgen	helg	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
 15	og	og	CCONJ	konj	_	21	cc	_	_
@@ -24421,7 +24421,7 @@
 15	og	og	CCONJ	konj	_	18	cc	_	_
 16	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	cop	_	_
 17	selvfølgelig	selvfølgelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	18	advmod	_	_
-18	lykkelig	lykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	conj	_	_
+18	lykkelig	lykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	conj	_	_
 19	over	over	ADP	prep	_	22	case	_	_
 20	å	å	PART	inf-merke	_	22	mark	_	_
 21	kunne	kunne	AUX	verb	VerbForm=Inf	22	aux	_	_
@@ -24456,12 +24456,12 @@
 6	fordi	fordi	SCONJ	sbu	_	9	mark	_	_
 7	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	_	_
 8	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	cop	_	_
-9	sikker	sikker	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	advcl	_	_
+9	sikker	sikker	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	advcl	_	_
 10	på	på	ADP	prep	_	14	case	_	_
 11	at	at	SCONJ	sbu	_	14	mark	_	_
 12	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
 13	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	14	cop	_	_
-14	sjanseløs	sjanseløs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	advcl	_	_
+14	sjanseløs	sjanseløs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	advcl	_	_
 15	i	i	ADP	prep	_	16	case	_	_
 16	sammendraget	sammendrag	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	14	obl	_	_
 17	(	$(	PUNCT	<parentes-beg>	_	19	punct	_	SpaceAfter=No
@@ -24483,7 +24483,7 @@
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 3	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
 4	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
-5	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	ccomp	_	_
+5	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	ccomp	_	_
 6	for	for	ADP	prep	_	10	case	_	_
 7	at	at	SCONJ	sbu	_	10	mark	_	_
 8	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	_	_
@@ -24598,7 +24598,7 @@
 3	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 4	vært	være	AUX	verb	VerbForm=Part	6	cop	_	_
 5	ekstremt	ekstrem	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
-6	målbevisst	målbevisst	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+6	målbevisst	målbevisst	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 7	siden	siden	SCONJ	sbu	_	9	mark	_	_
 8	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nsubj	_	_
 9	begynte	begynne	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	advcl	_	_
@@ -24662,7 +24662,7 @@
 5	til	til	ADP	prep	_	10	case	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
 7	meget	meget	ADV	adv	_	8	advmod	_	_
-8	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+8	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 9	19.	19.	ADJ	adj	Number=Plur|NumType=Ord	10	amod	_	SpaceAfter=No
 10	plass	plass	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 11	fra	fra	ADP	prep	_	13	case	_	_
@@ -24833,7 +24833,7 @@
 # text = Dette underbygger min og andres påstand om at dette er mer enn et spill, dette er en jobb.
 1	Dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	underbygger	underbygge	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+3	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 4	og	og	CCONJ	konj	_	5	cc	_	_
 5	andres	annen	DET	det	Case=Gen|Number=Plur|PronType=Dem	3	conj	_	_
 6	påstand	påstand	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
@@ -24861,13 +24861,13 @@
 5	som	som	SCONJ	sbu	_	8	mark	_	_
 6	skulle	skulle	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	aux	_	_
 7	være	være	AUX	verb	VerbForm=Inf	8	cop	_	_
-8	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+8	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 9	i	i	ADP	prep	_	15	case	_	_
 10	«	$"	PUNCT	<anf>	_	11	punct	_	SpaceAfter=No
 11	Football	Football	PROPN	subst	_	14	obl	_	_
 12	Manager	Manager	PROPN	subst	_	11	flat:name	_	SpaceAfter=No
 13	»	$"	PUNCT	<anf>	_	11	punct	_	_
-14	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	15	det	_	_
+14	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 15	verden	verden	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	2	punct	_	_
 17	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux	_	_
@@ -24888,7 +24888,7 @@
 2	Interactive	Interactive	PROPN	subst	_	1	flat:name	_	_
 3	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 4	vært	være	AUX	verb	VerbForm=Part	5	cop	_	_
-5	ansvarlig	ansvarlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+5	ansvarlig	ansvarlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 6	for	for	ADP	prep	_	7	case	_	_
 7	spillserien	spillserie	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 8	i	i	ADP	prep	_	10	case	_	_
@@ -24940,7 +24940,7 @@
 17	samme	samme	DET	det	Definite=Def|PronType=Dem	18	det	_	_
 18	suksess	suksess	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	obj	_	_
 19	som	som	ADV	prep	_	18	advmod	_	_
-20	Sports	Sports	PROPN	subst	_	22	nmod	_	_
+20	Sports	Sports	PROPN	subst	_	22	nmod:poss	_	_
 21	Interactives	Interactive	PROPN	subst	Case=Gen	20	flat:name	_	_
 22	spillserie	spillserie	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	dislocated	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -25005,7 +25005,7 @@
 6	ingen	ingen	DET	det	Gender=Masc|Number=Sing|Polarity=Neg	7	det	_	_
 7	måte	måte	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obl	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-9	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	nyhet	nyhet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	24	punct	_	_
 12	både	både	CCONJ	konj	_	17	cc	_	_
@@ -25035,7 +25035,7 @@
 6	med	med	ADP	prep	_	10	case	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
 8	så	så	ADV	adv	_	9	advmod	_	_
-9	vellykket	vellykket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	vellykket	vellykket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	motor	motor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 11	som	som	ADP	prep	_	13	case	_	_
 12	«	$"	PUNCT	<anf>	_	13	punct	_	SpaceAfter=No
@@ -25109,7 +25109,7 @@
 13	som	som	SCONJ	sbu	_	14	mark	_	_
 14	gir	gi	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	acl:relcl	_	_
 15	deg	du	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=2|PronType=Prs	14	iobj	_	_
-16	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	oversikt	oversikt	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	14	obj	_	_
 18	over	over	ADP	prep	_	19	case	_	_
 19	kampbildet	kampbilde	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	17	nmod	_	SpaceAfter=No
@@ -25141,7 +25141,7 @@
 
 # sent_id = 017122
 # text = Min favoritt er den som måler spillernes selvtillit i kampbildet, og forteller deg hvem som gjorde feil og spiller uten selvtillit.
-1	Min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	2	det	_	_
+1	Min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 2	favoritt	favoritt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 4	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	0	root	_	_
@@ -25181,7 +25181,7 @@
 6	nyhet	nyhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	13	obl	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	6	punct	_	_
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	cop	_	_
-9	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+9	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 10	assisterende	assistere	ADJ	adj	VerbForm=Part	11	amod	_	_
 11	manager	manager	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nsubj	_	_
 12	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
@@ -25195,7 +25195,7 @@
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 4	nybegynner	nybegynner	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obl	_	_
 5	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	_	_
-6	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+6	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 7	høyre	høyre	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	8	amod	_	_
 8	hånd	hånd	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nsubj	_	_
 9	fort	fort	ADJ	adj	Degree=Pos	10	advmod	_	_
@@ -25216,11 +25216,11 @@
 7	kampen	kamp	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	1	conj	_	_
 8	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 9	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	8	nsubj	_	_
-10	øyeblikkelig	øyeblikkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	øyeblikkelig	øyeblikkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	feedback	feedback	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obj	_	_
 12	fra	fra	ADP	prep	_	13	case	_	_
 13	sidemannen	sidemann	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	_
-14	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	13	det	_	_
+14	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 15	på	på	ADP	prep	_	16	case	_	_
 16	benken	benk	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	nmod	_	SpaceAfter=No
 17	,	$,	PUNCT	<komma>	_	19	punct	_	_
@@ -25281,7 +25281,7 @@
 5	hatt	ha	VERB	verb	VerbForm=Part	0	root	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
 7	så	så	ADV	adv	_	8	advmod	_	_
-8	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	sesongstart	sesongstart	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obj	_	_
 10	på	på	ADP	prep	_	12	case	_	_
 11	«	$"	PUNCT	<anf>	_	12	punct	_	SpaceAfter=No
@@ -25304,17 +25304,17 @@
 28	men	men	CCONJ	konj	_	33	cc	_	_
 29	med	med	ADP	prep	_	32	case	_	_
 30	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	32	det	_	_
-31	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	32	amod	_	_
+31	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	32	amod	_	_
 32	assistent	assistent	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	33	obl	_	_
 33	får	få	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	20	conj	_	_
 34	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	33	nsubj	_	_
-35	verdifull	verdifull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	36	amod	_	_
+35	verdifull	verdifull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	36	amod	_	_
 36	hjelp	hjelp	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	33	obj	_	SpaceAfter=No
 37	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 017129
 # text = Min høyre hånd fortalte meg fort at spillerne ikke taklet det høye tempoet og feilplasserte kortpasningene, mine markeringsspillere var ikke gode nok og spissene mine var ikke raske nok.
-1	Min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	_
+1	Min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	_
 2	høyre	høyre	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	3	amod	_	_
 3	hånd	hånd	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj	_	_
 4	fortalte	fortelle	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
@@ -25331,7 +25331,7 @@
 15	feilplasserte	feilplassere	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	conj	_	_
 16	kortpasningene	kortpasning	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	15	obj	_	SpaceAfter=No
 17	,	$,	PUNCT	<komma>	_	22	punct	_	_
-18	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	19	det	_	_
+18	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 19	markeringsspillere	markeringsspiller	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	22	nsubj	_	_
 20	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	22	cop	_	_
 21	ikke	ikke	PART	adv	Polarity=Neg	22	advmod	_	_
@@ -25339,7 +25339,7 @@
 23	nok	nok	ADV	adv	_	22	advmod	_	_
 24	og	og	CCONJ	konj	_	29	cc	_	_
 25	spissene	spiss	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	29	nsubj	_	_
-26	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	25	det	_	_
+26	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	25	nmod:poss	_	_
 27	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	29	cop	_	_
 28	ikke	ikke	PART	adv	Polarity=Neg	29	advmod	_	_
 29	raske	rask	ADJ	adj	Degree=Pos|Number=Plur	22	conj	_	_
@@ -25353,7 +25353,7 @@
 3	kampen	kamp	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	obl	_	_
 4	kommer	komme	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 5	altså	altså	ADV	adv	_	4	advmod	_	_
-6	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	det	_	_
+6	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 7	mest	mye	ADJ	adj	Definite=Ind|Degree=Sup	8	advmod	_	_
 8	verdifulle	verdifull	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	9	amod	_	_
 9	hjelper	hjelper	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj	_	_
@@ -25367,7 +25367,7 @@
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
 2	annen	annen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Dem	3	det	_	_
 3	ting	ting	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nsubj	_	_
-4	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+4	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 5	gode	god	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	6	amod	_	_
 6	venn	venn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj	_	_
 7	hjelper	hjelpe	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	acl:relcl	_	_
@@ -25377,7 +25377,7 @@
 11	å	å	PART	inf-merke	_	12	mark	_	_
 12	finne	finne	VERB	verb	VerbForm=Inf	0	root	_	_
 13	spillere	spiller	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	12	obj	_	_
-14	tilgjengelig	tilgjengelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+14	tilgjengelig	tilgjengelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 15	for	for	ADP	prep	_	16	case	_	_
 16	lån	lån	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	14	obl	_	_
 17	i	i	ADP	prep	_	19	case	_	_
@@ -25391,7 +25391,7 @@
 2	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	1	nsubj	_	_
 3	at	at	SCONJ	sbu	_	8	mark	_	_
 4	laget	lag	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	8	nsubj	_	_
-5	ditt	din	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	_
+5	ditt	din	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 6	ikke	ikke	PART	adv	Polarity=Neg	8	advmod	_	_
 7	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
 8	sterkt	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	1	ccomp	_	_
@@ -25424,7 +25424,7 @@
 2	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 3	kanskje	kanskje	ADV	adv	_	4	advmod	_	_
 4	brukte	bruke	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	1	acl:relcl	_	_
-5	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+5	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 6	assisterende	assistere	ADJ	adj	VerbForm=Part	7	amod	_	_
 7	manager	manager	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 8	til	til	ADV	prep	_	4	advmod	_	_
@@ -25445,9 +25445,9 @@
 # sent_id = 017135
 # text = En ny og artig nyhet på FM 2009 er altså disse pressekonferansene, gøy med en gang, for så å bli kjedelig.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 3	og	og	CCONJ	konj	_	4	cc	_	_
-4	artig	artig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	conj	_	_
+4	artig	artig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	conj	_	_
 5	nyhet	nyhet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nsubj	_	_
 6	på	på	ADP	prep	_	7	case	_	_
 7	FM	FM	PROPN	subst	_	5	nmod	_	_
@@ -25457,7 +25457,7 @@
 11	disse	disse	DET	det	Number=Plur|PronType=Dem	12	det	_	_
 12	pressekonferansene	pressekonferanse	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	0	root	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	14	punct	_	_
-14	gøy	gøy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	conj	_	_
+14	gøy	gøy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	conj	_	_
 15	med	med	ADP	prep	_	17	case	_	_
 16	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
 17	gang	gang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	obl	_	SpaceAfter=No
@@ -25466,7 +25466,7 @@
 20	så	så	ADV	adv	_	22	advmod	_	_
 21	å	å	PART	inf-merke	_	22	mark	_	_
 22	bli	bli	VERB	verb	VerbForm=Inf	14	advcl	_	_
-23	kjedelig	kjedelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	xcomp	_	SpaceAfter=No
+23	kjedelig	kjedelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	xcomp	_	SpaceAfter=No
 24	.	$.	PUNCT	clb	_	12	punct	_	_
 
 # sent_id = 017136
@@ -25533,7 +25533,7 @@
 4	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 5	bare	bare	ADV	adv	_	7	advmod	_	_
 6	være	være	AUX	verb	VerbForm=Inf	7	cop	_	_
-7	gøy	gøy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+7	gøy	gøy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	7	punct	_	_
 
 # sent_id = 017139
@@ -25598,7 +25598,7 @@
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
 10	farlig	farlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	11	advmod	_	_
-11	morsom	morsom	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	morsom	morsom	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	metode	metode	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 13	for	for	ADP	prep	_	15	case	_	_
 14	å	å	PART	inf-merke	_	15	mark	_	_
@@ -25607,7 +25607,7 @@
 17	pressekonferanse	pressekonferanse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obj	_	SpaceAfter=No
 18	,	$,	PUNCT	<komma>	_	20	punct	_	_
 19	spesielt	spesiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	20	advmod	_	_
-20	gøy	gøy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	conj	_	_
+20	gøy	gøy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	conj	_	_
 21	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	20	cop	_	_
 22	tilleggskommentaren	tilleggskommentar	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	20	nsubj	_	_
 23	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	26	nsubj	_	_
@@ -25643,13 +25643,13 @@
 23	deg	du	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=2|PronType=Prs	22	obj	_	_
 24	med	med	ADP	prep	_	27	case	_	_
 25	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	27	det	_	_
-26	tapt	tape	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	27	amod	_	_
+26	tapt	tape	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	27	amod	_	_
 27	ligacupkamp	ligacupkamp	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	22	obl	_	SpaceAfter=No
 28	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 017143
 # text = Stor fallhøyde
-1	Stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	fallhøyde	fallhøyde	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 
 # sent_id = 017144
@@ -25663,7 +25663,7 @@
 7	-spill	-spill	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	8	obl	_	_
 8	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 9	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	expl	_	_
-10	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	fallhøyde	fallhøyde	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nsubj	_	_
 12	i	i	ADP	prep	_	15	case	_	_
 13	de	de	DET	det	Number=Plur|PronType=Art	15	det	_	_
@@ -25681,7 +25681,7 @@
 # text = Velger du din egen alder som manager og lar være å skryte på deg en tidligere karriere som landslagspiller for Norge (69 kamper og 12 mål), stoler som regel spillere i større klubber ikke på deg.
 1	Velger	velge	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	30	advcl	_	_
 2	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	1	nsubj	_	_
-3	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+3	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 4	egen	egen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Prs	5	det	_	_
 5	alder	alder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	obj	_	_
 6	som	som	ADP	prep	_	7	case	_	_
@@ -25725,7 +25725,7 @@
 1	Og	og	CCONJ	konj	_	3	cc	_	_
 2	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	_
 3	tar	ta	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obj	_	_
 6	å	å	PART	inf-merke	_	7	mark	_	_
 7	overbevise	overbevise	VERB	verb	VerbForm=Inf	3	csubj	_	_
@@ -25755,7 +25755,7 @@
 16	første	første	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing|NumType=Ord	17	amod	_	_
 17	sesong	sesong	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obl	_	_
 18	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	21	aux:pass	_	_
-19	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	21	nsubj	_	_
+19	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	21	nsubj:pass	_	_
 20	fort	fort	ADJ	adj	Degree=Pos	21	advmod	_	_
 21	jaktet	jakte	VERB	verb	VerbForm=Part	4	conj	_	_
 22	på	på	ADV	prep	_	21	advmod	_	_
@@ -25776,7 +25776,7 @@
 # text = Er du norsk manager i Englands nest øverste divisjon blir du også hele tiden linket til norske klubber.
 1	Er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 2	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	4	nsubj	_	_
-3	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	manager	manager	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obl	_	_
 5	i	i	ADP	prep	_	9	case	_	_
 6	Englands	England	PROPN	subst	Case=Gen	9	nmod	_	_
@@ -25784,7 +25784,7 @@
 8	øverste	øvre	ADJ	adj	Definite=Def|Degree=Sup	9	amod	_	_
 9	divisjon	divisjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nmod	_	_
 10	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux:pass	_	_
-11	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	15	nsubj	_	_
+11	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	15	nsubj:pass	_	_
 12	også	også	ADV	adv	_	15	advmod	_	_
 13	hele	hel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	14	amod	_	_
 14	tiden	tid	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	obl	_	_
@@ -25828,7 +25828,7 @@
 20	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
 21	aldri	aldri	ADV	adv	_	22	advmod	_	_
 22	så	så	ADV	adv	_	23	advmod	_	_
-23	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	24	amod	_	_
+23	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	24	amod	_	_
 24	oppussing	oppussing	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	obj	_	_
 25	til	til	ADP	prep	_	27	case	_	_
 26	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	27	det	_	_
@@ -25838,7 +25838,7 @@
 # sent_id = 017152
 # text = Speiderne dine forteller deg også hovedstaden i for eksempel Sverige, og hvor mange innbyggere landet har.
 1	Speiderne	speider	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	3	nsubj	_	_
-2	dine	din	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	1	det	_	_
+2	dine	din	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	1	nmod:poss	_	_
 3	forteller	fortelle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	deg	du	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=2|PronType=Prs	3	iobj	_	_
 5	også	også	ADV	adv	_	3	advmod	_	_
@@ -25872,7 +25872,7 @@
 12	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
 13	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	14	advmod	_	_
 14	mer	mye	ADJ	adj	Degree=Cmp	15	advmod	_	_
-15	oversiktlig	oversiktlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+15	oversiktlig	oversiktlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	15	punct	_	_
 
 # sent_id = 017154
@@ -25897,8 +25897,8 @@
 
 # sent_id = 017155
 # text = Fortløpende informasjon fra landene de besøker settes også pris på.
-1	Fortløpende	fortløpende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
-2	informasjon	informasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj	_	_
+1	Fortløpende	fortløpende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
+2	informasjon	informasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj:pass	_	_
 3	fra	fra	ADP	prep	_	4	case	_	_
 4	landene	land	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	2	nmod	_	_
 5	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	_	_
@@ -25980,7 +25980,7 @@
 1	At	at	SCONJ	sbu	_	6	mark	_	_
 2	innbyttere	innbytter	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	6	nsubj	_	_
 3	med	med	ADP	prep	_	5	case	_	_
-4	lite	lite	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	lite	lite	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	spilletid	spilletid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	nmod	_	_
 6	får	få	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	22	csubj	_	_
 7	ingen	ingen	DET	det	Gender=Masc|Number=Sing|Polarity=Neg	8	det	_	_
@@ -25989,7 +25989,7 @@
 10	stedet	sted	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	obl	_	_
 11	for	for	ADP	prep	_	14	case	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-13	laber	laber	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	laber	laber	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	sekser	sekser	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nmod	_	_
 15	som	som	ADP	prep	_	16	case	_	_
 16	tidligere	tidlig	ADJ	adj	Degree=Cmp	6	advmod	_	SpaceAfter=No
@@ -25997,7 +25997,7 @@
 18	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	22	cop	_	_
 19	også	også	ADV	adv	_	22	advmod	_	_
 20	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-21	ønsket	ønske	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	22	amod	_	_
+21	ønsket	ønske	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	22	amod	_	_
 22	oppdatering	oppdatering	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	22	punct	_	_
 
@@ -26044,7 +26044,7 @@
 10	som	som	SCONJ	sbu	_	12	mark	_	_
 11	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	_	_
 12	fått	få	VERB	verb	VerbForm=Part	6	acl:relcl	_	_
-13	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	15	det	_	_
+13	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 14	egen	egen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Prs	15	det	_	_
 15	status	status	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obj	_	_
 16	på	på	ADP	prep	_	18	case	_	_
@@ -26061,7 +26061,7 @@
 27	og	og	CCONJ	konj	_	29	cc	_	_
 28	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	29	nsubj	_	_
 29	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	22	conj	_	_
-30	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	31	amod	_	_
+30	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	31	amod	_	_
 31	stemning	stemning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	29	obj	_	_
 32	i	i	ADP	prep	_	33	case	_	_
 33	stallen	stall	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	31	nmod	_	_
@@ -26076,7 +26076,7 @@
 # sent_id = 017162
 # text = Hardt arbeid belønnes
 1	Hardt	hard	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	2	amod	_	_
-2	arbeid	arbeid	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	nsubj	_	_
+2	arbeid	arbeid	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	nsubj:pass	_	_
 3	belønnes	belønne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 
 # sent_id = 017163
@@ -26141,7 +26141,7 @@
 4	tidligere	tidlig	ADJ	adj	Degree=Cmp	2	amod	_	_
 5	belønnes	belønne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 6	hardt	hard	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	amod	_	_
-7	arbeid	arbeid	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	5	nsubj	_	SpaceAfter=No
+7	arbeid	arbeid	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	5	nsubj:pass	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 017166
@@ -26175,7 +26175,7 @@
 7	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	11	nsubj	_	_
 8	også	også	ADV	adv	_	11	advmod	_	_
 9	være	være	AUX	verb	VerbForm=Inf	11	cop	_	_
-10	kvinnelig	kvinnelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	kvinnelig	kvinnelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	manager	manager	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	xcomp	_	SpaceAfter=No
 12	?	$?	PUNCT	clb	_	1	punct	_	_
 
@@ -26188,7 +26188,7 @@
 5	i	i	ADP	prep	_	10	case	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
 7	«	$"	PUNCT	<anf>	_	8	punct	_	SpaceAfter=No
-8	mannsdominert	mannsdominert	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	SpaceAfter=No
+8	mannsdominert	mannsdominert	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	SpaceAfter=No
 9	»	$"	PUNCT	<anf>	_	8	punct	_	_
 10	idrett	idrett	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nmod	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -26249,7 +26249,7 @@
 3	,	$,	PUNCT	<komma>	_	6	punct	_	_
 4	men	men	CCONJ	konj	_	6	cc	_	_
 5	mindre	liten	ADJ	adj	Degree=Cmp	6	advmod	_	_
-6	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	conj	_	_
+6	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	conj	_	_
 
 # sent_id = 017172
 # text = Forbruket økt med 20 prosent på ti år.
@@ -26371,7 +26371,7 @@
 # sent_id = 017178
 # text = Ifølge kulturansvarlig for frukt i produsentorganisasjonen Norgrønt, Knut Byrkjenes Hauso, ligger det et potensial i Norge for å dyrke mer pærer, spesielt sorter som skiller seg ut fra importpærene.
 1	Ifølge	ifølge	ADP	prep	_	2	case	_	_
-2	kulturansvarlig	kulturansvarlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	advmod	_	_
+2	kulturansvarlig	kulturansvarlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	advmod	_	_
 3	for	for	ADP	prep	_	4	case	_	_
 4	frukt	frukt	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	nmod	_	_
 5	i	i	ADP	prep	_	6	case	_	_
@@ -26410,7 +26410,7 @@
 2	Hannah	Hannah	PROPN	subst	_	4	nsubj	_	_
 3	får	få	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 4	oppfylt	oppfylle	VERB	verb	VerbForm=Part	0	root	_	_
-5	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+5	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 6	siste	sist	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	7	amod	_	_
 7	ønske	ønske	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	4	obj	_	_
 8	likevel	likevel	ADV	adv	_	4	advmod	_	_
@@ -26464,7 +26464,7 @@
 6	siste	sist	ADJ	adj	Degree=Pos|Number=Plur	7	amod	_	_
 7	månedene	måned	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	4	obj	_	_
 8	av	av	ADP	prep	_	10	case	_	_
-9	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	10	det	_	_
+9	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	10	nmod:poss	_	_
 10	liv	liv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	7	nmod	_	_
 11	hjemme	hjemme	ADP	prep	_	13	case	_	_
 12	hos	hos	ADP	prep	_	13	case	_	_
@@ -26510,7 +26510,7 @@
 # text = Overbeviste med sin modenhet:
 1	Overbeviste	overbevise	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 2	med	med	ADP	prep	_	4	case	_	_
-3	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	_
+3	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 4	modenhet	modenhet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
 5	:	$:	PUNCT	clb	_	1	punct	_	_
 
@@ -26538,7 +26538,7 @@
 3	Hannah	Hannah	PROPN	subst	_	1	nmod	_	_
 4	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 5	fått	få	VERB	verb	VerbForm=Part	0	root	_	_
-6	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	oppmerksomhet	oppmerksomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	obj	_	_
 8	i	i	ADP	prep	_	10	case	_	_
 9	britiske	britisk	ADJ	adj	Degree=Pos|Number=Plur	10	amod	_	_
@@ -26574,7 +26574,7 @@
 2	orker	orke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	ikke	ikke	PART	adv	Polarity=Neg	2	advmod	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	operasjon	operasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	11	punct	_	_
 8	og	og	CCONJ	konj	_	11	cc	_	_
@@ -26591,7 +26591,7 @@
 3	å	å	PART	inf-merke	_	5	mark	_	_
 4	få	få	AUX	verb	VerbForm=Inf	5	aux	_	_
 5	tilbringe	tilbringe	VERB	verb	VerbForm=Inf	2	xcomp	_	_
-6	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	det	_	_
+6	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 7	siste	sist	ADJ	adj	Degree=Pos|Number=Plur	8	amod	_	_
 8	dager	dag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	obj	_	_
 9	hjemme	hjemme	ADV	prep	_	5	advmod	_	_
@@ -26724,7 +26724,7 @@
 8	og	og	CCONJ	konj	_	9	cc	_	_
 9	sagt	si	VERB	verb	VerbForm=Part	6	conj	_	_
 10	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	9	obj	_	_
-11	villig	villig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	xcomp	_	_
+11	villig	villig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	xcomp	_	_
 12	til	til	ADP	prep	_	14	case	_	_
 13	å	å	PART	inf-merke	_	14	mark	_	_
 14	forsikre	forsikre	VERB	verb	VerbForm=Inf	11	advcl	_	_
@@ -26763,23 +26763,23 @@
 9	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux	_	_
 10	være	være	AUX	verb	VerbForm=Inf	13	cop	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-12	fin	fin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	fin	fin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	avkobling	avkobling	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	31	ccomp	_	_
 14	for	for	ADP	prep	_	15	case	_	_
 15	meg	jeg	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=1|PronType=Prs	13	nmod	_	_
 16	og	og	CCONJ	konj	_	17	cc	_	_
 17	familien	familie	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	conj	_	_
-18	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	det	_	SpaceAfter=No
+18	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	nmod:poss	_	SpaceAfter=No
 19	,	$,	PUNCT	<komma>	_	26	punct	_	_
 20	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	26	nsubj	_	_
 21	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	26	aux	_	_
 22	være	være	AUX	verb	VerbForm=Inf	26	cop	_	_
 23	som	som	ADP	prep	_	26	case	_	_
 24	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	26	det	_	_
-25	vanlig	vanlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	amod	_	_
+25	vanlig	vanlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	amod	_	_
 26	familie	familie	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	conj	_	_
 27	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	29	det	_	_
-28	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	29	amod	_	_
+28	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	29	amod	_	_
 29	stund	stund	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	26	obl	_	SpaceAfter=No
 30	,	$,	PUNCT	<komma>	_	26	punct	_	_
 31	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -26844,7 +26844,7 @@
 17	å	å	PART	inf-merke	_	18	mark	_	_
 18	se	se	VERB	verb	VerbForm=Inf	14	advcl	_	_
 19	smilet	smil	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	18	obj	_	_
-20	hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	19	det	_	_
+20	hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 21	når	når	SCONJ	sbu	_	23	mark	_	_
 22	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	23	nsubj	_	_
 23	kommer	komme	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	advcl	_	_
@@ -26886,7 +26886,7 @@
 4	medisinene	medisin	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	3	nsubj	_	_
 5	til	til	ADP	prep	_	8	case	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	hjertefeil	hjertefeil	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	12	punct	_	_
 10	og	og	CCONJ	konj	_	12	cc	_	_
@@ -26924,7 +26924,7 @@
 8	livet	liv	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	obj	_	_
 9	sammen	sammen	ADV	adv	_	13	advmod	_	_
 10	med	med	ADP	prep	_	13	case	_	_
-11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	det	_	_
+11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 12	aller	aller	ADV	adv	_	11	advmod	_	_
 13	nærmeste	nær	ADJ	adj	Definite=Def|Degree=Sup	7	advmod	_	SpaceAfter=No
 14	,	$,	PUNCT	<komma>	_	4	punct	_	_
@@ -26960,7 +26960,7 @@
 13	overbeviste	overbevise	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	advcl	_	_
 14	barnevernet	barnevern	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	13	obj	_	_
 15	med	med	ADP	prep	_	17	case	_	_
-16	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	det	_	_
+16	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
 17	modenhet	modenhet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	obl	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -26983,7 +26983,7 @@
 8	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 9	gjennomgått	gjennomgå	VERB	verb	VerbForm=Part	0	root	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-11	vellykket	vellykket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	vellykket	vellykket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	hjertetransplantasjon	hjertetransplantasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obj	_	_
 13	ved	ved	ADP	prep	_	14	case	_	_
 14	Rikshospitalet	Rikshospitalet	PROPN	subst	_	9	obl	_	SpaceAfter=No
@@ -26997,7 +26997,7 @@
 3	operasjonen	operasjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 4	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 5	vært	være	AUX	verb	VerbForm=Part	6	cop	_	_
-6	vellykket	vellykket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	ccomp	_	SpaceAfter=No
+6	vellykket	vellykket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	ccomp	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	6	punct	_	_
 8	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 9	ordførerens	ordfører	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
@@ -27006,7 +27006,7 @@
 12	W.	W.	PROPN	subst	Abbr=Yes	11	flat:name	_	_
 13	Olsen	Olsen	PROPN	subst	_	11	flat:name	_	_
 14	til	til	ADP	prep	_	17	case	_	_
-15	Tønsbergs	Tønsbergs	PROPN	subst	_	17	nmod	_	_
+15	Tønsbergs	Tønsbergs	PROPN	subst	_	17	nmod:poss	_	_
 16	Blads	Blad	PROPN	subst	Case=Gen	15	flat:name	_	_
 17	nettutgave	nettutgave	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	8	obl	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	8	punct	_	_
@@ -27062,7 +27062,7 @@
 # text = Olsen er sykmeldt fra jobben som ordfører i Tønsberg inntil videre, og det er ikke ventet at han vil kunne vende tilbake til arbeidet før neste år.
 1	Olsen	Olsen	PROPN	subst	_	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	sykmeldt	sykmeldt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	sykmeldt	sykmeldt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	fra	fra	ADP	prep	_	5	case	_	_
 5	jobben	jobb	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
 6	som	som	ADP	prep	_	7	case	_	_
@@ -27149,7 +27149,7 @@
 10	hadde	ha	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	conj	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
 12	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	13	advmod	_	_
-13	lykkelig	lykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	lykkelig	lykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	oppvekst	oppvekst	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obj	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -27163,7 +27163,7 @@
 # text = - Fra min radikale ungdom, en gang på 80-tallet.
 1	-	$-	PUNCT	<strek>	_	5	punct	_	_
 2	Fra	fra	ADP	prep	_	5	case	_	_
-3	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+3	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 4	radikale	radikal	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	5	amod	_	_
 5	ungdom	ungdom	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	8	punct	_	_
@@ -27177,7 +27177,7 @@
 # text = Palestinaskjerf, lilla anorakk og fotformsko.
 1	Palestinaskjerf	palestinaskjerf	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	0	root	_	SpaceAfter=No
 2	,	$,	PUNCT	<komma>	_	4	punct	_	_
-3	lilla	lilla	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	lilla	lilla	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	anorakk	anorakk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	conj	_	_
 5	og	og	CCONJ	konj	_	6	cc	_	_
 6	fotformsko	fotformsko	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	conj	_	SpaceAfter=No
@@ -27235,7 +27235,7 @@
 8	skulle	skulle	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	aux	_	_
 9	bli	bli	VERB	verb	VerbForm=Inf	3	xcomp	_	_
 10	noen	noen	DET	det	Gender=Masc|Number=Sing|PronType=Ind	12	det	_	_
-11	grasiøs	grasiøs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	grasiøs	grasiøs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	gasselle	gasselle	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	xcomp	_	_
 13	på	på	ADP	prep	_	14	case	_	_
 14	dansegulvet	dansegulv	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	12	nmod	_	SpaceAfter=No
@@ -27251,7 +27251,7 @@
 # text = Med en liflig eim av parfyme og et steinras av et smykke på brystet åpner Signy Fardal døra til leiligheten på Frogner.
 1	Med	med	ADP	prep	_	4	case	_	_
 2	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-3	liflig	liflig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	liflig	liflig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	eim	eim	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obl	_	_
 5	av	av	ADP	prep	_	6	case	_	_
 6	parfyme	parfyme	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nmod	_	_
@@ -27368,7 +27368,7 @@
 1	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
 2	så	se	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	visstnok	visstnok	ADV	adv	_	2	advmod	_	_
-4	latterlig	latterlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	xcomp	_	_
+4	latterlig	latterlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	xcomp	_	_
 5	ut	ut	ADV	prep	_	2	advmod	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -27376,18 +27376,18 @@
 # text = Den er stor og svart.
 1	Den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	og	og	CCONJ	konj	_	5	cc	_	_
-5	svart	svart	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	conj	_	SpaceAfter=No
+5	svart	svart	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	conj	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 017244
 # text = Rein i snittet og blank.
-1	Rein	rein	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+1	Rein	rein	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 2	i	i	ADP	prep	_	3	case	_	_
 3	snittet	snitt	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	1	obl	_	_
 4	og	og	CCONJ	konj	_	5	cc	_	_
-5	blank	blank	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	1	conj	_	SpaceAfter=No
+5	blank	blank	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	1	conj	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	1	punct	_	_
 
 # sent_id = 017245
@@ -27483,9 +27483,9 @@
 3	grønne	grønn	ADJ	adj	Degree=Pos|Number=Plur	0	root	_	_
 4	og	og	CCONJ	konj	_	5	cc	_	_
 5	maskaraen	maskara	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	conj	_	_
-6	mørk	mørk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	xcomp	_	_
+6	mørk	mørk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	xcomp	_	_
 7	og	og	CCONJ	konj	_	12	cc	_	_
-8	svarene	svar	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	12	nsubj	_	_
+8	svarene	svar	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	12	nsubj:pass	_	_
 9	som	som	SCONJ	sbu	_	10	mark	_	_
 10	kommer	komme	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	acl:relcl	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	8	punct	_	_
@@ -27502,7 +27502,7 @@
 22	mot	mot	ADP	prep	_	23	case	_	_
 23	hverandre	hverandre	PRON	pron	Animacy=Hum|Number=Plur|PronType=Rcp	21	obl	_	_
 24	rundt	rundt	ADP	prep	_	27	case	_	_
-25	Signy	Signy	PROPN	subst	_	27	nmod	_	_
+25	Signy	Signy	PROPN	subst	_	27	nmod:poss	_	_
 26	Fardals	Fardal	PROPN	subst	Case=Gen	25	flat:name	_	_
 27	hals	hals	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
 28	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -27510,7 +27510,7 @@
 # sent_id = 017250
 # text = - Min første tanke var:
 1	-	$-	PUNCT	<strek>	_	5	punct	_	_
-2	Min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	_
+2	Min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 3	første	første	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing|NumType=Ord	4	amod	_	_
 4	tanke	tanke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj	_	_
 5	var	være	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
@@ -27523,7 +27523,7 @@
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 4	jo	jo	ADV	adv	_	6	advmod	_	_
 5	så	så	ADV	adv	_	6	advmod	_	_
-6	forgjengelig	forgjengelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+6	forgjengelig	forgjengelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	6	punct	_	_
 
 # sent_id = 017252
@@ -27533,7 +27533,7 @@
 3	omtrent	omtrent	ADV	adv	_	5	advmod	_	_
 4	i	i	ADP	prep	_	5	case	_	_
 5	øyeblikket	øyeblikk	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	obl	_	_
-6	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
+6	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj:pass	_	_
 7	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux:pass	_	_
 8	født	føde	VERB	verb	VerbForm=Part	5	acl:relcl	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -27608,7 +27608,7 @@
 
 # sent_id = 017256
 # text = Lang kjole i et cocktailparty er no-no.
-1	Lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	kjole	kjole	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj	_	_
 3	i	i	ADP	prep	_	5	case	_	_
 4	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
@@ -27720,7 +27720,7 @@
 6	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	_	_
 7	mote	mote	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nsubj	_	_
 8	så	så	ADV	adv	_	9	advmod	_	_
-9	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	ccomp	_	_
+9	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	ccomp	_	_
 10	da	da	ADV	adv	_	9	advmod	_	SpaceAfter=No
 11	?	$?	PUNCT	clb	_	9	punct	_	_
 
@@ -27740,7 +27740,7 @@
 12	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux	_	_
 13	løpe	løpe	VERB	verb	VerbForm=Inf	6	advcl	_	_
 14	hvis	hvis	SCONJ	sbu	_	17	mark	_	_
-15	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	17	nsubj	_	_
+15	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	17	nsubj:pass	_	_
 16	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux:pass	_	_
 17	truet	true	VERB	verb	VerbForm=Part	13	advcl	_	SpaceAfter=No
 18	,	$,	PUNCT	<komma>	_	23	punct	_	_
@@ -27773,7 +27773,7 @@
 17	ut	ut	ADV	prep	_	14	advmod	_	_
 18	av	av	ADP	prep	_	19	case	_	_
 19	fasaden	fasade	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
-20	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	19	det	_	SpaceAfter=No
+20	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	19	nmod:poss	_	SpaceAfter=No
 21	.	$.	PUNCT	clb	_	1	punct	_	_
 
 # sent_id = 017267
@@ -27811,7 +27811,7 @@
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 3	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	expl	_	_
 4	på	på	ADP	prep	_	6	case	_	_
-5	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+5	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 6	plass	plass	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 7	å	å	PART	inf-merke	_	8	mark	_	_
 8	skyte	skyte	VERB	verb	VerbForm=Inf	6	csubj	_	_
@@ -27879,7 +27879,7 @@
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
 2	Mote	mote	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+4	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 5	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 017274
@@ -27999,7 +27999,7 @@
 2	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 3	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 4	bli	bli	VERB	verb	VerbForm=Inf	0	root	_	_
-5	lykkelig	lykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	xcomp	_	_
+5	lykkelig	lykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	xcomp	_	_
 6	av	av	ADP	prep	_	8	case	_	_
 7	å	å	PART	inf-merke	_	8	mark	_	_
 8	kjøpe	kjøpe	VERB	verb	VerbForm=Inf	5	advcl	_	_
@@ -28012,7 +28012,7 @@
 # text = Jeg elsker min Chanelveske.
 1	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
 2	elsker	elske	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	_
+3	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 4	Chanelveske	Chanelveske	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	SpaceAfter=No
 5	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -28043,13 +28043,13 @@
 12	bransjen	bransje	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
 13	blir	bli	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	csubj	_	_
 14	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	15	advmod	_	_
-15	småskadet	småskadet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	xcomp	_	SpaceAfter=No
+15	småskadet	småskadet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	xcomp	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 017284
 # text = Og opptatt av ting som selvfølgelig ikke er viktig.
 1	Og	og	CCONJ	konj	_	2	cc	_	_
-2	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+2	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 3	av	av	ADP	prep	_	4	case	_	_
 4	ting	ting	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	2	obl	_	_
 5	som	som	SCONJ	sbu	_	9	mark	_	_
@@ -28107,7 +28107,7 @@
 12	få	få	VERB	verb	VerbForm=Inf	4	conj	_	_
 13	gjennomslag	gjennomslag	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	12	obj	_	_
 14	for	for	ADP	prep	_	16	case	_	_
-15	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	16	det	_	_
+15	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	16	nmod:poss	_	_
 16	synspunkter	synspunkt	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	13	nmod	_	_
 17	fordi	fordi	SCONJ	sbu	_	19	mark	_	_
 18	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	19	nsubj	_	_
@@ -28220,7 +28220,7 @@
 11	het	hete	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	acl:relcl	_	_
 12	Twiggy	Twiggy	PROPN	subst	_	11	xcomp	_	_
 13	og	og	CCONJ	konj	_	16	cc	_	_
-14	miniskjørtet	miniskjørt	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	16	nsubj	_	_
+14	miniskjørtet	miniskjørt	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	16	nsubj:pass	_	_
 15	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	16	aux:pass	_	_
 16	oppfunnet	oppfinne	VERB	verb	VerbForm=Part	11	conj	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -28270,7 +28270,7 @@
 7	med	med	ADP	prep	_	8	case	_	_
 8	oppbrett	oppbrett	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nmod	_	_
 9	og	og	CCONJ	konj	_	11	cc	_	_
-10	høyhalset	høyhalset	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	høyhalset	høyhalset	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	genser	genser	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	conj	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -28284,8 +28284,8 @@
 6	gule	gul	ADJ	adj	Degree=Pos|Number=Plur	7	amod	_	_
 7	knestrømper	knestrømpe	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	4	conj	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	11	punct	_	_
-9	oppbrettet	oppbrettet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
-10	hjemmesydd	hjemmesydd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+9	oppbrettet	oppbrettet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
+10	hjemmesydd	hjemmesydd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	dongeribukse	dongeribukse	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	conj	_	_
 12	og	og	CCONJ	konj	_	13	cc	_	_
 13	hippieskjorte	hippieskjorte	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	conj	_	SpaceAfter=No
@@ -28362,7 +28362,7 @@
 3	,	$,	PUNCT	<komma>	_	4	punct	_	_
 4	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	appos	_	_
 5	ble	bli	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-6	rød	rød	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	xcomp	_	SpaceAfter=No
+6	rød	rød	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	xcomp	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 017304
@@ -28371,7 +28371,7 @@
 2	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 3	hadde	ha	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	radikal	radikal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	radikal	radikal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	ungdom	ungdom	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -28577,7 +28577,7 @@
 12	Røkke	Røkke	PROPN	subst	_	10	flat:name	_	_
 13	i	i	ADP	prep	_	14	case	_	_
 14	privatflyet	privatfly	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	9	obl	_	_
-15	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	14	det	_	_
+15	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	14	nmod:poss	_	_
 16	på	på	ADP	prep	_	17	case	_	_
 17	vei	vei	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obl	_	_
 18	mot	mot	ADP	prep	_	19	case	_	_
@@ -28738,7 +28738,7 @@
 7	men	men	CCONJ	konj	_	11	cc	_	_
 8	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	expl	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	_	_
-10	beinhard	beinhard	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	beinhard	beinhard	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	jobbing	jobbing	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	conj	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -28777,7 +28777,7 @@
 5	Fardal	Fardal	PROPN	subst	_	9	obl	_	_
 6	være	være	AUX	verb	VerbForm=Inf	9	cop	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	kulturopplevelse	kulturopplevelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 10	.	$.	PUNCT	clb	_	9	punct	_	_
 
@@ -28829,7 +28829,7 @@
 9	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	_	_
 10	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	_	_
 11	så	så	ADV	adv	_	12	advmod	_	_
-12	privilegert	privilegere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	3	dislocated	_	_
+12	privilegert	privilegere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	3	dislocated	_	_
 13	som	som	SCONJ	sbu	_	14	mark	_	_
 14	sitter	sitte	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	acl:relcl	_	_
 15	her	her	ADV	prep	_	14	advmod	_	SpaceAfter=No
@@ -28936,7 +28936,7 @@
 # text = For en syk bransje».
 1	For	for	ADV	adv	_	4	advmod	_	_
 2	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-3	syk	syk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	syk	syk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	bransje	bransje	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 5	»	$"	PUNCT	<anf>	_	4	punct	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	4	punct	_	_
@@ -29032,7 +29032,7 @@
 # sent_id = 017348
 # text = Fra fin hagefest til finanser.
 1	Fra	fra	ADP	prep	_	3	case	_	_
-2	fin	fin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	fin	fin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	hagefest	hagefest	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 4	til	til	ADP	prep	_	5	case	_	_
 5	finanser	finans	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	obl	_	SpaceAfter=No
@@ -29203,7 +29203,7 @@
 6	minst	liten	ADJ	adj	Definite=Ind|Degree=Sup	7	advmod	_	_
 7	like	like	ADV	adv	_	8	advmod	_	_
 8	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
-9	verdt	verdt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	advcl	_	_
+9	verdt	verdt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	advcl	_	_
 10	om	om	ADP	prep	_	14	case	_	_
 11	fem	fem	NUM	det	Number=Plur|NumType=Card	14	nummod	_	_
 12	eller	eller	CCONJ	konj	_	13	cc	_	_
@@ -29262,13 +29262,13 @@
 # sent_id = 017361
 # text = - Du ble beskrevet som autoritær og dominerende.
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
-2	Du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	4	nsubj	_	_
+2	Du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	4	nsubj:pass	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	_	_
 4	beskrevet	beskrive	VERB	verb	VerbForm=Part	0	root	_	_
 5	som	som	ADP	prep	_	6	case	_	_
-6	autoritær	autoritær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	xcomp	_	_
+6	autoritær	autoritær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	xcomp	_	_
 7	og	og	CCONJ	konj	_	8	cc	_	_
-8	dominerende	dominerende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	conj	_	SpaceAfter=No
+8	dominerende	dominerende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	conj	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 017362
@@ -29298,12 +29298,12 @@
 4	man	man	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|PronType=Prs	10	nsubj	_	_
 5	til	til	ADP	prep	_	8	case	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	viss	viss	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	viss	viss	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	grad	grad	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obl	_	_
 9	være	være	AUX	verb	VerbForm=Inf	10	cop	_	_
-10	dominerende	dominerende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+10	dominerende	dominerende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 11	og	og	CCONJ	konj	_	12	cc	_	_
-12	autoritær	autoritær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	conj	_	SpaceAfter=No
+12	autoritær	autoritær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	conj	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	16	punct	_	_
 14	men	men	CCONJ	konj	_	16	cc	_	_
 15	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	_	_
@@ -29322,7 +29322,7 @@
 # sent_id = 017365
 # text = Det verste var at det ble sagt at jeg mobbet ansatte og baksnakket dem.
 1	Det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	2	det	_	_
-2	verste	vond	ADJ	adj	Definite=Def|Degree=Sup	7	nsubj	_	_
+2	verste	vond	ADJ	adj	Definite=Def|Degree=Sup	7	nsubj:pass	_	_
 3	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	_	_
 4	at	at	SCONJ	sbu	_	7	mark	_	_
 5	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	expl	_	_
@@ -29353,7 +29353,7 @@
 1	Nå	nå	ADV	adv	_	2	advmod	_	_
 2	viser	vise	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	medarbeiderundersøkelse	medarbeiderundersøkelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	nsubj	_	_
 6	at	at	SCONJ	sbu	_	9	mark	_	_
 7	de	de	DET	det	Number=Plur|PronType=Art	8	det	_	_
@@ -29369,14 +29369,14 @@
 # sent_id = 017368
 # text = Men jeg kan nok fortsatt oppfattes som mer skummel enn jeg opplever meg selv som.
 1	Men	men	CCONJ	konj	_	6	cc	_	_
-2	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	_
+2	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj:pass	_	_
 3	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 4	nok	nok	ADV	adv	_	6	advmod	_	_
 5	fortsatt	fortsatt	ADV	adv	_	6	advmod	_	_
 6	oppfattes	oppfatte	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 7	som	som	ADP	prep	_	9	case	_	_
 8	mer	mye	ADJ	adj	Degree=Cmp	9	advmod	_	_
-9	skummel	skummel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	xcomp	_	_
+9	skummel	skummel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	xcomp	_	_
 10	enn	enn	SCONJ	sbu	_	12	mark	_	_
 11	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	_	_
 12	opplever	oppleve	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	advcl	_	_
@@ -29392,7 +29392,7 @@
 3	jo	jo	ADV	adv	_	6	advmod	_	_
 4	ikke	ikke	PART	adv	Polarity=Neg	6	advmod	_	_
 5	noen	noen	DET	det	Gender=Masc|Number=Sing|PronType=Ind	6	det	_	_
-6	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+6	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 7	...	$...	PUNCT	clb	_	13	punct	_	_
 8	og	og	CCONJ	konj	_	13	cc	_	_
 9	nå	nå	ADV	adv	_	13	advmod	_	_
@@ -29507,13 +29507,13 @@
 6	å	å	PART	inf-merke	_	7	mark	_	_
 7	ha	ha	VERB	verb	VerbForm=Inf	3	advcl	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-9	viss	viss	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	viss	viss	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	profil	profil	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	18	punct	_	_
 12	men	men	CCONJ	konj	_	18	cc	_	_
 13	selvfølgelig	selvfølgelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	18	advmod	_	_
 14	skulle	skulle	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	18	aux	_	_
-15	man	man	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|PronType=Prs	18	nsubj	_	_
+15	man	man	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|PronType=Prs	18	nsubj:pass	_	_
 16	helst	helst	ADV	adv	_	18	advmod	_	_
 17	bli	bli	AUX	verb	VerbForm=Inf	18	aux:pass	_	_
 18	elsket	elske	VERB	verb	VerbForm=Part	3	conj	_	_
@@ -29577,7 +29577,7 @@
 2	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
-5	sosial	sosial	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+5	sosial	sosial	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	8	punct	_	_
 7	og	og	CCONJ	konj	_	8	cc	_	_
 8	liker	like	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	conj	_	_
@@ -29601,7 +29601,7 @@
 8	være	være	AUX	verb	VerbForm=Inf	9	cop	_	_
 9	åpne	åpen	ADJ	adj	Degree=Pos|Number=Plur	5	amod	_	_
 10	om	om	ADP	prep	_	12	case	_	_
-11	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	det	_	_
+11	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 12	liv	liv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	9	obl	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -29614,7 +29614,7 @@
 5	vet	vite	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	_	_
 7	om	om	ADP	prep	_	9	case	_	_
-8	hverandres	hverandres	PRON	det	Number=Plur|Poss=Yes|PronType=Rcp	9	det	_	_
+8	hverandres	hverandres	PRON	det	Number=Plur|Poss=Yes|PronType=Rcp	9	nmod:poss	_	_
 9	drømmer	drøm	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	obl	_	_
 10	og	og	CCONJ	konj	_	11	cc	_	_
 11	kjærlighetsliv	kjærlighetsliv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	conj	_	SpaceAfter=No
@@ -29662,7 +29662,7 @@
 # text = Men jentene mine er ærgjerrige og flinke, og det er godt å vite at hvis jeg blir truffet av lynet i morgen, så kommer det til å gå bra med Elle.
 1	Men	men	CCONJ	konj	_	5	cc	_	_
 2	jentene	jente	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	5	nsubj	_	_
-3	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	2	det	_	_
+3	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 5	ærgjerrige	ærgjerrig	ADJ	adj	Degree=Pos|Number=Plur	0	root	_	_
 6	og	og	CCONJ	konj	_	7	cc	_	_
@@ -29676,7 +29676,7 @@
 14	vite	vite	VERB	verb	VerbForm=Inf	12	csubj	_	_
 15	at	at	SCONJ	sbu	_	26	mark	_	_
 16	hvis	hvis	SCONJ	sbu	_	19	mark	_	_
-17	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	_	_
+17	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj:pass	_	_
 18	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux:pass	_	_
 19	truffet	treffe	VERB	verb	VerbForm=Part	26	advcl	_	_
 20	av	av	ADP	prep	_	21	case	_	_
@@ -29705,7 +29705,7 @@
 6	Signy	Signy	PROPN	subst	_	9	nsubj	_	_
 7	Fardal	Fardal	PROPN	subst	_	6	flat:name	_	_
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	_	_
-9	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	csubj	_	_
+9	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	csubj	_	_
 10	i	i	ADP	prep	_	12	case	_	_
 11	å	å	PART	inf-merke	_	12	mark	_	_
 12	shoppe	shoppe	VERB	verb	VerbForm=Inf	9	advcl	_	SpaceAfter=No
@@ -29799,10 +29799,10 @@
 1	-	$-	PUNCT	<strek>	_	7	punct	_	_
 2	Er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
 3	mannen	mann	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
-4	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	_
+4	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	_
 5	fortsatt	fortsatt	ADV	adv	_	6	advmod	_	_
 6	like	like	ADV	adv	_	7	advmod	_	_
-7	entusiastisk	entusiastisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+7	entusiastisk	entusiastisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 8	når	når	SCONJ	sbu	_	10	mark	_	_
 9	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	10	nsubj	_	_
 10	kommer	komme	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	advcl	_	_
@@ -29858,7 +29858,7 @@
 2	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 3	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	jo	jo	ADV	adv	_	3	advmod	_	_
-5	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+5	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 6	egen	egen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Prs	7	det	_	_
 7	økonomi	økonomi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	12	punct	_	_
@@ -29914,7 +29914,7 @@
 7	som	som	SCONJ	sbu	_	8	mark	_	_
 8	finnes	finnes	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	_	_
 9	i	i	ADP	prep	_	11	case	_	_
-10	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	samfunn	samfunn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	8	obl	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	19	punct	_	_
 13	som	som	SCONJ	sbu	_	19	mark	_	_
@@ -29922,13 +29922,13 @@
 15	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
 16	minst	liten	ADJ	adj	Definite=Ind|Degree=Sup	17	advmod	_	_
 17	like	like	ADV	adv	_	18	advmod	_	_
-18	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	fare	fare	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nmod	_	_
 20	for	for	ADP	prep	_	22	case	_	_
-21	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	22	det	_	_
+21	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	22	nmod:poss	_	_
 22	demokrati	demokrati	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	19	nmod	_	_
 23	og	og	CCONJ	konj	_	25	cc	_	_
-24	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	25	det	_	_
+24	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	25	nmod:poss	_	_
 25	medmennesker	medmenneske	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	22	conj	_	SpaceAfter=No
 26	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -29940,7 +29940,7 @@
 4	,	$,	PUNCT	<komma>	_	9	punct	_	_
 5	men	men	CCONJ	konj	_	9	cc	_	_
 6	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-7	jobben	jobb	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	_
+7	jobben	jobb	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	nsubj:pass	_	_
 8	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 9	gjøres	gjøre	VERB	verb	VerbForm=Inf|Voice=Pass	3	conj	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	9	punct	_	_
@@ -29964,7 +29964,7 @@
 12	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj	_	_
 13	besvarte	besvare	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	_	_
 14	ikke	ikke	PART	adv	Polarity=Neg	13	advmod	_	_
-15	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	16	det	_	_
+15	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	16	nmod:poss	_	_
 16	henvendelser	henvendelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	13	obj	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -29988,7 +29988,7 @@
 16	90-tallet	90-tall	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	10	obl	_	_
 17	igjen	igjen	ADV	adv	_	20	advmod	_	_
 18	i	i	ADP	prep	_	20	case	_	_
-19	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	amod	_	_
+19	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	amod	_	_
 20	sving	sving	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 21	.	$.	PUNCT	clb	_	20	punct	_	_
 
@@ -29997,7 +29997,7 @@
 1	I	i	ADP	prep	_	2	case	_	_
 2	helga	helg	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	7	obl	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
-4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	nsubj	_	_
+4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	nsubj:pass	_	_
 5	av	av	ADP	prep	_	6	case	_	_
 6	dem	de	PRON	pron	Case=Acc|Number=Plur|Person=3|PronType=Prs	4	nmod	_	_
 7	pågrepet	pågripe	VERB	verb	VerbForm=Part	0	root	_	_
@@ -30022,7 +30022,7 @@
 2	Vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	særlig	særlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
-5	bekymret	bekymre	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	25	ccomp	_	_
+5	bekymret	bekymre	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	25	ccomp	_	_
 6	for	for	ADP	prep	_	7	case	_	_
 7	enkeltpersoner	enkeltperson	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	obl	_	_
 8	som	som	SCONJ	sbu	_	9	mark	_	_
@@ -30030,7 +30030,7 @@
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
 11	kombinasjon	kombinasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obj	_	_
 12	av	av	ADP	prep	_	14	case	_	_
-13	nynazistisk	nynazistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	nynazistisk	nynazistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	bakgrunn	bakgrunn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 15	,	$,	PUNCT	<komma>	_	16	punct	_	_
 16	kontakt	kontakt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	conj	_	_
@@ -30057,8 +30057,8 @@
 7	mener	mene	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	imidlertid	imidlertid	ADV	adv	_	7	advmod	_	_
 9	at	at	SCONJ	sbu	_	14	mark	_	_
-10	deres	deres	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
-11	organisasjon	organisasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nsubj	_	_
+10	deres	deres	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
+11	organisasjon	organisasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nsubj:pass	_	_
 12	ikke	ikke	PART	adv	Polarity=Neg	14	advmod	_	_
 13	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	_	_
 14	koples	kople	VERB	verb	VerbForm=Inf|Voice=Pass	7	xcomp	_	_
@@ -30095,8 +30095,8 @@
 13	politiske	politisk	ADJ	adj	Degree=Pos|Number=Plur	14	amod	_	_
 14	partier	parti	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	10	nmod	_	_
 15	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	cop	_	_
-16	tilknyttet	tilknytte	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	5	amod	_	_
-17	deres	deres	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	18	det	_	_
+16	tilknyttet	tilknytte	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	5	amod	_	_
+17	deres	deres	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	18	nmod:poss	_	_
 18	organisasjon	organisasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	obj	_	SpaceAfter=No
 19	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -30180,7 +30180,7 @@
 23	at	at	SCONJ	sbu	_	29	mark	_	_
 24	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	26	det	_	_
 25	eventuelle	eventuell	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	26	amod	_	_
-26	volden	vold	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	29	nsubj	_	_
+26	volden	vold	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	29	nsubj:pass	_	_
 27	nødvendigvis	nødvendigvis	ADV	adv	_	29	advmod	_	_
 28	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	29	aux	_	_
 29	knyttes	knytte	VERB	verb	VerbForm=Inf|Voice=Pass	18	advcl	_	_
@@ -30197,7 +30197,7 @@
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
 6	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 7	av	av	ADP	prep	_	9	case	_	_
-8	deres	deres	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	det	_	_
+8	deres	deres	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 9	retorikk	retorikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nmod	_	SpaceAfter=No
 10	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -30254,7 +30254,7 @@
 8	uten	uten	ADP	prep	_	10	case	_	_
 9	å	å	PART	inf-merke	_	10	mark	_	_
 10	drive	drive	VERB	verb	VerbForm=Inf	7	advcl	_	_
-11	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	overvåking	overvåking	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	obj	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -30310,7 +30310,7 @@
 2	sjette	sjette	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing|NumType=Ord	3	amod	_	_
 3	bindet	bind	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	12	nsubj	_	_
 4	av	av	ADP	prep	_	9	case	_	_
-5	Karl	Karl	PROPN	subst	Gender=Masc	9	nmod	_	_
+5	Karl	Karl	PROPN	subst	Gender=Masc	9	nmod:poss	_	_
 6	Ove	Ove	PROPN	subst	Gender=Masc	5	flat:name	_	_
 7	Knausgårds	Knausgård	PROPN	subst	Case=Gen	5	flat:name	_	_
 8	«	$"	PUNCT	<anf>	_	9	punct	_	SpaceAfter=No
@@ -30340,11 +30340,11 @@
 6	øke	øke	VERB	verb	VerbForm=Inf	3	advcl	_	_
 7	bevisstheten	bevissthet	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	obj	_	_
 8	rundt	rundt	ADP	prep	_	10	case	_	_
-9	lingvistisk	lingvistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	lingvistisk	lingvistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	vold	vold	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	3	punct	_	_
 12	mener	mene	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-13	dansk	dansk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	dansk	dansk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	litteraturkritiker	litteraturkritiker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nsubj	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	12	punct	_	_
 
@@ -30363,10 +30363,10 @@
 3	Knausgård	Knausgård	PROPN	subst	_	1	flat:name	_	_
 4	gjør	gjøre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	omfattende	omfattende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	omfattende	omfattende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	lesning	lesning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 8	av	av	ADP	prep	_	12	case	_	_
-9	Adolf	Adolf	PROPN	subst	Gender=Masc	12	nmod	_	_
+9	Adolf	Adolf	PROPN	subst	Gender=Masc	12	nmod:poss	_	_
 10	Hitlers	Hitler	PROPN	subst	Case=Gen	9	flat:name	_	_
 11	«	$"	PUNCT	<anf>	_	12	punct	_	SpaceAfter=No
 12	Mein	Mein	PROPN	subst	_	7	nmod	_	_
@@ -30498,7 +30498,7 @@
 15	dreie	dreie	VERB	verb	VerbForm=Inf	3	conj	_	_
 16	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	15	obj	_	_
 17	om	om	ADP	prep	_	22	case	_	_
-18	Adolf	Adolf	PROPN	subst	Gender=Masc	22	nmod	_	_
+18	Adolf	Adolf	PROPN	subst	Gender=Masc	22	nmod:poss	_	_
 19	Hitlers	Hitler	PROPN	subst	Case=Gen	18	flat:name	_	_
 20	selvbiografiske	selvbiografisk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	22	amod	_	_
 21	ideologiske	ideologisk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	22	amod	_	_
@@ -30561,7 +30561,7 @@
 5	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 6	ført	føre	VERB	verb	VerbForm=Part	32	advcl	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	bevisst	bevisst	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	bevisst	bevisst	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
 10	om	om	ADP	prep	_	13	case	_	_
 11	ikke	ikke	PART	adv	Polarity=Neg	13	advmod	_	_
@@ -30617,13 +30617,13 @@
 3	om	om	ADP	prep	_	4	case	_	_
 4	sammenhengen	sammenheng	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 5	mellom	mellom	ADP	prep	_	9	case	_	_
-6	lingvistisk	lingvistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+6	lingvistisk	lingvistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 7	og	og	CCONJ	konj	_	8	cc	_	_
-8	fysisk	fysisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	conj	_	_
+8	fysisk	fysisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	conj	_	_
 9	vold	vold	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nmod	_	_
 10	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	_	_
 11	svært	svær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	12	advmod	_	_
-12	aktuell	aktuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+12	aktuell	aktuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	18	punct	_	_
 14	ikke	ikke	PART	adv	Polarity=Neg	15	advmod	_	_
 15	minst	liten	ADJ	adj	Definite=Ind|Degree=Sup	18	advmod	_	_
@@ -30640,7 +30640,7 @@
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	cop	_	_
 5	dessuten	dessuten	ADV	adv	_	18	advmod	_	_
 6	nylig	nylig	ADV	adv	_	18	advmod	_	_
-7	Victor	Victor	PROPN	subst	Gender=Fem	10	nmod	_	_
+7	Victor	Victor	PROPN	subst	Gender=Fem	10	nmod:poss	_	_
 8	Klemperers	Klemperer	PROPN	subst	Case=Gen	7	flat:name	_	_
 9	store	stor	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	10	amod	_	_
 10	verk	verk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	18	nsubj	_	_
@@ -30679,7 +30679,7 @@
 8	tvunget	tvinge	VERB	verb	VerbForm=Part	2	xcomp	_	_
 9	fram	fram	ADV	prep	_	8	advmod	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-11	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	aktualitet	aktualitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obj	_	_
 13	i	i	ADP	prep	_	14	case	_	_
 14	spørsmålet	spørsmål	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	8	obl	_	_
@@ -30727,7 +30727,7 @@
 10	til	til	ADP	prep	_	11	case	_	_
 11	orde	orde	NOUN	subst	_	9	obl	_	_
 12	uten	uten	ADP	prep	_	14	case	_	_
-13	redaksjonell	redaksjonell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	redaksjonell	redaksjonell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	innblanding	innblanding	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	obl	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	9	punct	_	_
 
@@ -30877,7 +30877,7 @@
 4	også	også	ADV	adv	_	2	advmod	_	_
 5	likhetene	likhet	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	2	obj	_	_
 6	mellom	mellom	ADP	prep	_	11	case	_	_
-7	Anders	Anders	PROPN	subst	Gender=Masc	11	nmod	_	_
+7	Anders	Anders	PROPN	subst	Gender=Masc	11	nmod:poss	_	_
 8	Behring	Behring	PROPN	subst	_	7	flat:name	_	_
 9	Breiviks	Breivik	PROPN	subst	Case=Gen	7	flat:name	_	_
 10	publiserte	publisere	ADJ	adj	Definite=Def|Number=Sing|VerbForm=Part	11	amod	_	_
@@ -30894,7 +30894,7 @@
 21	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	22	det	_	_
 22	påfallende	påfallende	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	5	conj	_	_
 23	ved	ved	ADP	prep	_	26	case	_	_
-24	Behring	Behring	PROPN	subst	_	26	nmod	_	_
+24	Behring	Behring	PROPN	subst	_	26	nmod:poss	_	_
 25	Breiviks	Breivik	PROPN	subst	Case=Gen	24	flat:name	_	_
 26	synspunkter	synspunkt	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	22	obl	_	_
 27	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	22	cop	_	_
@@ -30981,7 +30981,7 @@
 12	Kampf	Kampf	PROPN	subst	_	11	flat:name	_	SpaceAfter=No
 13	»	$"	PUNCT	<anf>	_	11	punct	_	_
 14	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
-15	dristig	dristig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	ccomp	_	SpaceAfter=No
+15	dristig	dristig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	ccomp	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 017449
@@ -31065,7 +31065,7 @@
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	2	det	_	_
 2	rekke	rekke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nmod	_	_
 3	etiske	etisk	ADJ	adj	Degree=Pos|Number=Plur	4	amod	_	_
-4	spørsmål	spørsmål	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nsubj	_	_
+4	spørsmål	spørsmål	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nsubj:pass	_	_
 5	virvles	virvle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	24	ccomp	_	_
 6	opp	opp	ADV	prep	_	5	advmod	_	_
 7	og	og	CCONJ	konj	_	9	cc	_	_
@@ -31073,7 +31073,7 @@
 9	gjør	gjøre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	conj	_	_
 10	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	expl	_	_
 11	i	i	ADP	prep	_	13	case	_	_
-12	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	grad	grad	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obl	_	_
 14	mulig	mulig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	xcomp	_	_
 15	å	å	PART	inf-merke	_	16	mark	_	_
@@ -31115,15 +31115,15 @@
 1	Forfatteren	forfatter	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 2	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	ccomp	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	formidabel	formidabel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	formidabel	formidabel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	evne	evne	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 6	til	til	ADP	prep	_	9	case	_	_
 7	å	å	PART	inf-merke	_	9	mark	_	_
 8	være	være	AUX	verb	VerbForm=Inf	9	cop	_	_
-9	reaksjonær	reaksjonær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+9	reaksjonær	reaksjonær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 10	og	og	CCONJ	konj	_	12	cc	_	_
 11	samtidig	samtidig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	12	advmod	_	_
-12	nyskapende	nyskapende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	conj	_	_
+12	nyskapende	nyskapende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	conj	_	_
 13	og	og	CCONJ	konj	_	14	cc	_	_
 14	bekjennende	bekjenne	ADJ	adj	VerbForm=Part	12	conj	_	SpaceAfter=No
 15	,	$,	PUNCT	<komma>	_	2	punct	_	_
@@ -31142,7 +31142,7 @@
 5	Hverven	Hverven	PROPN	subst	_	3	flat:name	_	_
 6	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
 7	mer	mye	ADJ	adj	Degree=Cmp	8	advmod	_	_
-8	skeptisk	skeptisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+8	skeptisk	skeptisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 9	til	til	ADP	prep	_	11	case	_	_
 10	å	å	PART	inf-merke	_	11	mark	_	_
 11	kople	kople	VERB	verb	VerbForm=Inf	8	advcl	_	_
@@ -31161,7 +31161,7 @@
 2	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	_
 3	finnes	finnes	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	33	ccomp	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	gruppering	gruppering	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nsubj	_	_
 7	i	i	ADP	prep	_	10	case	_	_
 8	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
@@ -31186,7 +31186,7 @@
 27	til	til	ADP	prep	_	28	case	_	_
 28	inntekt	inntekt	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	20	obl	_	_
 29	for	for	ADP	prep	_	31	case	_	_
-30	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	31	det	_	_
+30	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	31	nmod:poss	_	_
 31	meninger	mening	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	28	nmod	_	SpaceAfter=No
 32	,	$,	PUNCT	<komma>	_	3	punct	_	_
 33	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -31219,9 +31219,9 @@
 22	sider	side	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	20	nmod	_	_
 23	om	om	ADP	prep	_	28	case	_	_
 24	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	28	det	_	_
-25	tålmodig	tålmodig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	28	amod	_	_
+25	tålmodig	tålmodig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	28	amod	_	_
 26	og	og	CCONJ	konj	_	27	cc	_	_
-27	omsorgsfull	omsorgsfull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	conj	_	_
+27	omsorgsfull	omsorgsfull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	conj	_	_
 28	far	far	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	22	nmod	_	SpaceAfter=No
 29	.	$.	PUNCT	clb	_	19	punct	_	_
 
@@ -31260,7 +31260,7 @@
 9	rasende	rase	ADJ	adj	VerbForm=Part	10	amod	_	_
 10	attenhundretallsmannen	attenhundretallsmann	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
 11	i	i	ADP	prep	_	13	case	_	_
-12	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	13	det	_	_
+12	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 13	indre	indre	ADJ	adj	Degree=Cmp	10	amod	_	_
 14	som	som	SCONJ	sbu	_	16	mark	_	_
 15	alle	alle	PRON	pron	Number=Plur|Person=3|PronType=Prs,Tot	16	nsubj	_	_
@@ -31281,7 +31281,7 @@
 2	mener	mene	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	imidlertid	imidlertid	ADV	adv	_	2	advmod	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	nsubj	_	_
+5	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	nsubj:pass	_	_
 6	av	av	ADP	prep	_	7	case	_	_
 7	meningene	mening	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	5	nmod	_	_
 8	som	som	SCONJ	sbu	_	9	mark	_	_
@@ -31305,7 +31305,7 @@
 4	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	0	root	_	_
 5	å	å	PART	inf-merke	_	7	mark	_	_
 6	være	være	AUX	verb	VerbForm=Inf	7	cop	_	_
-7	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	csubj	_	_
+7	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	csubj	_	_
 8	over	over	ADP	prep	_	13	case	_	_
 9	at	at	SCONJ	sbu	_	13	mark	_	_
 10	Knausgårds	Knausgård	PROPN	subst	Case=Gen	11	nmod	_	_
@@ -31322,7 +31322,7 @@
 21	vunnet	vinne	VERB	verb	VerbForm=Part	18	acl:relcl	_	_
 22	fram	fram	ADV	prep	_	21	advmod	_	_
 23	i	i	ADP	prep	_	25	case	_	_
-24	bred	bred	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	bred	bred	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	offentlighet	offentlighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	21	obl	_	SpaceAfter=No
 26	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -31346,7 +31346,7 @@
 16	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	cop	_	_
 17	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	18	advmod	_	_
 18	kraftigere	kraftig	ADJ	adj	Degree=Cmp	19	advmod	_	_
-19	rettet	rette	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	2	advcl	_	_
+19	rettet	rette	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	2	advcl	_	_
 20	mot	mot	ADP	prep	_	23	case	_	_
 21	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
 22	svenske	svensk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	23	amod	_	_
@@ -31382,7 +31382,7 @@
 12	å	å	PART	inf-merke	_	15	mark	_	_
 13	være	være	AUX	verb	VerbForm=Inf	15	cop	_	_
 14	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	15	advmod	_	_
-15	frekk	frekk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	SpaceAfter=No
+15	frekk	frekk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	24	punct	_	_
 17	fordi	fordi	SCONJ	sbu	_	24	mark	_	_
 18	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
@@ -31391,7 +31391,7 @@
 21	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
 22	måte	måte	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	24	obl	_	_
 23	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	24	cop	_	_
-24	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	advcl	_	_
+24	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	advcl	_	_
 25	-	$-	PUNCT	<strek>	_	31	punct	_	_
 26	ikke	ikke	PART	adv	Polarity=Neg	27	advmod	_	_
 27	bare	bare	ADV	adv	_	31	advmod	_	_
@@ -31446,7 +31446,7 @@
 13	verket	verk	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	10	nmod	_	SpaceAfter=No
 14	,	$,	PUNCT	<komma>	_	20	punct	_	_
 15	at	at	SCONJ	sbu	_	20	mark	_	_
-16	tittelen	tittel	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	20	nsubj	_	_
+16	tittelen	tittel	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	20	nsubj:pass	_	_
 17	aldri	aldri	ADV	adv	_	20	advmod	_	_
 18	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	20	cop	_	_
 19	blitt	bli	AUX	verb	VerbForm=Part	20	aux:pass	_	_
@@ -31487,7 +31487,7 @@
 2	forlagssjef	forlagssjef	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj	_	_
 3	Berdahl	Berdahl	PROPN	subst	_	2	appos	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
-5	tilbakeholden	tilbakeholden	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+5	tilbakeholden	tilbakeholden	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 6	med	med	ADP	prep	_	8	case	_	_
 7	å	å	PART	inf-merke	_	8	mark	_	_
 8	røpe	røpe	VERB	verb	VerbForm=Inf	5	advcl	_	_
@@ -31718,7 +31718,7 @@
 6	ikke	ikke	PART	adv	Polarity=Neg	7	advmod	_	_
 7	svarer	svare	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	advcl	_	_
 8	på	på	ADP	prep	_	10	case	_	_
-9	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	det	_	_
+9	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	nmod:poss	_	_
 10	krav	krav	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	7	obl	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	7	punct	_	_
 12	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	_	_
@@ -31828,7 +31828,7 @@
 
 # sent_id = 017493
 # text = Brei front
-1	Brei	brei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Brei	brei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	front	front	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 
 # sent_id = 017494
@@ -31881,7 +31881,7 @@
 4	fram	fram	ADV	prep	_	3	advmod	_	_
 5	protestene	protest	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	3	obj	_	_
 6	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	bakgrunn	bakgrunn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
 9	i	i	ADP	prep	_	10	case	_	_
 10	studentforeninger	studentforening	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	6	xcomp	_	SpaceAfter=No
@@ -31922,7 +31922,7 @@
 1	Demonstrasjonene	demonstrasjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	2	nsubj	_	_
 2	foregikk	foregå	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	i	i	ADP	prep	_	5	case	_	_
-4	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	grad	grad	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	_
 6	fredfullt	fredfull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	2	advmod	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -31947,13 +31947,13 @@
 # text = Over 450 mennesker ble arrestert og et titall mennesker ble skadet.
 1	Over	over	ADP	prep	_	2	case	_	_
 2	450	450	NUM	det	Number=Plur|NumType=Card	3	nummod	_	_
-3	mennesker	menneske	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nsubj	_	_
+3	mennesker	menneske	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nsubj:pass	_	_
 4	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	arrestert	arrestere	VERB	verb	VerbForm=Part	0	root	_	_
 6	og	og	CCONJ	konj	_	11	cc	_	_
 7	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
 8	titall	titall	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	nmod	_	_
-9	mennesker	menneske	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	11	nsubj	_	_
+9	mennesker	menneske	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	11	nsubj:pass	_	_
 10	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	11	aux:pass	_	_
 11	skadet	skade	VERB	verb	VerbForm=Part	5	conj	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	5	punct	_	_
@@ -32046,13 +32046,13 @@
 22	av	av	ADP	prep	_	26	case	_	_
 23	hvilket	hvilken	DET	det	Gender=Neut|Number=Sing|PronType=Int	24	det	_	_
 24	universitet	universitet	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	26	obl	_	_
-25	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	26	nsubj	_	_
+25	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	26	nsubj:pass	_	_
 26	eksamineres	eksaminere	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	21	advcl	_	_
 27	fra	fra	ADP	prep	_	24	case	_	SpaceAfter=No
 28	,	$,	PUNCT	<komma>	_	33	punct	_	_
 29	enn	enn	ADP	prep	_	33	case	_	_
 30	av	av	ADP	prep	_	33	case	_	_
-31	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	33	det	_	_
+31	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	33	nmod:poss	_	_
 32	egen	egen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Prs	33	det	_	_
 33	innsats	innsats	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
 34	,	$,	PUNCT	<komma>	_	3	punct	_	_
@@ -32061,7 +32061,7 @@
 37	Navarrete	Navarrete	PROPN	subst	_	36	flat:name	_	SpaceAfter=No
 38	,	$,	PUNCT	<komma>	_	41	punct	_	_
 39	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	41	det	_	_
-40	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	41	amod	_	_
+40	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	41	amod	_	_
 41	analytiker	analytiker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	36	appos	_	_
 42	ved	ved	ADP	prep	_	43	case	_	_
 43	Universitet	Universitet	PROPN	subst	_	41	nmod	_	_
@@ -32072,7 +32072,7 @@
 # sent_id = 017505
 # text = Chiles utdanningssystem preges, på samme måte som det chilenske samfunnet for øvrig, av skyhøy ulikhet.
 1	Chiles	Chile	PROPN	subst	Case=Gen	2	nmod	_	_
-2	utdanningssystem	utdanningssystem	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	nsubj	_	_
+2	utdanningssystem	utdanningssystem	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	nsubj:pass	_	_
 3	preges	prege	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	7	punct	_	_
 5	på	på	ADP	prep	_	7	case	_	_
@@ -32086,18 +32086,18 @@
 13	øvrig	øvrig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	11	amod	_	SpaceAfter=No
 14	,	$,	PUNCT	<komma>	_	7	punct	_	_
 15	av	av	ADP	prep	_	17	case	_	_
-16	skyhøy	skyhøy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	skyhøy	skyhøy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	ulikhet	ulikhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 017506
 # text = Utdanning ble under Augusto Pinochet sitt diktatur på 1980-tallet i økende grad overlatt til private skoler og universiteter.
-1	Utdanning	utdanning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	13	nsubj	_	_
+1	Utdanning	utdanning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	13	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	aux:pass	_	_
 3	under	under	ADP	prep	_	7	case	_	_
 4	Augusto	Augusto	PROPN	subst	_	7	nmod	_	_
 5	Pinochet	Pinochet	PROPN	subst	_	4	flat:name	_	_
-6	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	_
+6	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 7	diktatur	diktatur	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	13	obl	_	_
 8	på	på	ADP	prep	_	9	case	_	_
 9	1980-tallet	1980-tall	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	13	obl	_	_
@@ -32148,7 +32148,7 @@
 # text = Bare 15 prosent av utdanningen blir finansiert av det offentlige og mange unge pådrar seg stor gjeld etter studietida.
 1	Bare	bare	ADV	adv	_	2	advmod	_	_
 2	15	15	NUM	det	Number=Plur|NumType=Card	3	nummod	_	_
-3	prosent	prosent	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	7	nsubj	_	_
+3	prosent	prosent	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	7	nsubj:pass	_	_
 4	av	av	ADP	prep	_	5	case	_	_
 5	utdanningen	utdanning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 6	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux:pass	_	_
@@ -32161,7 +32161,7 @@
 13	unge	ung	ADJ	adj	Degree=Pos|Number=Plur	14	nsubj	_	_
 14	pådrar	pådra	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	conj	_	_
 15	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	14	iobj	_	_
-16	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	gjeld	gjeld	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	14	obj	_	_
 18	etter	etter	ADP	prep	_	19	case	_	_
 19	studietida	studietid	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	17	nmod	_	SpaceAfter=No
@@ -32170,7 +32170,7 @@
 # sent_id = 017510
 # text = Ønsker ny grunnlov
 1	Ønsker	ønske	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	grunnlov	grunnlov	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	obj	_	_
 
 # sent_id = 017511
@@ -32192,7 +32192,7 @@
 5	som	som	SCONJ	sbu	_	6	mark	_	_
 6	krever	kreve	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	_	_
 7	at	at	SCONJ	sbu	_	9	mark	_	_
-8	grunnloven	grunnlov	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	_
+8	grunnloven	grunnlov	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	nsubj:pass	_	_
 9	endres	endre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	6	ccomp	_	_
 10	for	for	ADP	prep	_	12	case	_	_
 11	å	å	PART	inf-merke	_	12	mark	_	_
@@ -32227,7 +32227,7 @@
 7	på	på	ADP	prep	_	8	case	_	_
 8	plass	plass	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	xcomp	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-10	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	grunnlov	grunnlov	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	3	punct	_	_
 13	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -32255,7 +32255,7 @@
 # sent_id = 017515
 # text = En ny grunnlov vil etter demonstrantenes ønske skape rom for direkte demokrati ved å gi velgere mulighet til å delta i folkeavstemninger.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	grunnlov	grunnlov	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nsubj	_	_
 4	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 5	etter	etter	ADP	prep	_	7	case	_	_
@@ -32282,7 +32282,7 @@
 # text = - Kravet vårt handler om omfordeling av rikdommen som i dag er fordelt på bakgrunn av den institusjonelle arven fra Pinochets diktatur, sier Cuevas.
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
 2	Kravet	krav	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	4	nsubj	_	_
-3	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	2	det	_	_
+3	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 4	handler	handle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	24	ccomp	_	_
 5	om	om	ADP	prep	_	6	case	_	_
 6	omfordeling	omfordeling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	obl	_	_
@@ -32330,7 +32330,7 @@
 7	ta	ta	VERB	verb	VerbForm=Inf	3	xcomp	_	_
 8	ansvar	ansvar	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	7	obj	_	_
 9	for	for	ADP	prep	_	12	case	_	_
-10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	12	det	_	_
+10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 11	egen	egen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Prs	12	det	_	_
 12	eldrepolitikk	eldrepolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	15	punct	_	_
@@ -32346,13 +32346,13 @@
 23	i	i	ADP	prep	_	24	case	_	_
 24	arbeidet	arbeid	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	22	obl	_	_
 25	for	for	ADP	prep	_	27	case	_	_
-26	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	27	amod	_	_
+26	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	27	amod	_	_
 27	sykehjemsdekning	sykehjemsdekning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	24	nmod	_	SpaceAfter=No
 28	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 017520
 # text = Lei ansvarsfraskrivelse:
-1	Lei	lei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Lei	lei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	ansvarsfraskrivelse	ansvarsfraskrivelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 3	:	$:	PUNCT	clb	_	2	punct	_	_
 
@@ -32362,7 +32362,7 @@
 1	Aps	Ap	PROPN	subst	Abbr=Yes|Case=Gen	2	nmod	_	_
 2	partisekretær	partisekretær	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	lei	lei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	lei	lei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	av	av	ADP	prep	_	8	case	_	_
 6	at	at	SCONJ	sbu	_	8	mark	_	_
 7	Frp	Frp	PROPN	subst	Abbr=Yes	8	nsubj	_	_
@@ -32381,7 +32381,7 @@
 20	ta	ta	VERB	verb	VerbForm=Inf	16	xcomp	_	_
 21	ansvar	ansvar	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	20	obj	_	_
 22	for	for	ADP	prep	_	25	case	_	_
-23	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	25	det	_	_
+23	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	25	nmod:poss	_	_
 24	egen	egen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Prs	25	det	_	_
 25	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	20	obl	_	SpaceAfter=No
 26	.	$.	PUNCT	clb	_	4	punct	_	_
@@ -32391,7 +32391,7 @@
 1	Jan	Jan	PROPN	subst	Gender=Masc	3	nsubj	_	_
 2	Mayen	Mayen	PROPN	subst	_	1	flat:name	_	_
 3	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+4	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 5	egen	egen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Prs	6	det	_	_
 6	kontinentalsokkel	kontinentalsokkel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	10	punct	_	_
@@ -32433,7 +32433,7 @@
 10	og	og	CCONJ	konj	_	11	cc	_	_
 11	lov	lov	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	conj	_	_
 12	om	om	ADP	prep	_	14	case	_	_
-13	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	sone	sone	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	nmod	_	_
 15	gi	gi	VERB	verb	VerbForm=Inf	0	root	_	_
 16	hjemmel	hjemmel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obj	_	_
@@ -32450,7 +32450,7 @@
 27	opp	opp	ADV	prep	_	26	advmod	_	_
 28	til	til	ADP	prep	_	34	case	_	_
 29	at	at	SCONJ	sbu	_	34	mark	_	_
-30	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	34	nsubj	_	_
+30	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	34	nsubj:pass	_	_
 31	ikke	ikke	PART	adv	Polarity=Neg	34	advmod	_	_
 32	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	34	aux	_	_
 33	bli	bli	AUX	verb	VerbForm=Inf	34	aux:pass	_	_
@@ -32473,7 +32473,7 @@
 10	eller	eller	CCONJ	konj	_	15	cc	_	_
 11	på	på	ADP	prep	_	15	case	_	_
 12	at	at	SCONJ	sbu	_	15	mark	_	_
-13	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	rett	rett	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	nsubj	_	_
 15	får	få	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	conj	_	_
 16	anvendelse	anvendelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obj	_	_
@@ -32511,7 +32511,7 @@
 14	nr	nr.	NOUN	subst	Abbr=Yes	15	obl	_	_
 15	12	12	NUM	det	Number=Plur|NumType=Card	10	nmod	_	_
 16	om	om	ADP	prep	_	18	case	_	_
-17	vitenskapelig	vitenskapelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	vitenskapelig	vitenskapelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	utforsking	utforsking	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	nmod	_	_
 19	og	og	CCONJ	konj	_	20	cc	_	_
 20	undersøkelse	undersøkelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	conj	_	_
@@ -32573,7 +32573,7 @@
 7	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	20	aux:pass	_	_
 8	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
 9	administrative	administrativ	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	10	amod	_	_
-10	ansvar	ansvar	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	20	nsubj	_	_
+10	ansvar	ansvar	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	20	nsubj:pass	_	_
 11	for	for	ADP	prep	_	12	case	_	_
 12	øya	øy	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	10	nmod	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	18	punct	_	_
@@ -32635,13 +32635,13 @@
 # text = Stasjonssjefen har begrenset politimyndighet.
 1	Stasjonssjefen	stasjonssjef	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 2	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	begrenset	begrense	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	4	amod	_	_
+3	begrenset	begrense	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	4	amod	_	_
 4	politimyndighet	politimyndighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	obj	_	SpaceAfter=No
 5	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 017532
 # text = Eventuell bergverksdrift hører under Bergmesteren på Svalbard, jf forskrift 23 april 1976.
-1	Eventuell	eventuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Eventuell	eventuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	bergverksdrift	bergverksdrift	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	nsubj	_	_
 3	hører	høre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	ccomp	_	_
 4	under	under	ADP	prep	_	5	case	_	_
@@ -32726,7 +32726,7 @@
 17	,	$,	PUNCT	<komma>	_	18	punct	_	_
 18	turisme	turisme	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	conj	_	_
 19	og	og	CCONJ	konj	_	21	cc	_	_
-20	ymse	ymse	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	amod	_	_
+20	ymse	ymse	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	amod	_	_
 21	næringsvirksomhet	næringsvirksomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	conj	_	SpaceAfter=No
 22	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -32763,7 +32763,7 @@
 2	miljørelevante	miljørelevant	ADJ	adj	Degree=Pos|Number=Plur	3	amod	_	_
 3	regler	regel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	nsubj	_	_
 4	i	i	ADP	prep	_	6	case	_	_
-5	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	lov	lov	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nmod	_	_
 7	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 8	gjelde	gjelde	VERB	verb	VerbForm=Inf	0	root	_	_
@@ -32832,7 +32832,7 @@
 21	at	at	SCONJ	sbu	_	31	mark	_	_
 22	bestemmelsen	bestemmelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	31	nsubj	_	_
 23	gjennom	gjennom	ADP	prep	_	26	case	_	_
-24	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	26	det	_	_
+24	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	26	nmod:poss	_	_
 25	tredje	tredje	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing|NumType=Ord	26	amod	_	_
 26	ledd	ledd	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	31	obl	_	_
 27	(	$(	PUNCT	<parentes-beg>	_	28	punct	_	SpaceAfter=No
@@ -32840,7 +32840,7 @@
 29	)	$)	PUNCT	<parentes-slutt>	_	28	punct	_	_
 30	uttrykkelig	uttrykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	31	advmod	_	_
 31	rammer	ramme	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	acl	_	_
-32	betydelig	betydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	33	amod	_	_
+32	betydelig	betydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	33	amod	_	_
 33	skade	skade	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	31	obj	_	_
 34	på	på	ADP	prep	_	36	case	_	_
 35	eventuelle	eventuell	ADJ	adj	Degree=Pos|Number=Plur	36	amod	_	_
@@ -32951,7 +32951,7 @@
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	_	_
 9	fastsatt	fastsette	VERB	verb	VerbForm=Part	0	root	_	_
 10	i	i	ADP	prep	_	12	case	_	_
-11	midlertidig	midlertidig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	midlertidig	midlertidig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	forskrift	forskrift	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	obl	_	_
 13	28	28	NUM	det	Number=Plur|NumType=Card	14	nummod	_	_
 14	mai	mai	NOUN	subst	Gender=Masc	12	nmod	_	_
@@ -33065,7 +33065,7 @@
 6	,	$,	PUNCT	<komma>	_	7	punct	_	_
 7	oljevirksomhet	oljevirksomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	conj	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	10	punct	_	_
-9	industriell	industriell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	industriell	industriell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	virksomhet	virksomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	conj	_	_
 11	generelt	generell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	10	amod	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	13	punct	_	_
@@ -33185,7 +33185,7 @@
 # text = Regulært skal planene forelegges fylkesmannen minst ett år før iverksetting.
 1	Regulært	regulær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	4	advmod	_	_
 2	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
-3	planene	plan	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	4	nsubj	_	_
+3	planene	plan	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	4	nsubj:pass	_	_
 4	forelegges	forelegge	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 5	fylkesmannen	fylkesmann	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	obj	_	_
 6	minst	liten	ADJ	adj	Definite=Ind|Degree=Sup	7	advmod	_	_
@@ -33232,7 +33232,7 @@
 7	som	som	SCONJ	sbu	_	9	mark	_	_
 8	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 9	volde	volde	VERB	verb	VerbForm=Inf	6	acl:relcl	_	_
-10	omfattende	omfattende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	omfattende	omfattende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	forurensning	forurensning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	obj	_	_
 12	eller	eller	CCONJ	konj	_	13	cc	_	_
 13	skade	skade	VERB	verb	VerbForm=Inf	9	conj	_	_
@@ -33251,7 +33251,7 @@
 26	)	$)	PUNCT	<parentes-slutt>	_	22	punct	_	SpaceAfter=No
 27	,	$,	PUNCT	<komma>	_	31	punct	_	_
 28	og	og	CCONJ	konj	_	31	cc	_	_
-29	planene	plan	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	31	nsubj	_	_
+29	planene	plan	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	31	nsubj:pass	_	_
 30	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	31	aux	_	_
 31	påbys	påby	VERB	verb	VerbForm=Inf|Voice=Pass	3	conj	_	_
 32	endret	endre	VERB	verb	VerbForm=Part	31	ccomp	_	_
@@ -33276,7 +33276,7 @@
 9	dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	obl	_	_
 10	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	csubj	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-12	alminnelig	alminnelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	alminnelig	alminnelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	adgang	adgang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obj	_	_
 14	til	til	ADP	prep	_	16	case	_	_
 15	å	å	PART	inf-merke	_	16	mark	_	_
@@ -33310,7 +33310,7 @@
 22	,	$,	PUNCT	<komma>	_	28	punct	_	_
 23	og	og	CCONJ	konj	_	28	cc	_	_
 24	slike	slik	DET	det	Number=Plur|PronType=Dem	25	det	_	_
-25	pålegg	pålegg	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	28	nsubj	_	_
+25	pålegg	pålegg	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	28	nsubj:pass	_	_
 26	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	28	aux	_	_
 27	også	også	ADV	adv	_	28	advmod	_	_
 28	gis	gi	VERB	verb	VerbForm=Inf|Voice=Pass	3	conj	_	_
@@ -33337,7 +33337,7 @@
 7	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
 8	skje	skje	VERB	verb	VerbForm=Inf	0	root	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-10	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	opprydding	opprydding	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obj	_	_
 12	og	og	CCONJ	konj	_	13	cc	_	_
 13	tilbakeføring	tilbakeføring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	conj	_	_
@@ -33351,7 +33351,7 @@
 
 # sent_id = 017563
 # text = Det kan imidlertid dispenseres fra dette kravet (§ 7 første ledd).
-1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
+1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj:pass	_	_
 2	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	imidlertid	imidlertid	ADV	adv	_	4	advmod	_	_
 4	dispenseres	dispensere	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
@@ -33371,7 +33371,7 @@
 1	Forskriften	forskrift	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 2	oppstiller	oppstille	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	generell	generell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	generell	generell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	hensynsregel	hensynsregel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 6	for	for	ADP	prep	_	7	case	_	_
 7	omgang	omgang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nmod	_	_
@@ -33391,7 +33391,7 @@
 21	til	til	ADP	prep	_	22	case	_	_
 22	endring	endring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	20	obl	_	_
 23	eller	eller	CCONJ	konj	_	25	cc	_	_
-24	vesentlig	vesentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	vesentlig	vesentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	forurensning	forurensning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	22	conj	_	_
 26	av	av	ADP	prep	_	27	case	_	_
 27	grunnen	grunn	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	SpaceAfter=No
@@ -33413,9 +33413,9 @@
 43	og	og	CCONJ	konj	_	49	cc	_	_
 44	heller	heller	ADV	adv	_	45	advmod	_	_
 45	ikke	ikke	PART	adv	Polarity=Neg	49	nmod	_	_
-46	vesentlig	vesentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	49	amod	_	_
+46	vesentlig	vesentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	49	amod	_	_
 47	eller	eller	CCONJ	konj	_	48	cc	_	_
-48	unødig	unødig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	46	conj	_	_
+48	unødig	unødig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	46	conj	_	_
 49	skade	skade	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	25	conj	_	_
 50	på	på	ADP	prep	_	51	case	_	_
 51	plante-	plante-	NOUN	subst	_	49	nmod	_	_
@@ -33465,7 +33465,7 @@
 8	nr	nr.	NOUN	subst	Abbr=Yes	9	obl	_	_
 9	70	70	NUM	det	Number=Plur|NumType=Card	4	nmod	_	_
 10	gjort	gjøre	VERB	verb	VerbForm=Part	0	root	_	_
-11	gjeldende	gjeldende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	xcomp	_	_
+11	gjeldende	gjeldende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	xcomp	_	_
 12	for	for	ADP	prep	_	13	case	_	_
 13	Jan	Jan	PROPN	subst	Gender=Masc	11	obl	_	_
 14	Mayen	Mayen	PROPN	subst	_	13	flat:name	_	_
@@ -33560,14 +33560,14 @@
 2	vilt	vilt	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	xcomp	_	_
 3	regnes	regne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 4	viltlevende	viltlevende	ADJ	adj	Degree=Pos|Number=Plur	5	amod	_	_
-5	fugler	fugl	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	nsubj	_	SpaceAfter=No
+5	fugler	fugl	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	nsubj:pass	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	7	punct	_	_
 7	landpattedyr	landpattedyr	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	conj	_	_
 8	og	og	CCONJ	konj	_	9	cc	_	_
 9	sjøpattedyr	sjøpattedyr	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	conj	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	13	punct	_	_
 11	men	men	CCONJ	konj	_	13	cc	_	_
-12	smågnagere	smågnager	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	13	nsubj	_	_
+12	smågnagere	smågnager	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	13	nsubj:pass	_	_
 13	omfattes	omfatte	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	3	conj	_	_
 14	ikke	ikke	PART	adv	Polarity=Neg	13	advmod	_	_
 15	av	av	ADP	prep	_	16	case	_	_
@@ -33595,7 +33595,7 @@
 13	for	for	ADP	prep	_	14	case	_	_
 14	sjøpattedyr	sjøpattedyr	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	17	obl	_	_
 15	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux:pass	_	_
-16	forskriften	forskrift	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	17	nsubj	_	_
+16	forskriften	forskrift	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	17	nsubj:pass	_	_
 17	forvaltet	forvalte	VERB	verb	VerbForm=Part	2	conj	_	_
 18	av	av	ADP	prep	_	19	case	_	_
 19	Fiskeridepartementet	Fiskeridepartementet	PROPN	subst	_	17	obl	_	_
@@ -33622,7 +33622,7 @@
 11	både	både	CCONJ	konj	_	12	cc	_	_
 12	sjørøye	sjørøye	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	appos	_	_
 13	og	og	CCONJ	konj	_	15	cc	_	_
-14	stasjonær	stasjonær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	stasjonær	stasjonær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	røye	røye	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	12	conj	_	SpaceAfter=No
 16	)	$)	PUNCT	<parentes-slutt>	_	12	punct	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -33644,7 +33644,7 @@
 13	mellom	mellom	ADP	prep	_	14	case	_	_
 14	artene	art	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	12	nmod	_	_
 15	og	og	CCONJ	konj	_	17	cc	_	_
-16	deres	deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	17	det	_	_
+16	deres	deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
 17	naturgrunnlag	naturgrunnlag	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	14	conj	_	_
 18	og	og	CCONJ	konj	_	20	cc	_	_
 19	mellom	mellom	ADP	prep	_	20	case	_	_
@@ -33663,7 +33663,7 @@
 32	regulere	regulere	VERB	verb	VerbForm=Inf	6	conj	_	_
 33	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	36	det	_	_
 34	økologisk	økologisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	35	advmod	_	_
-35	forsvarlig	forsvarlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	36	amod	_	_
+35	forsvarlig	forsvarlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	36	amod	_	_
 36	høsting	høsting	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	32	obj	_	_
 37	av	av	ADP	prep	_	38	case	_	_
 38	vilt	vilt	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	36	nmod	_	_
@@ -33691,7 +33691,7 @@
 12	fangst	fangst	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	conj	_	_
 13	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
 14	bare	bare	ADV	adv	_	15	advmod	_	_
-15	lovlig	lovlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	conj	_	_
+15	lovlig	lovlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	conj	_	_
 16	innen	innen	ADP	prep	_	18	case	_	_
 17	de	de	DET	det	Number=Plur|PronType=Art	18	det	_	_
 18	jakttider	jakttid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	15	obl	_	_
@@ -33724,7 +33724,7 @@
 13	forekommer	forekomme	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	acl:relcl	_	SpaceAfter=No
 14	)	$)	PUNCT	<parentes-slutt>	_	13	punct	_	_
 15	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	cop	_	_
-16	totalfredet	totalfrede	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	SpaceAfter=No
+16	totalfredet	totalfrede	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	16	punct	_	_
 
 # sent_id = 017576
@@ -33738,7 +33738,7 @@
 7	nødstilstand	nødstilstand	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 8	eller	eller	CCONJ	konj	_	11	cc	_	_
 9	med	med	ADP	prep	_	11	case	_	_
-10	særskilt	særskilt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	særskilt	særskilt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	tillatelse	tillatelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	conj	_	_
 12	for	for	ADP	prep	_	14	case	_	_
 13	å	å	PART	inf-merke	_	14	mark	_	_
@@ -33748,7 +33748,7 @@
 17	folk	folk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	15	nmod	_	_
 18	eller	eller	CCONJ	konj	_	21	cc	_	_
 19	annen	annen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Dem	21	det	_	_
-20	vesentlig	vesentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	amod	_	_
+20	vesentlig	vesentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	amod	_	_
 21	skade	skade	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	conj	_	_
 22	(	$(	PUNCT	<parentes-beg>	_	23	punct	_	SpaceAfter=No
 23	§	§	NOUN	subst	_	5	parataxis	_	_
@@ -33972,7 +33972,7 @@
 1	Bestemmelsen	bestemmelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 2	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	vært	være	AUX	verb	VerbForm=Part	4	cop	_	_
-4	aktuell	aktuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	aktuell	aktuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	med	med	ADP	prep	_	6	case	_	_
 6	tanke	tanke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 7	på	på	ADP	prep	_	8	case	_	_
@@ -33996,7 +33996,7 @@
 11	men	men	CCONJ	konj	_	16	cc	_	_
 12	utførselsforbudet	utførselsforbud	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	16	nsubj	_	_
 13	for	for	ADP	prep	_	15	case	_	_
-14	levende	levende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	levende	levende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	rev	rev	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nmod	_	_
 16	står	stå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	_	_
 17	ved	ved	ADP	prep	_	18	case	_	_
@@ -34018,7 +34018,7 @@
 33	om	om	ADP	prep	_	34	case	_	_
 34	utførselsforbud	utførselsforbud	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	27	nmod	_	_
 35	for	for	ADP	prep	_	37	case	_	_
-36	levende	levende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	37	amod	_	_
+36	levende	levende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	37	amod	_	_
 37	rev	rev	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	34	nmod	_	SpaceAfter=No
 38	,	$,	PUNCT	<komma>	_	39	punct	_	_
 39	skogmår	skogmår	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	37	conj	_	_
@@ -34115,7 +34115,7 @@
 # text = Nyere tekniske kulturminner og steder som historiske hendelser knytter seg til, kan fredes av Riksantikvaren med hjemmel i § 3.
 1	Nyere	ny	ADJ	adj	Degree=Cmp	3	amod	_	_
 2	tekniske	teknisk	ADJ	adj	Degree=Pos|Number=Plur	3	amod	_	_
-3	kulturminner	kulturminne	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	14	nsubj	_	_
+3	kulturminner	kulturminne	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	14	nsubj:pass	_	_
 4	og	og	CCONJ	konj	_	5	cc	_	_
 5	steder	sted	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	3	conj	_	_
 6	som	som	SCONJ	sbu	_	9	mark	_	_
@@ -34139,7 +34139,7 @@
 # sent_id = 017592
 # text = For ny virksomhet gjelder en undersøkelses- og tiltaksplikt for å hindre at fredet fast kulturminne blir skadet (§ 6), og hvis et kulturminne kan bli berørt, kreves det vedtak av fylkesmannen for at arbeidet kan fortsette (§ 5).
 1	For	for	ADP	prep	_	3	case	_	_
-2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	virksomhet	virksomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	obl	_	_
 4	gjelder	gjelde	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
@@ -34152,7 +34152,7 @@
 12	at	at	SCONJ	sbu	_	17	mark	_	_
 13	fredet	frede	ADJ	adj	Definite=Ind|Gender=Neut|Number=Sing|VerbForm=Part	15	amod	_	_
 14	fast	fast	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	15	amod	_	_
-15	kulturminne	kulturminne	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	17	nsubj	_	_
+15	kulturminne	kulturminne	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	17	nsubj:pass	_	_
 16	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux:pass	_	_
 17	skadet	skade	VERB	verb	VerbForm=Part	11	xcomp	_	_
 18	(	$(	PUNCT	<parentes-beg>	_	19	punct	_	SpaceAfter=No
@@ -34163,7 +34163,7 @@
 23	og	og	CCONJ	konj	_	31	cc	_	_
 24	hvis	hvis	SCONJ	sbu	_	29	mark	_	_
 25	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	26	det	_	_
-26	kulturminne	kulturminne	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	29	nsubj	_	_
+26	kulturminne	kulturminne	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	29	nsubj:pass	_	_
 27	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	29	aux	_	_
 28	bli	bli	AUX	verb	VerbForm=Inf	29	aux:pass	_	_
 29	berørt	berøre	VERB	verb	VerbForm=Part	31	advcl	_	SpaceAfter=No
@@ -34186,7 +34186,7 @@
 
 # sent_id = 017593
 # text = Funn av løse kulturminner fra før 1900 skal meldes til fylkesmannen og er statens eiendom hvis det ikke er rimelig håp om å finne eieren (§ 9), og Riksantikvaren kan i medfør av § 10 frede også yngre kulturminner.
-1	Funn	funn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	nsubj	_	_
+1	Funn	funn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	nsubj:pass	_	_
 2	av	av	ADP	prep	_	4	case	_	_
 3	løse	løs	ADJ	adj	Degree=Pos|Number=Plur	4	amod	_	_
 4	kulturminner	kulturminne	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	1	nmod	_	_
@@ -34233,7 +34233,7 @@
 # sent_id = 017594
 # text = Fredete kulturminner må ikke tas med ut av riket (§ 11), men det er ikke noe forbud mot å ta kulturminner fra Jan Mayen med til Svalbard eller fastlandet.
 1	Fredete	frede	ADJ	adj	Number=Plur|VerbForm=Part	2	amod	_	_
-2	kulturminner	kulturminne	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nsubj	_	_
+2	kulturminner	kulturminne	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nsubj:pass	_	_
 3	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 4	ikke	ikke	PART	adv	Polarity=Neg	5	advmod	_	_
 5	tas	ta	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
@@ -34340,7 +34340,7 @@
 11	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux	_	_
 12	også	også	ADV	adv	_	13	advmod	_	_
 13	gjøres	gjøre	VERB	verb	VerbForm=Inf|Voice=Pass	2	conj	_	_
-14	gjeldende	gjeldende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	xcomp	_	_
+14	gjeldende	gjeldende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	xcomp	_	_
 15	for	for	ADP	prep	_	17	case	_	_
 16	annen	annen	DET	det	Definite=Ind|Gender=Fem|Number=Sing|PronType=Dem	17	det	_	_
 17	virksomhet	virksomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	13	obl	_	_
@@ -34351,7 +34351,7 @@
 
 # sent_id = 017598
 # text = Reguleringer herunder fredning og kvotebegrensninger kan vedtas med hjemmel i § 4 med virkning for både norske og utenlandske fartøyer (jf § 1 fjerde ledd).
-1	Reguleringer	regulering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	7	nsubj	_	_
+1	Reguleringer	regulering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	7	nsubj:pass	_	_
 2	herunder	herunder	ADP	prep	_	3	case	_	_
 3	fredning	fredning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	1	nmod	_	_
 4	og	og	CCONJ	konj	_	5	cc	_	_
@@ -34408,7 +34408,7 @@
 24	av	av	ADP	prep	_	25	case	_	_
 25	avtale	avtale	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	23	nmod	_	_
 26	med	med	ADP	prep	_	28	case	_	_
-27	vedkommende	vedkommende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	28	amod	_	_
+27	vedkommende	vedkommende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	28	amod	_	_
 28	stat	stat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	25	nmod	_	_
 29	(	$(	PUNCT	<parentes-beg>	_	30	punct	_	SpaceAfter=No
 30	jf	jf.	VERB	verb	Abbr=Yes|Mood=Ind|Tense=Pres|VerbForm=Fin	2	parataxis	_	_
@@ -34507,10 +34507,10 @@
 5	å	å	PART	inf-merke	_	6	mark	_	_
 6	gjelde	gjelde	VERB	verb	VerbForm=Inf	4	xcomp	_	_
 7	for	for	ADP	prep	_	9	case	_	_
-8	bentisk	bentisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	bentisk	bentisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	fauna	fauna	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obl	_	_
 10	og	og	CCONJ	konj	_	12	cc	_	_
-11	marin	marin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	marin	marin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	vegetasjon	vegetasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	conj	_	_
 13	generelt	generell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	12	amod	_	SpaceAfter=No
 14	,	$,	PUNCT	<komma>	_	19	punct	_	_
@@ -34626,20 +34626,20 @@
 3	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	Jan	Jan	PROPN	subst	Gender=Masc	3	nsubj	_	_
 5	Mayen	Mayen	PROPN	subst	_	4	flat:name	_	_
-6	betydelig	betydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	betydelig	betydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	interesse	interesse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 017609
 # text = Mesteparten av øya må sies å være upåvirket av mennesker på annen måte enn gjennom langtransport av stoffer, og også denne påvirkningen er begrenset.
-1	Mesteparten	mestepart	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
+1	Mesteparten	mestepart	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj:pass	_	_
 2	av	av	ADP	prep	_	3	case	_	_
 3	øya	øy	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	_
 4	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 5	sies	si	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 6	å	å	PART	inf-merke	_	8	mark	_	_
 7	være	være	AUX	verb	VerbForm=Inf	8	cop	_	_
-8	upåvirket	upåvirket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	xcomp	_	_
+8	upåvirket	upåvirket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	xcomp	_	_
 9	av	av	ADP	prep	_	10	case	_	_
 10	mennesker	menneske	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	8	obl	_	_
 11	på	på	ADP	prep	_	13	case	_	_
@@ -34656,7 +34656,7 @@
 22	denne	denne	DET	det	Gender=Masc|Number=Sing|PronType=Dem	23	det	_	_
 23	påvirkningen	påvirkning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	25	nsubj	_	_
 24	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	25	cop	_	_
-25	begrenset	begrenset	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	SpaceAfter=No
+25	begrenset	begrenset	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	SpaceAfter=No
 26	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 017610
@@ -34665,7 +34665,7 @@
 2	geologiske	geologisk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	3	amod	_	_
 3	bakgrunnen	bakgrunn	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
-5	unik	unik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+5	unik	unik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 6	for	for	ADP	prep	_	7	case	_	_
 7	Norge	Norge	PROPN	subst	_	5	obl	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	11	punct	_	_
@@ -34709,7 +34709,7 @@
 8	i	i	ADP	prep	_	9	case	_	_
 9	praksis	praksis	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obl	_	_
 10	meget	meget	ADV	adv	_	11	advmod	_	_
-11	begrenset	begrenset	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+11	begrenset	begrenset	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	16	punct	_	_
 13	med	med	ADP	prep	_	16	case	_	_
 14	ca	ca.	ADV	adv	Abbr=Yes	15	advmod	_	_
@@ -34748,7 +34748,7 @@
 12	ofte	ofte	ADJ	adj	Degree=Pos	15	advmod	_	_
 13	være	være	AUX	verb	VerbForm=Inf	15	cop	_	_
 14	meget	meget	ADV	adv	_	15	advmod	_	_
-15	farefull	farefull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	_
+15	farefull	farefull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	_
 16	(	$(	PUNCT	<parentes-beg>	_	17	punct	_	SpaceAfter=No
 17	jf	jf.	VERB	verb	Abbr=Yes|Mood=Ind|Tense=Pres|VerbForm=Fin	5	parataxis	_	_
 18	saksforholdet	saksforhold	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	17	obj	_	_
@@ -34786,7 +34786,7 @@
 17	dem	de	PRON	pron	Case=Acc|Number=Plur|Person=3|PronType=Prs	15	obl	_	_
 18	som	som	SCONJ	sbu	_	19	mark	_	_
 19	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	acl:relcl	_	_
-20	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	21	det	_	_
+20	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	21	nmod:poss	_	_
 21	arbeid	arbeid	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	19	obj	_	_
 22	på	på	ADP	prep	_	23	case	_	_
 23	Jan	Jan	PROPN	subst	Gender=Masc	19	obl	_	_
@@ -34839,7 +34839,7 @@
 2	Svalbard	Svalbard	PROPN	subst	_	3	obl	_	_
 3	drives	drive	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 4	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	_
-5	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	næringsvirksomhet	næringsvirksomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obj	_	_
 7	i	i	ADP	prep	_	8	case	_	_
 8	familiesamfunn	familiesamfunn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	3	obl	_	SpaceAfter=No
@@ -34855,7 +34855,7 @@
 18	hundre	hundre	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	19	nmod	_	_
 19	ganger	gang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	20	obl	_	_
 20	så	så	ADV	adv	_	21	advmod	_	_
-21	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	conj	_	_
+21	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	conj	_	_
 22	som	som	ADP	prep	_	24	case	_	_
 23	på	på	ADP	prep	_	24	case	_	_
 24	Jan	Jan	PROPN	subst	Gender=Masc	20	obl	_	_
@@ -34871,12 +34871,12 @@
 5	norske	norsk	ADJ	adj	Degree=Pos|Number=Plur	6	amod	_	_
 6	myndigheter	myndighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	7	nsubj	_	_
 7	holde	holde	VERB	verb	VerbForm=Inf	0	root	_	_
-8	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	kontroll	kontroll	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	_
 10	med	med	ADP	prep	_	11	case	_	_
 11	oppstarting	oppstarting	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	nmod	_	_
 12	av	av	ADP	prep	_	14	case	_	_
-13	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	aktivitet	aktivitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 15	,	$,	PUNCT	<komma>	_	18	punct	_	_
 16	mens	mens	SCONJ	sbu	_	18	mark	_	_
@@ -34897,7 +34897,7 @@
 5	forhold	forhold	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	13	nsubj	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	9	punct	_	_
 7	og	og	CCONJ	konj	_	9	cc	_	_
-8	begrenset	begrenset	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	begrenset	begrenset	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	tilgang	tilgang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	conj	_	_
 10	til	til	ADP	prep	_	11	case	_	_
 11	ferskvann	ferskvann	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	nmod	_	SpaceAfter=No
@@ -34912,7 +34912,7 @@
 20	mindre	liten	ADJ	adj	Degree=Cmp	21	advmod	_	_
 21	egnet	egnet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	13	ccomp	_	_
 22	for	for	ADP	prep	_	24	case	_	_
-23	fast	fast	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	24	amod	_	_
+23	fast	fast	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	24	amod	_	_
 24	bosetting	bosetting	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	21	obl	_	_
 25	enn	enn	ADP	prep	_	26	case	_	_
 26	Svalbard	Svalbard	PROPN	subst	_	20	obl	_	SpaceAfter=No
@@ -34938,12 +34938,12 @@
 16	,	$,	PUNCT	<komma>	_	27	punct	_	_
 17	og	og	CCONJ	konj	_	27	cc	_	_
 18	at	at	SCONJ	sbu	_	27	mark	_	_
-19	nødvendig	nødvendig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	amod	_	_
+19	nødvendig	nødvendig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	amod	_	_
 20	styring	styring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	27	nsubj	_	_
 21	med	med	ADP	prep	_	25	case	_	_
 22	den	den	DET	det	Gender=Fem|Number=Sing|PronType=Art	25	det	_	_
 23	eksisterende	eksistere	ADJ	adj	VerbForm=Part	25	amod	_	_
-24	statlig	statlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	statlig	statlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	virksomhet	virksomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	20	nmod	_	_
 26	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	27	aux	_	_
 27	skje	skje	VERB	verb	VerbForm=Inf	13	conj	_	_
@@ -35000,7 +35000,7 @@
 5	i	i	ADP	prep	_	6	case	_	_
 6	retten	rett	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	8	punct	_	_
-8	tiltalt	tiltale	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	2	xcomp	_	_
+8	tiltalt	tiltale	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	2	xcomp	_	_
 9	for	for	ADP	prep	_	12	case	_	_
 10	å	å	PART	inf-merke	_	12	mark	_	_
 11	ha	ha	AUX	verb	VerbForm=Inf	12	aux	_	_
@@ -35054,7 +35054,7 @@
 17	Storbritannia	Storbritannia	PROPN	subst	_	15	nmod	_	SpaceAfter=No
 18	,	$,	PUNCT	<komma>	_	3	punct	_	_
 19	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	20	cop	_	_
-20	ansatt	ansatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+20	ansatt	ansatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 21	om	om	ADP	prep	_	22	case	_	_
 22	bord	bord	NOUN	subst	_	20	obl	_	_
 23	på	på	ADP	prep	_	24	case	_	_
@@ -35063,12 +35063,12 @@
 
 # sent_id = 017626
 # text = Min klient stiller seg fullstendig uforstående til tiltalen.
-1	Min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	2	det	_	_
+1	Min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 2	klient	klient	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nsubj	_	_
 3	stiller	stille	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	3	obj	_	_
 5	fullstendig	fullstendig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
-6	uforstående	uforstående	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	xcomp	_	_
+6	uforstående	uforstående	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	xcomp	_	_
 7	til	til	ADP	prep	_	8	case	_	_
 8	tiltalen	tiltale	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -35169,7 +35169,7 @@
 15	inn	inn	ADP	prep	_	17	case	_	_
 16	på	på	ADP	prep	_	17	case	_	_
 17	lugaren	lugar	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
-18	hennes	hennes	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	det	_	_
+18	hennes	hennes	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
 19	og	og	CCONJ	konj	_	20	cc	_	_
 20	voldtok	voldta	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	14	conj	_	_
 21	henne	hun	PRON	pron	Animacy=Hum|Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	20	obj	_	SpaceAfter=No
@@ -35177,7 +35177,7 @@
 
 # sent_id = 017632
 # text = Han ble ikke lenge etter pågrepet, og har siden sittet varetektsfengslet, sier statsadvokat Jogeir Nogva, som skal være aktor i rettssaka mot mannen.
-1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
+1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 3	ikke	ikke	PART	adv	Polarity=Neg	4	advmod	_	_
 4	lenge	lenge	ADJ	adj	Degree=Pos	6	advmod	_	_
@@ -35188,7 +35188,7 @@
 9	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	_	_
 10	siden	siden	ADV	adv	_	11	advmod	_	_
 11	sittet	sitte	VERB	verb	VerbForm=Part	6	conj	_	_
-12	varetektsfengslet	varetektsfengsle	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	11	xcomp	_	SpaceAfter=No
+12	varetektsfengslet	varetektsfengsle	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	11	xcomp	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	11	punct	_	_
 14	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 15	statsadvokat	statsadvokat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nsubj	_	_
@@ -35235,7 +35235,7 @@
 6	og	og	CCONJ	konj	_	7	cc	_	_
 7	fornærmede	fornærmet	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	5	conj	_	_
 8	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	acl	_	_
-9	ulik	ulik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	ulik	ulik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	nasjonalitet	nasjonalitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obj	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	2	punct	_	_
 12	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	_	_
@@ -35361,7 +35361,7 @@
 
 # sent_id = 017641
 # text = Aktiv verdiskapningspolitikk for distriktene
-1	Aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	verdiskapningspolitikk	verdiskapningspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 3	for	for	ADP	prep	_	4	case	_	_
 4	distriktene	distrikt	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	2	nmod	_	_
@@ -35393,7 +35393,7 @@
 # text = Fremveksten til norsk havbruksnæring er et godt eksempel på hvordan privat initiativ har utviklet sterke bedrifter og næringer.
 1	Fremveksten	fremvekst	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
 2	til	til	ADP	prep	_	4	case	_	_
-3	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	havbruksnæring	havbruksnæring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	1	nmod	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
 6	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
@@ -35418,7 +35418,7 @@
 3	tid	tid	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obl	_	_
 4	med	med	ADP	prep	_	7	case	_	_
 5	økende	øke	ADJ	adj	VerbForm=Part	7	amod	_	_
-6	internasjonal	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	internasjonal	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	konkurranse	konkurranse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nmod	_	_
 8	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	_	_
 9	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	expl	_	_
@@ -35427,7 +35427,7 @@
 12	for	for	ADP	prep	_	17	case	_	_
 13	at	at	SCONJ	sbu	_	17	mark	_	_
 14	nye	ny	ADJ	adj	Degree=Pos|Number=Plur	15	amod	_	_
-15	ideer	idé	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	17	nsubj	_	_
+15	ideer	idé	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	17	nsubj:pass	_	_
 16	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux:pass	_	_
 17	omdannet	omdanne	VERB	verb	VerbForm=Part	11	acl	_	_
 18	til	til	ADP	prep	_	20	case	_	_
@@ -35466,7 +35466,7 @@
 # text = Fremskrittspartiet mener dette best kan gjøres ved at marine og maritime næringer i større grad gis rammevilkår på linje med ordinære næringer og at det skilles mellom nærings- og distriktspolitikk.
 1	Fremskrittspartiet	Fremskrittspartiet	PROPN	subst	Gender=Neut	2	nsubj	_	_
 2	mener	mene	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
+3	dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj:pass	_	_
 4	best	god	ADJ	adj	Definite=Ind|Degree=Sup	6	advmod	_	_
 5	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 6	gjøres	gjøre	VERB	verb	VerbForm=Inf|Voice=Pass	2	xcomp	_	_
@@ -35475,7 +35475,7 @@
 9	marine	marin	ADJ	adj	Degree=Pos|Number=Plur	12	amod	_	_
 10	og	og	CCONJ	konj	_	11	cc	_	_
 11	maritime	maritim	ADJ	adj	Degree=Pos|Number=Plur	9	conj	_	_
-12	næringer	næring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	16	nsubj	_	_
+12	næringer	næring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	16	nsubj:pass	_	_
 13	i	i	ADP	prep	_	15	case	_	_
 14	større	stor	ADJ	adj	Degree=Cmp	15	amod	_	_
 15	grad	grad	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	obl	_	_
@@ -35510,9 +35510,9 @@
 10	å	å	PART	inf-merke	_	11	mark	_	_
 11	skape	skape	VERB	verb	VerbForm=Inf	7	xcomp	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
-13	robust	robust	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+13	robust	robust	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 14	og	og	CCONJ	konj	_	15	cc	_	_
-15	konkurransedyktig	konkurransedyktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	conj	_	_
+15	konkurransedyktig	konkurransedyktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	conj	_	_
 16	næring	næring	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obj	_	SpaceAfter=No
 17	,	$,	PUNCT	<komma>	_	7	punct	_	_
 18	så	så	ADV	adv	_	21	advmod	_	_
@@ -35521,7 +35521,7 @@
 21	gi	gi	VERB	verb	VerbForm=Inf	0	root	_	_
 22	som	som	ADP	prep	_	23	case	_	_
 23	resultat	resultat	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	21	xcomp	_	_
-24	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	vekst	vekst	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	21	obj	_	SpaceAfter=No
 26	,	$,	PUNCT	<komma>	_	28	punct	_	_
 27	nye	ny	ADJ	adj	Degree=Pos|Number=Plur	28	amod	_	_
@@ -35537,7 +35537,7 @@
 1	Dagens	dag	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 2	distriktspolitikk	distriktspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	feilslått	feilslått	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	feilslått	feilslått	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	ved	ved	ADP	prep	_	9	case	_	_
 6	at	at	SCONJ	sbu	_	9	mark	_	_
 7	man	man	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|PronType=Prs	9	nsubj	_	_
@@ -35551,7 +35551,7 @@
 15	markedene	marked	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	13	conj	_	_
 16	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	cop	_	_
 17	i	i	ADP	prep	_	19	case	_	_
-18	stadig	stadig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	stadig	stadig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	endring	endring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	nmod	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -35567,7 +35567,7 @@
 8	skape	skape	VERB	verb	VerbForm=Inf	0	root	_	_
 9	grunnlag	grunnlag	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	8	obj	_	_
 10	for	for	ADP	prep	_	12	case	_	_
-11	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	vekst	vekst	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nmod	_	_
 13	i	i	ADP	prep	_	15	case	_	_
 14	mange	mange	ADJ	adj	Degree=Pos|Number=Plur	15	amod	_	_
@@ -35645,7 +35645,7 @@
 12	som	som	SCONJ	sbu	_	13	mark	_	_
 13	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	acl:relcl	_	_
 14	at	at	SCONJ	sbu	_	18	mark	_	_
-15	Tafjordfjella	Tafjordfjella	PROPN	subst	_	18	nsubj	_	_
+15	Tafjordfjella	Tafjordfjella	PROPN	subst	_	18	nsubj:pass	_	_
 16	ikke	ikke	PART	adv	Polarity=Neg	18	advmod	_	_
 17	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	aux	_	_
 18	røres	røre	VERB	verb	VerbForm=Inf|Voice=Pass	13	xcomp	_	SpaceAfter=No
@@ -35669,7 +35669,7 @@
 3	daglig	daglig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	2	advmod	_	_
 4	at	at	SCONJ	sbu	_	7	mark	_	_
 5	bygda	bygd	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	7	nsubj	_	_
-6	vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+6	vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 7	dør	dø	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	_	_
 8	mer	mye	ADJ	adj	Degree=Cmp	11	advmod	_	_
 9	og	og	CCONJ	konj	_	10	cc	_	_
@@ -35700,7 +35700,7 @@
 6	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 7	Tafjordbygda	Tafjordbygda	PROPN	subst	_	9	nsubj	_	_
 8	være	være	AUX	verb	VerbForm=Inf	9	cop	_	_
-9	fraflyttet	fraflytte	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	_
+9	fraflyttet	fraflytte	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	_
 10	innen	innen	ADP	prep	_	12	case	_	_
 11	få	få	ADJ	adj	Degree=Pos|Number=Plur	12	amod	_	_
 12	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	9	obl	_	SpaceAfter=No
@@ -36061,7 +36061,7 @@
 # sent_id = 017676
 # text = En helårsvei mellom Tafjord og Grotli kan stort sett legges i tunnel, og det trenger ikke ødelegge opplevelsene for dem som tar seg en tur i Tafjordfjella noen ganger i året.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	2	det	_	_
-2	helårsvei	helårsvei	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nsubj	_	_
+2	helårsvei	helårsvei	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nsubj:pass	_	_
 3	mellom	mellom	ADP	prep	_	4	case	_	_
 4	Tafjord	Tafjord	PROPN	subst	_	2	nmod	_	_
 5	og	og	CCONJ	konj	_	6	cc	_	_
@@ -36205,7 +36205,7 @@
 6	Naturvernforbundet	Naturvernforbundet	PROPN	subst	_	7	nsubj	_	_
 7	ønsker	ønske	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	ccomp	_	_
 8	at	at	SCONJ	sbu	_	11	mark	_	_
-9	bygdesamfunnet	bygdesamfunn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	11	nsubj	_	_
+9	bygdesamfunnet	bygdesamfunn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	11	nsubj:pass	_	_
 10	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	_	_
 11	bygges	bygge	VERB	verb	VerbForm=Inf|Voice=Pass	7	xcomp	_	_
 12	ned	ned	ADV	prep	_	11	advmod	_	SpaceAfter=No
@@ -36542,7 +36542,7 @@
 1	Nå	nå	ADV	adv	_	2	advmod	_	_
 2	ble	bli	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	ccomp	_	_
 3	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
-4	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	xcomp	_	SpaceAfter=No
+4	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	xcomp	_	SpaceAfter=No
 5	!	$!	PUNCT	clb	_	2	punct	_	_
 6	jubler	juble	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 7	SVs	SV	PROPN	subst	Case=Gen	8	nmod	_	_
@@ -36608,7 +36608,7 @@
 8	Energi	Energi	PROPN	subst	_	7	flat:name	_	_
 9	la	legge	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	18	advcl	_	_
 10	fram	fram	ADV	prep	_	9	advmod	_	_
-11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	det	_	_
+11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 12	planer	plan	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	9	obj	_	_
 13	om	om	ADP	prep	_	14	case	_	_
 14	gasskraftverk	gasskraftverk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	12	nmod	_	_
@@ -36628,7 +36628,7 @@
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
 2	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	positiv	positiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	positiv	positiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	til	til	ADP	prep	_	6	case	_	_
 6	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	obl	_	_
 7	Hustadmarmor	Hustadmarmor	PROPN	subst	_	8	nsubj	_	_
@@ -36648,7 +36648,7 @@
 1	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	4	advmod	_	_
-4	spent	spent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	spent	spent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	på	på	ADP	prep	_	8	case	_	_
 6	hva	hva	PRON	pron	PronType=Int	8	obj	_	_
 7	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj	_	_
@@ -36685,7 +36685,7 @@
 3	SVs	SV	PROPN	subst	Case=Gen	4	nmod	_	_
 4	gasskraftpolitikk	gasskraftpolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	vanskelig	vanskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	vanskelig	vanskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	valgkampsak	valgkampsak	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 8	for	for	ADP	prep	_	9	case	_	_
 9	partiet	parti	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	nmod	_	_
@@ -36795,7 +36795,7 @@
 3	fått	få	VERB	verb	VerbForm=Part	13	ccomp	_	_
 4	fram	fram	ADV	prep	_	3	advmod	_	_
 5	budskapet	budskap	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	obj	_	_
-6	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	SpaceAfter=No
+6	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	11	punct	_	_
 8	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	_	_
@@ -36861,13 +36861,13 @@
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
 2	Er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	4	nsubj	_	_
-4	overrasket	overraske	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	_
+4	overrasket	overraske	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	_
 5	over	over	ADP	prep	_	10	case	_	_
 6	at	at	SCONJ	sbu	_	10	mark	_	_
 7	skepsisen	skepsis	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	_
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	_	_
 9	såpass	såpass	ADV	adv	_	10	advmod	_	_
-10	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	advcl	_	SpaceAfter=No
+10	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	advcl	_	SpaceAfter=No
 11	?	$?	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 017724
@@ -37060,7 +37060,7 @@
 12	gasskraftverk	gasskraftverk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	10	obl	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	10	punct	_	_
 14	deler	dele	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-15	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	16	det	_	_
+15	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	16	nmod:poss	_	_
 16	tolkning	tolkning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	14	obj	_	_
 17	av	av	ADP	prep	_	18	case	_	_
 18	meningsmålingen	meningsmåling	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	SpaceAfter=No
@@ -37097,7 +37097,7 @@
 2	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 3	vært	være	AUX	verb	VerbForm=Part	6	cop	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	vanskelig	vanskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	vanskelig	vanskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	sak	sak	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 7	som	som	SCONJ	sbu	_	11	mark	_	_
 8	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	_	_
@@ -37144,7 +37144,7 @@
 13	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	expl	_	_
 14	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	acl	_	_
 15	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-16	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	vilje	vilje	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nsubj	_	_
 18	til	til	ADP	prep	_	20	case	_	_
 19	å	å	PART	inf-merke	_	20	mark	_	_
@@ -37289,7 +37289,7 @@
 
 # sent_id = 017748
 # text = Nær 70 prosent av SVs velgere sier de ikke ønsker gasskraft basert på eksisterende teknologi.
-1	Nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	advmod	_	_
+1	Nær	nær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	advmod	_	_
 2	70	70	NUM	det	Number=Plur|NumType=Card	3	nummod	_	_
 3	prosent	prosent	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	7	nsubj	_	_
 4	av	av	ADP	prep	_	6	case	_	_
@@ -37489,7 +37489,7 @@
 7	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
 8	siste	sist	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	9	amod	_	_
 9	synet	syn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	xcomp	_	_
-10	eierne	eier	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	17	nsubj	_	_
+10	eierne	eier	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	17	nsubj:pass	_	_
 11	av	av	ADP	prep	_	12	case	_	_
 12	toleransebegrepet	toleransebegrep	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	10	nmod	_	_
 13	i	i	ADP	prep	_	14	case	_	_
@@ -37507,7 +37507,7 @@
 2	Halvorsen	Halvorsen	PROPN	subst	_	1	flat:name	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	ikke	ikke	PART	adv	Polarity=Neg	5	advmod	_	_
-5	nådig	nådig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+5	nådig	nådig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 6	når	når	SCONJ	sbu	_	8	mark	_	_
 7	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
 8	angriper	angripe	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	advcl	_	_
@@ -37535,7 +37535,7 @@
 30	imot	imot	ADP	prep	_	31	case	_	_
 31	han	han	PRON	pron	Animacy=Hum|Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	28	obl	_	_
 32	pga	pga.	ADP	prep	Abbr=Yes	34	case	_	_
-33	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	34	det	_	_
+33	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	34	nmod:poss	_	_
 34	holdninger	holdning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	28	obl	_	SpaceAfter=No
 35	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -37573,7 +37573,7 @@
 6	føle	føle	VERB	verb	VerbForm=Inf	2	advcl	_	_
 7	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	6	obj	_	_
 8	«	$"	PUNCT	<anf>	_	9	punct	_	SpaceAfter=No
-9	mislykket	mislykket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	xcomp	_	SpaceAfter=No
+9	mislykket	mislykket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	xcomp	_	SpaceAfter=No
 10	»	$"	PUNCT	<anf>	_	9	punct	_	_
 11	og	og	CCONJ	konj	_	13	cc	_	_
 12	«	$"	PUNCT	<anf>	_	13	punct	_	SpaceAfter=No
@@ -37637,14 +37637,14 @@
 2	koster	koste	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	å	å	PART	inf-merke	_	5	mark	_	_
 4	være	være	AUX	verb	VerbForm=Inf	5	cop	_	_
-5	uenig	uenig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	nsubj	_	_
+5	uenig	uenig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	nsubj	_	_
 6	med	med	ADP	prep	_	7	case	_	_
 7	Halvorsen	Halvorsen	PROPN	subst	_	5	obl	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 017765
 # text = Hennes meningsfelle Øyvind Foss går faktisk enda lenger i sin kamp mot friskoler, særlig de kristne.
-1	Hennes	hennes	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	2	det	_	_
+1	Hennes	hennes	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 2	meningsfelle	meningsfelle	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj	_	_
 3	Øyvind	Øyvind	PROPN	subst	Gender=Masc	2	appos	_	_
 4	Foss	Foss	PROPN	subst	_	3	flat:name	_	_
@@ -37653,7 +37653,7 @@
 7	enda	enda	ADV	adv	_	8	advmod	_	_
 8	lenger	lang	ADJ	adj	Degree=Cmp	5	advmod	_	_
 9	i	i	ADP	prep	_	11	case	_	_
-10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	kamp	kamp	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 12	mot	mot	ADP	prep	_	13	case	_	_
 13	friskoler	friskole	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	11	nmod	_	SpaceAfter=No
@@ -37706,9 +37706,9 @@
 2	mener	mene	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
 4	«	$"	PUNCT	<anf>	_	8	punct	_	SpaceAfter=No
-5	flerkulturell	flerkulturell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	SpaceAfter=No
+5	flerkulturell	flerkulturell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	5	punct	_	_
-7	demokratisk	demokratisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	demokratisk	demokratisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	rettstat	rettstat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nsubj	_	SpaceAfter=No
 9	»	$"	PUNCT	<anf>	_	8	punct	_	_
 10	ikke	ikke	PART	adv	Polarity=Neg	12	advmod	_	_
@@ -37725,7 +37725,7 @@
 3	nemlig	nemlig	ADV	adv	_	2	advmod	_	_
 4	at	at	SCONJ	sbu	_	8	mark	_	_
 5	«	$"	PUNCT	<anf>	_	8	punct	_	SpaceAfter=No
-6	mennesker	menneske	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	8	nsubj	_	_
+6	mennesker	menneske	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	8	nsubj:pass	_	_
 7	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux:pass	_	_
 8	krenket	krenke	VERB	verb	VerbForm=Part	2	xcomp	_	_
 9	og	og	CCONJ	konj	_	11	cc	_	_
@@ -37787,7 +37787,7 @@
 7	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 8	sende	sende	VERB	verb	VerbForm=Inf	4	xcomp	_	_
 9	barna	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	8	obj	_	_
-10	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	9	det	_	_
+10	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 11	på	på	ADP	prep	_	12	case	_	_
 12	skoler	skole	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	obl	_	_
 13	som	som	SCONJ	sbu	_	14	mark	_	_
@@ -37799,7 +37799,7 @@
 19	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	obl	_	_
 20	som	som	SCONJ	sbu	_	25	mark	_	_
 21	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
-22	rød	rød	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	amod	_	_
+22	rød	rød	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	amod	_	_
 23	regjering	regjering	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	25	nsubj	_	_
 24	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	25	aux	_	_
 25	ønske	ønske	VERB	verb	VerbForm=Inf	19	acl:relcl	_	SpaceAfter=No
@@ -37807,7 +37807,7 @@
 
 # sent_id = 017773
 # text = De bør derfor forbys.
-1	De	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	_	_
+1	De	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj:pass	_	_
 2	bør	burde	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	derfor	derfor	ADV	adv	_	4	advmod	_	_
 4	forbys	forby	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	SpaceAfter=No
@@ -37887,7 +37887,7 @@
 13	velge	velge	VERB	verb	VerbForm=Inf	9	acl	_	_
 14	skole	skole	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	obj	_	_
 15	for	for	ADP	prep	_	17	case	_	_
-16	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	17	det	_	_
+16	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
 17	barn	barn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	13	obl	_	SpaceAfter=No
 18	?	$?	PUNCT	clb	_	5	punct	_	_
 
@@ -37913,7 +37913,7 @@
 1	Dersom	dersom	SCONJ	sbu	_	8	mark	_	_
 2	å	å	PART	inf-merke	_	4	mark	_	_
 3	være	være	AUX	verb	VerbForm=Inf	4	cop	_	_
-4	tolerant	tolerant	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	csubj	_	_
+4	tolerant	tolerant	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	csubj	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
 6	å	å	PART	inf-merke	_	8	mark	_	_
 7	bare	bare	ADV	adv	_	8	advmod	_	_
@@ -37987,7 +37987,7 @@
 3	lett	lett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	0	root	_	_
 4	å	å	PART	inf-merke	_	6	mark	_	_
 5	være	være	AUX	verb	VerbForm=Inf	6	cop	_	_
-6	tøff	tøff	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	csubj	_	_
+6	tøff	tøff	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	csubj	_	_
 7	i	i	ADP	prep	_	8	case	_	_
 8	kjeften	kjeft	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	obl	_	_
 9	når	når	SCONJ	sbu	_	11	mark	_	_
@@ -38043,7 +38043,7 @@
 15	ut	ut	ADP	prep	_	19	case	_	_
 16	av	av	ADP	prep	_	19	case	_	_
 17	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
-18	sosialistisk	sosialistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	sosialistisk	sosialistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	regjering	regjering	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	obl	_	_
 20	og	og	CCONJ	konj	_	21	cc	_	_
 21	gå	gå	VERB	verb	VerbForm=Inf	14	conj	_	_
@@ -38098,7 +38098,7 @@
 6	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	amod	_	_
 7	område	område	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	nsubj	_	_
 8	med	med	ADP	prep	_	10	case	_	_
-9	rød-grønn	rød-grønn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	rød-grønn	rød-grønn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	usikkerhet	usikkerhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	nmod	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	13	punct	_	_
 12	både	både	CCONJ	konj	_	13	cc	_	_
@@ -38120,7 +38120,7 @@
 6	hva	hva	PRON	pron	PronType=Int	9	obl	_	_
 7	sosialistene	sosialist	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	9	nsubj	_	_
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	_	_
-9	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	ccomp	_	_
+9	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	ccomp	_	_
 10	om	om	ADP	prep	_	6	case	_	SpaceAfter=No
 11	?	$?	PUNCT	clb	_	4	punct	_	_
 
@@ -38141,7 +38141,7 @@
 # newpar
 # sent_id = 017792
 # text = Karita Bekkemellem Orheims innlegg i Sunnmørsposten 19. august bekrefter nok en gang at Arbeiderpartiet ikke har noen politikk for de sentrale utfordringene i norsk skole.
-1	Karita	Karita	PROPN	subst	_	4	nmod	_	_
+1	Karita	Karita	PROPN	subst	_	4	nmod:poss	_	_
 2	Bekkemellem	Bekkemellem	PROPN	subst	_	1	flat:name	_	_
 3	Orheims	Orheim	PROPN	subst	Case=Gen	1	flat:name	_	_
 4	innlegg	innlegg	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	nsubj	_	_
@@ -38164,7 +38164,7 @@
 21	sentrale	sentral	ADJ	adj	Degree=Pos|Number=Plur	22	amod	_	_
 22	utfordringene	utfordring	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	18	nmod	_	_
 23	i	i	ADP	prep	_	25	case	_	_
-24	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	skole	skole	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	22	nmod	_	SpaceAfter=No
 26	.	$.	PUNCT	clb	_	9	punct	_	_
 
@@ -38181,7 +38181,7 @@
 9	bedre	god	ADJ	adj	Degree=Cmp	10	amod	_	_
 10	skolebygg	skolebygg	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	conj	_	_
 11	og	og	CCONJ	konj	_	13	cc	_	_
-12	utvidet	utvide	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	13	amod	_	_
+12	utvidet	utvide	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	13	amod	_	_
 13	skoledag	skoledag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	conj	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -38191,7 +38191,7 @@
 2	dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nmod	_	_
 3	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	_
-5	bred	bred	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	bred	bred	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	enighet	enighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	nsubj	_	_
 7	om	om	ADP	prep	_	2	case	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	12	punct	_	_
@@ -38200,7 +38200,7 @@
 11	sosialistene	sosialist	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	12	nsubj	_	_
 12	lover	love	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	_	_
 13	mer	mye	ADJ	adj	Degree=Cmp	15	amod	_	_
-14	gratis	gratis	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	gratis	gratis	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	mat	mat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obj	_	_
 16	enn	enn	SCONJ	sbu	_	18	mark	_	_
 17	regjeringen	regjering	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	18	nsubj	_	_
@@ -38323,7 +38323,7 @@
 # sent_id = 017801
 # text = Regjeringens skolereform Kunnskapsløftet skal gjennomføres fra 2006.
 1	Regjeringens	regjering	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
-2	skolereform	skolereform	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj	_	_
+2	skolereform	skolereform	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj:pass	_	_
 3	Kunnskapsløftet	Kunnskapsløftet	PROPN	subst	_	2	appos	_	_
 4	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 5	gjennomføres	gjennomføre	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
@@ -38436,7 +38436,7 @@
 3	forbli	forbli	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 5	godt	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
-6	bevart	bevart	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	bevart	bevart	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	hemmelighet	hemmelighet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	xcomp	_	_
 8	helt	hel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
 9	til	til	SCONJ	sbu	_	15	mark	_	_
@@ -38514,14 +38514,14 @@
 9	til	til	ADP	prep	_	10	case	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	xcomp	_	_
 11	av	av	ADP	prep	_	14	case	_	_
-12	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	14	det	_	_
+12	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	14	nmod:poss	_	_
 13	viktigste	viktig	ADJ	adj	Definite=Def|Degree=Sup	14	amod	_	_
 14	oppgaver	oppgave	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	10	nmod	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 017811
 # text = Diskriminering og rasisme skal aktivt bekjempes.
-1	Diskriminering	diskriminering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	nsubj	_	_
+1	Diskriminering	diskriminering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	nsubj:pass	_	_
 2	og	og	CCONJ	konj	_	3	cc	_	_
 3	rasisme	rasisme	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	conj	_	_
 4	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
@@ -38531,7 +38531,7 @@
 
 # sent_id = 017812
 # text = Integreringen av innvandrere må forbedres.
-1	Integreringen	integrering	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
+1	Integreringen	integrering	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj:pass	_	_
 2	av	av	ADP	prep	_	3	case	_	_
 3	innvandrere	innvandrer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	1	nmod	_	_
 4	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
@@ -38543,10 +38543,10 @@
 1	Gode	god	ADJ	adj	Degree=Pos|Number=Plur	2	amod	_	_
 2	norskkunnskaper	norskkunnskap	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	7	nsubj	_	_
 3	og	og	CCONJ	konj	_	5	cc	_	_
-4	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	jobbformidling	jobbformidling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	conj	_	_
 6	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
-7	avgjørende	avgjørende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+7	avgjørende	avgjørende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 8	for	for	ADP	prep	_	10	case	_	_
 9	å	å	PART	inf-merke	_	10	mark	_	_
 10	lykkes	lykkes	VERB	verb	VerbForm=Inf	7	advcl	_	_
@@ -38560,7 +38560,7 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	føre	føre	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	offensiv	offensiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	offensiv	offensiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	miljø-	miljø-	NOUN	subst	_	3	obj	_	_
 7	og	og	CCONJ	konj	_	8	cc	_	_
 8	ressurspolitikk	ressurspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	conj	_	_
@@ -38569,13 +38569,13 @@
 11	målet	mål	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	9	obl	_	_
 12	om	om	ADP	prep	_	15	case	_	_
 13	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
-14	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	utvikling	utvikling	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 017815
 # text = Arbeidet med biologisk mangfold, opprydding i gamle miljøsynder og bekjempelse av PCB-forurensning skal forsterkes.
-1	Arbeidet	arbeid	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	15	nsubj	_	_
+1	Arbeidet	arbeid	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	15	nsubj:pass	_	_
 2	med	med	ADP	prep	_	4	case	_	_
 3	biologisk	biologisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	4	amod	_	_
 4	mangfold	mangfold	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	1	nmod	_	SpaceAfter=No
@@ -38640,7 +38640,7 @@
 11	Kyoto-avtalens	Kyoto-avtale	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	_
 12	mål	mål	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	10	obj	_	_
 13	om	om	ADP	prep	_	15	case	_	_
-14	demonstrerbar	demonstrerbar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	demonstrerbar	demonstrerbar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	framgang	framgang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nmod	_	_
 16	innen	innen	ADP	prep	_	17	case	_	_
 17	2005	2005	NUM	det	Number=Plur|NumType=Card	15	nmod	_	SpaceAfter=No
@@ -38649,8 +38649,8 @@
 # sent_id = 017819
 # text = En vesentlig del av utslippsreduksjonen skal oppnås gjennom nasjonale tiltak.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	vesentlig	vesentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
-3	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj	_	_
+2	vesentlig	vesentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
+3	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj:pass	_	_
 4	av	av	ADP	prep	_	5	case	_	_
 5	utslippsreduksjonen	utslippsreduksjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 6	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
@@ -38662,7 +38662,7 @@
 
 # sent_id = 017820
 # text = Etableringen av et nasjonalt kvotesystem skal framskyndes.
-1	Etableringen	etablering	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
+1	Etableringen	etablering	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nsubj:pass	_	_
 2	av	av	ADP	prep	_	5	case	_	_
 3	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
 4	nasjonalt	nasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	amod	_	_
@@ -38678,7 +38678,7 @@
 3	bidra	bidra	VERB	verb	VerbForm=Inf	0	root	_	_
 4	til	til	ADP	prep	_	7	case	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	framtidsrettet	framtidsrettet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	framtidsrettet	framtidsrettet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	energipolitikk	energipolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	11	punct	_	_
 9	hvor	hvor	ADV	adv	_	11	advmod	_	_
@@ -38710,7 +38710,7 @@
 # text = Samtidig styrkes tiltakene for energisparing.
 1	Samtidig	samtidig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	2	advmod	_	_
 2	styrkes	styrke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
-3	tiltakene	tiltak	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	2	nsubj	_	_
+3	tiltakene	tiltak	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	2	nsubj:pass	_	_
 4	for	for	ADP	prep	_	5	case	_	_
 5	energisparing	energisparing	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	nmod	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -38744,7 +38744,7 @@
 
 # sent_id = 017824
 # text = Økt forskning, et samarbeidsprogram med industrien, en økonomisk «startpakke» gjennom avgiftsfritak og en undersøkelse av miljømessig status med en fortløpende vurdering av utslippstillatelsene vil stå sentralt.
-1	Økt	øke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	2	amod	_	_
+1	Økt	øke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	2	amod	_	_
 2	forskning	forskning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	29	nsubj	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	5	punct	_	_
 4	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
@@ -38753,7 +38753,7 @@
 7	industrien	industri	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	12	punct	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-10	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+10	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 11	«	$"	PUNCT	<anf>	_	12	punct	_	SpaceAfter=No
 12	startpakke	startpakke	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	conj	_	SpaceAfter=No
 13	»	$"	PUNCT	<anf>	_	12	punct	_	_
@@ -38763,11 +38763,11 @@
 17	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
 18	undersøkelse	undersøkelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	conj	_	_
 19	av	av	ADP	prep	_	21	case	_	_
-20	miljømessig	miljømessig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	amod	_	_
+20	miljømessig	miljømessig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	amod	_	_
 21	status	status	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	nmod	_	_
 22	med	med	ADP	prep	_	25	case	_	_
 23	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
-24	fortløpende	fortløpende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	fortløpende	fortløpende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	vurdering	vurdering	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	nmod	_	_
 26	av	av	ADP	prep	_	27	case	_	_
 27	utslippstillatelsene	utslippstillatelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	25	nmod	_	_
@@ -38790,7 +38790,7 @@
 10	,	$,	PUNCT	<komma>	_	4	punct	_	_
 11	gis	gi	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 12	nye	ny	ADJ	adj	Degree=Pos|Number=Plur	13	amod	_	_
-13	utslippstillatelser	utslippstillatelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	11	nsubj	_	_
+13	utslippstillatelser	utslippstillatelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	11	nsubj:pass	_	_
 14	og	og	CCONJ	konj	_	15	cc	_	_
 15	konsesjoner	konsesjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	13	conj	_	_
 16	bare	bare	ADV	adv	_	11	advmod	_	_
@@ -38798,7 +38798,7 @@
 18	gasskraftverk	gasskraftverk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	11	obl	_	_
 19	basert	basere	VERB	verb	VerbForm=Part	18	acl:relcl	_	_
 20	på	på	ADP	prep	_	22	case	_	_
-21	CO2-fri	CO2-fri	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	amod	_	_
+21	CO2-fri	CO2-fri	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	amod	_	_
 22	teknologi	teknologi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	obl	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	11	punct	_	_
 
@@ -38822,7 +38822,7 @@
 4	bli	bli	AUX	verb	VerbForm=Inf	5	aux:pass	_	_
 5	utarbeidd	utarbeide	VERB	verb	VerbForm=Part	0	root	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	helhetlig	helhetlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	helhetlig	helhetlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	forvaltningsplan	forvaltningsplan	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obj	_	_
 9	for	for	ADP	prep	_	10	case	_	_
 10	Barentshavet	Barentshavet	PROPN	subst	Gender=Neut	8	nmod	_	SpaceAfter=No
@@ -38834,7 +38834,7 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	føre	føre	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 7	der	der	SCONJ	sbu	_	10	mark	_	_
 8	hovedmålene	hovedmål	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	10	nsubj	_	_
@@ -38843,17 +38843,17 @@
 11	til	til	ADP	prep	_	12	case	_	_
 12	alle	alle	PRON	pron	Number=Plur|Person=3|PronType=Prs,Tot	10	nmod	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	15	punct	_	_
-14	økt	øke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	15	amod	_	_
+14	økt	øke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	15	amod	_	_
 15	verdiskaping	verdiskaping	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	conj	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	17	punct	_	_
 17	videreutvikling	videreutvikling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	conj	_	_
 18	av	av	ADP	prep	_	19	case	_	_
 19	velferdssamfunnet	velferdssamfunn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	17	nmod	_	SpaceAfter=No
 20	,	$,	PUNCT	<komma>	_	22	punct	_	_
-21	rettferdig	rettferdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	amod	_	_
+21	rettferdig	rettferdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	amod	_	_
 22	fordeling	fordeling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	conj	_	_
 23	og	og	CCONJ	konj	_	25	cc	_	_
-24	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	utvikling	utvikling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	conj	_	SpaceAfter=No
 26	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -38879,7 +38879,7 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	legge	legge	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	kurs	kurs	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 7	for	for	ADP	prep	_	9	case	_	_
 8	statens	stat	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
@@ -38945,7 +38945,7 @@
 6	for	for	ADP	prep	_	8	case	_	_
 7	å	å	PART	inf-merke	_	8	mark	_	_
 8	sikre	sikre	VERB	verb	VerbForm=Inf	3	advcl	_	_
-9	økt	øke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	10	amod	_	_
+9	økt	øke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	10	amod	_	_
 10	tilgang	tilgang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obj	_	_
 11	til	til	ADP	prep	_	12	case	_	_
 12	arbeidskraft	arbeidskraft	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	nmod	_	SpaceAfter=No
@@ -38971,7 +38971,7 @@
 
 # sent_id = 017835
 # text = Regelverket for arbeidsinnvandring skal mykes opp.
-1	Regelverket	regelverk	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	5	nsubj	_	_
+1	Regelverket	regelverk	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	5	nsubj:pass	_	_
 2	for	for	ADP	prep	_	3	case	_	_
 3	arbeidsinnvandring	arbeidsinnvandring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	1	nmod	_	_
 4	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
@@ -38985,7 +38985,7 @@
 2	åpnes	åpne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 3	for	for	ADP	prep	_	9	case	_	_
 4	at	at	SCONJ	sbu	_	9	mark	_	_
-5	sykmeldte	sykmeldt	ADJ	adj	Degree=Pos|Number=Plur	9	nsubj	_	_
+5	sykmeldte	sykmeldt	ADJ	adj	Degree=Pos|Number=Plur	9	nsubj:pass	_	_
 6	raskere	rask	ADJ	adj	Degree=Cmp	9	advmod	_	_
 7	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 8	bli	bli	AUX	verb	VerbForm=Inf	9	aux:pass	_	_
@@ -39025,7 +39025,7 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	legge	legge	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	kurs	kurs	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 7	i	i	ADP	prep	_	8	case	_	_
 8	skatte-	skatte-	NOUN	subst	_	3	obl	_	_
@@ -39138,11 +39138,11 @@
 # sent_id = 017847
 # text = En god næringspolitikk er også god distriktspolitikk.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	næringspolitikk	næringspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
 5	også	også	ADV	adv	_	7	advmod	_	_
-6	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	distriktspolitikk	distriktspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	7	punct	_	_
 
@@ -39162,7 +39162,7 @@
 12	til	til	ADP	prep	_	13	case	_	_
 13	verdiskaping	verdiskaping	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	obl	_	SpaceAfter=No
 14	,	$,	PUNCT	<komma>	_	16	punct	_	_
-15	spredt	spredt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	spredt	spredt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	bosetting	bosetting	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	13	conj	_	_
 17	og	og	CCONJ	konj	_	19	cc	_	_
 18	gode	god	ADJ	adj	Degree=Pos|Number=Plur	19	amod	_	_
@@ -39207,7 +39207,7 @@
 
 # sent_id = 017851
 # text = Vegbevilgningene skal økes.
-1	Vegbevilgningene	vegbevilgning	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	3	nsubj	_	_
+1	Vegbevilgningene	vegbevilgning	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	3	nsubj:pass	_	_
 2	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	økes	øke	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	SpaceAfter=No
 4	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -39222,7 +39222,7 @@
 
 # sent_id = 017853
 # text = Sikkerheten innen sjøtransporten skal styrkes.
-1	Sikkerheten	sikkerhet	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
+1	Sikkerheten	sikkerhet	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj:pass	_	_
 2	innen	innen	ADP	prep	_	3	case	_	_
 3	sjøtransporten	sjøtransport	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	_
 4	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
@@ -39262,9 +39262,9 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	føre	føre	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-5	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+5	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 6	og	og	CCONJ	konj	_	7	cc	_	_
-7	positiv	positiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	_
+7	positiv	positiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	_
 8	storbypolitikk	storbypolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -39290,7 +39290,7 @@
 3	bedre	god	ADJ	adj	Degree=Cmp	4	amod	_	_
 4	kapasitet	kapasitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	7	punct	_	_
-6	økt	øke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	7	amod	_	_
+6	økt	øke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	7	amod	_	_
 7	frekvens	frekvens	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	conj	_	_
 8	og	og	CCONJ	konj	_	9	cc	_	_
 9	prisreduksjoner	prisreduksjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	4	conj	_	SpaceAfter=No
@@ -39319,7 +39319,7 @@
 8	at	at	SCONJ	sbu	_	19	mark	_	_
 9	de	de	DET	det	Number=Plur|PronType=Art	11	det	_	_
 10	store	stor	ADJ	adj	Degree=Pos|Number=Plur	11	amod	_	_
-11	mulighetene	mulighet	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	19	nsubj	_	_
+11	mulighetene	mulighet	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	19	nsubj:pass	_	_
 12	for	for	ADP	prep	_	13	case	_	_
 13	Kyst-Norge	Kyst-Norge	PROPN	subst	_	11	nmod	_	_
 14	innen	innen	ADP	prep	_	15	case	_	_
@@ -39337,13 +39337,13 @@
 3	bygge	bygge	VERB	verb	VerbForm=Inf	0	root	_	_
 4	på	på	ADP	prep	_	7	case	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	forvaltning	forvaltning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 8	av	av	ADP	prep	_	9	case	_	_
 9	ressursene	ressurs	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	7	nmod	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	21	punct	_	_
 11	og	og	CCONJ	konj	_	21	cc	_	_
-12	forurensninger	forurensning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	21	nsubj	_	_
+12	forurensninger	forurensning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	21	nsubj:pass	_	_
 13	som	som	SCONJ	sbu	_	15	mark	_	_
 14	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	_	_
 15	true	true	VERB	verb	VerbForm=Inf	12	acl:relcl	_	_
@@ -39368,7 +39368,7 @@
 9	landbruk	landbruk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	obl	_	_
 10	som	som	SCONJ	sbu	_	11	mark	_	_
 11	utnytter	utnytte	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	acl:relcl	_	_
-12	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	teknologi	teknologi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obj	_	_
 14	og	og	CCONJ	konj	_	16	cc	_	_
 15	nye	ny	ADJ	adj	Degree=Pos|Number=Plur	16	amod	_	_
@@ -39378,26 +39378,26 @@
 # sent_id = 017863
 # text = En viktig oppgave vil være å sikre trygg mat til forbrukerne, samtidig som forskjellen i matprisene i forhold til våre naboland reduseres.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	oppgave	oppgave	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj	_	_
 4	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 5	være	være	AUX	verb	VerbForm=Inf	7	cop	_	_
 6	å	å	PART	inf-merke	_	7	mark	_	_
 7	sikre	sikre	VERB	verb	VerbForm=Inf	0	root	_	_
-8	trygg	trygg	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	trygg	trygg	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	mat	mat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	_
 10	til	til	ADP	prep	_	11	case	_	_
 11	forbrukerne	forbruker	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	7	obl	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	13	punct	_	_
 13	samtidig	samtidig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	advmod	_	_
 14	som	som	SCONJ	sbu	_	23	mark	_	_
-15	forskjellen	forskjell	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	23	nsubj	_	_
+15	forskjellen	forskjell	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	23	nsubj:pass	_	_
 16	i	i	ADP	prep	_	17	case	_	_
 17	matprisene	matpris	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	15	nmod	_	_
 18	i	i	ADP	prep	_	19	case	_	_
 19	forhold	forhold	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	17	nmod	_	_
 20	til	til	ADP	prep	_	22	case	_	_
-21	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	22	det	_	_
+21	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	22	nmod:poss	_	_
 22	naboland	naboland	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	19	nmod	_	_
 23	reduseres	redusere	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	13	advcl	_	SpaceAfter=No
 24	.	$.	PUNCT	clb	_	7	punct	_	_
@@ -39418,7 +39418,7 @@
 12	fremme	fremme	VERB	verb	VerbForm=Inf	0	root	_	_
 13	modernisering	modernisering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	12	obj	_	_
 14	av	av	ADP	prep	_	16	case	_	_
-15	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	sektor	sektor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nmod	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	12	punct	_	_
 
@@ -39428,9 +39428,9 @@
 2	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	bli	bli	VERB	verb	VerbForm=Inf	0	root	_	_
 4	mer	mye	ADJ	adj	Degree=Cmp	5	advmod	_	_
-5	brukerorientert	brukerorientert	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	xcomp	_	_
+5	brukerorientert	brukerorientert	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	xcomp	_	_
 6	og	og	CCONJ	konj	_	7	cc	_	_
-7	serviceinnstilt	serviceinnstilt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	SpaceAfter=No
+7	serviceinnstilt	serviceinnstilt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 017866
@@ -39438,7 +39438,7 @@
 1	Gjennom	gjennom	ADP	prep	_	2	case	_	_
 2	effektivisering	effektivisering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obl	_	_
 3	frigjøres	frigjøre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
-4	ressurser	ressurs	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	nsubj	_	_
+4	ressurser	ressurs	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	nsubj:pass	_	_
 5	til	til	ADP	prep	_	7	case	_	_
 6	offentlige	offentlig	ADJ	adj	Degree=Pos|Number=Plur	7	amod	_	_
 7	kjerneoppgaver	kjerneoppgave	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	3	obl	_	SpaceAfter=No
@@ -39474,25 +39474,25 @@
 
 # sent_id = 017869
 # text = Lover og forskrifter skal forenkles og forskrifter gis tidsbegrenset varighet.
-1	Lover	lov	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	nsubj	_	_
+1	Lover	lov	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	nsubj:pass	_	_
 2	og	og	CCONJ	konj	_	3	cc	_	_
 3	forskrifter	forskrift	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	1	conj	_	_
 4	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 5	forenkles	forenkle	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 6	og	og	CCONJ	konj	_	8	cc	_	_
-7	forskrifter	forskrift	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	8	nsubj	_	_
+7	forskrifter	forskrift	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	8	nsubj:pass	_	_
 8	gis	gi	VERB	verb	VerbForm=Inf|Voice=Pass	5	conj	_	_
-9	tidsbegrenset	tidsbegrense	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	10	amod	_	_
+9	tidsbegrenset	tidsbegrense	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	10	amod	_	_
 10	varighet	varighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	8	obj	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 017870
 # text = Bruken av konkurranseutsetting i offentlig sektor skal utvides.
-1	Bruken	bruk	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
+1	Bruken	bruk	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj:pass	_	_
 2	av	av	ADP	prep	_	3	case	_	_
 3	konkurranseutsetting	konkurranseutsetting	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	1	nmod	_	_
 4	i	i	ADP	prep	_	6	case	_	_
-5	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	sektor	sektor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	nmod	_	_
 7	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 8	utvides	utvide	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	SpaceAfter=No
@@ -39500,14 +39500,14 @@
 
 # sent_id = 017871
 # text = Kjøp fra private bedrifter skal likestilles med offentlig egenproduksjon av tjenester.
-1	Kjøp	kjøp	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	6	nsubj	_	_
+1	Kjøp	kjøp	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	6	nsubj:pass	_	_
 2	fra	fra	ADP	prep	_	4	case	_	_
 3	private	privat	ADJ	adj	Degree=Pos|Number=Plur	4	amod	_	_
 4	bedrifter	bedrift	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	1	nmod	_	_
 5	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 6	likestilles	likestille	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 7	med	med	ADP	prep	_	9	case	_	_
-8	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	egenproduksjon	egenproduksjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obl	_	_
 10	av	av	ADP	prep	_	11	case	_	_
 11	tjenester	tjeneste	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	9	nmod	_	SpaceAfter=No
@@ -39515,7 +39515,7 @@
 
 # sent_id = 017872
 # text = Byggesaksforskriftene i plan- og bygningsloven skal forenkles og saksbehandlingstiden kortes ned for reguleringssaker.
-1	Byggesaksforskriftene	byggesaksforskrift	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	7	nsubj	_	_
+1	Byggesaksforskriftene	byggesaksforskrift	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	7	nsubj:pass	_	_
 2	i	i	ADP	prep	_	3	case	_	_
 3	plan-	plan-	NOUN	subst	_	1	nmod	_	_
 4	og	og	CCONJ	konj	_	5	cc	_	_
@@ -39523,7 +39523,7 @@
 6	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 7	forenkles	forenkle	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 8	og	og	CCONJ	konj	_	10	cc	_	_
-9	saksbehandlingstiden	saksbehandlingstid	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	_
+9	saksbehandlingstiden	saksbehandlingstid	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	nsubj:pass	_	_
 10	kortes	korte	VERB	verb	VerbForm=Inf|Voice=Pass	7	conj	_	_
 11	ned	ned	ADV	prep	_	10	advmod	_	_
 12	for	for	ADP	prep	_	13	case	_	_
@@ -39532,11 +39532,11 @@
 
 # sent_id = 017873
 # text = Åpningstidsloven oppheves, og bestemmelsene for søn- og helligdager overføres til helligdagslovgivningen.
-1	Åpningstidsloven	åpningstidslov	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
+1	Åpningstidsloven	åpningstidslov	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nsubj:pass	_	_
 2	oppheves	oppheve	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	10	punct	_	_
 4	og	og	CCONJ	konj	_	10	cc	_	_
-5	bestemmelsene	bestemmelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	10	nsubj	_	_
+5	bestemmelsene	bestemmelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	10	nsubj:pass	_	_
 6	for	for	ADP	prep	_	7	case	_	_
 7	søn-	søn-	NOUN	subst	_	5	nmod	_	_
 8	og	og	CCONJ	konj	_	9	cc	_	_
@@ -39566,7 +39566,7 @@
 1	Regjeringen	Regjeringen	PROPN	subst	_	3	nsubj	_	_
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	legge	legge	VERB	verb	VerbForm=Inf	0	root	_	_
-4	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	vekt	vekt	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obj	_	_
 6	på	på	ADP	prep	_	8	case	_	_
 7	å	å	PART	inf-merke	_	8	mark	_	_
@@ -39630,9 +39630,9 @@
 9	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
 10	samarbeid	samarbeid	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	7	obl	_	_
 11	mellom	mellom	ADP	prep	_	15	case	_	_
-12	privat	privat	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+12	privat	privat	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 13	og	og	CCONJ	konj	_	14	cc	_	_
-14	statlig	statlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	conj	_	_
+14	statlig	statlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	conj	_	_
 15	kapital	kapital	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nmod	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -39640,7 +39640,7 @@
 # text = Den norske kirke, frikirkene og andre trossamfunn skal sikres gode arbeidsvilkår.
 1	Den	Den	PROPN	subst	_	3	nmod	_	_
 2	norske	norsk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	3	amod	_	_
-3	kirke	kirke	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	nsubj	_	SpaceAfter=No
+3	kirke	kirke	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	nsubj:pass	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	5	punct	_	_
 5	frikirkene	frikirke	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	3	conj	_	_
 6	og	og	CCONJ	konj	_	8	cc	_	_
@@ -39655,7 +39655,7 @@
 # sent_id = 017880
 # text = Kirkens uavhengighet i åndelige spørsmål må respekteres, og Regjeringen vil fortsette reformarbeidet med overføring av større ansvar til kirkelige organer.
 1	Kirkens	kirke	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
-2	uavhengighet	uavhengighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	nsubj	_	_
+2	uavhengighet	uavhengighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	nsubj:pass	_	_
 3	i	i	ADP	prep	_	5	case	_	_
 4	åndelige	åndelig	ADJ	adj	Degree=Pos|Number=Plur	5	amod	_	_
 5	spørsmål	spørsmål	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	2	nmod	_	_
@@ -39705,7 +39705,7 @@
 # sent_id = 017882
 # text = Frivillige organisasjoner skal kompenseres for virkningen av momsreformen.
 1	Frivillige	frivillig	ADJ	adj	Degree=Pos|Number=Plur	2	amod	_	_
-2	organisasjoner	organisasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	4	nsubj	_	_
+2	organisasjoner	organisasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	4	nsubj:pass	_	_
 3	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 4	kompenseres	kompensere	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 5	for	for	ADP	prep	_	6	case	_	_
@@ -39716,7 +39716,7 @@
 
 # sent_id = 017883
 # text = Fradragsrammen for gaver til frivillige organisasjoner vil bli utvidet.
-1	Fradragsrammen	fradragsramme	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	_
+1	Fradragsrammen	fradragsramme	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	nsubj:pass	_	_
 2	for	for	ADP	prep	_	3	case	_	_
 3	gaver	gave	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	1	nmod	_	_
 4	til	til	ADP	prep	_	6	case	_	_
@@ -39742,7 +39742,7 @@
 11	men	men	CCONJ	konj	_	17	cc	_	_
 12	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	14	det	_	_
 13	gode	god	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	14	amod	_	_
-14	samfunn	samfunn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	17	nsubj	_	_
+14	samfunn	samfunn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	17	nsubj:pass	_	_
 15	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux	_	_
 16	bare	bare	ADV	adv	_	17	advmod	_	_
 17	skapes	skape	VERB	verb	VerbForm=Inf|Voice=Pass	5	conj	_	_
@@ -39775,10 +39775,10 @@
 
 # sent_id = 017886
 # text = Vår utfordring - vårt ansvar - er å gjøre Norge enda bedre.
-1	Vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	2	det	_	_
+1	Vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 2	utfordring	utfordring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	nsubj	_	_
 3	-	$-	PUNCT	<strek>	_	5	punct	_	_
-4	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+4	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	ansvar	ansvar	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	2	appos	_	_
 6	-	$-	PUNCT	<strek>	_	5	punct	_	_
 7	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	_	_
@@ -39797,7 +39797,7 @@
 # sent_id = 017888
 # text = Regjeringens erklæring foreslås utlagt for behandling i et senere møte.
 1	Regjeringens	regjering	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
-2	erklæring	erklæring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	nsubj	_	_
+2	erklæring	erklæring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	nsubj:pass	_	_
 3	foreslås	foreslå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 4	utlagt	utlegge	VERB	verb	VerbForm=Part	3	ccomp	_	_
 5	for	for	ADP	prep	_	6	case	_	_
@@ -39811,7 +39811,7 @@
 # sent_id = 017889
 # text = - Det anses vedtatt.
 1	-	$-	PUNCT	<strek>	_	3	punct	_	_
-2	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+2	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj:pass	_	_
 3	anses	anse	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 4	vedtatt	vedta	VERB	verb	VerbForm=Part	3	ccomp	_	SpaceAfter=No
 5	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -39847,7 +39847,7 @@
 1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	expl	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	_	_
 3	med	med	ADP	prep	_	5	case	_	_
-4	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	sorg	sorg	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	0	root	_	_
 6	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	_	_
 7	mottok	motta	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	advcl	_	_
@@ -39867,7 +39867,7 @@
 
 # sent_id = 017894
 # text = Norsk politikk mistet da en av landets mest populære politikere.
-1	Norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nsubj	_	_
 3	mistet	miste	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	da	da	ADV	adv	_	3	advmod	_	_
@@ -39892,7 +39892,7 @@
 9	til	til	ADP	prep	_	10	case	_	_
 10	1989	1989	NUM	det	Number=Plur|NumType=Card	4	obl	_	_
 11	og	og	CCONJ	konj	_	13	cc	_	_
-12	parlamentarisk	parlamentarisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	parlamentarisk	parlamentarisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	leder	leder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	conj	_	_
 14	i	i	ADP	prep	_	16	case	_	_
 15	tolv	tolv	NUM	det	Number=Plur|NumType=Card	16	nummod	_	_
@@ -39910,7 +39910,7 @@
 5	samferdselskomiteen	samferdselskomité	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 6	i	i	ADP	prep	_	10	case	_	_
 7	alle	all	DET	det	Number=Plur|PronType=Tot	10	det	_	_
-8	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	det	_	_
+8	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	nmod:poss	_	_
 9	fire	fire	NUM	det	Number=Plur|NumType=Card	10	nummod	_	_
 10	perioder	periode	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	obl	_	_
 11	på	på	ADP	prep	_	12	case	_	_
@@ -39945,7 +39945,7 @@
 9	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	cop	_	_
 10	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-12	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	talsperson	talsperson	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 14	for	for	ADP	prep	_	15	case	_	_
 15	Nord-Norge	Nord-Norge	PROPN	subst	_	13	obl	_	_
@@ -39959,7 +39959,7 @@
 2	Kvanmo	Kvanmo	PROPN	subst	_	1	flat:name	_	_
 3	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	debattant	debattant	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 7	og	og	CCONJ	konj	_	9	cc	_	_
 8	ofte	ofte	ADJ	adj	Degree=Pos	9	advmod	_	_
@@ -39976,7 +39976,7 @@
 19	Stortinget	Stortinget	PROPN	subst	Gender=Neut	17	nmod	_	_
 20	med	med	ADP	prep	_	23	case	_	_
 21	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
-22	direkte	direkte	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	amod	_	_
+22	direkte	direkte	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	amod	_	_
 23	replikk	replikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
 24	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -40012,14 +40012,14 @@
 8	for	for	ADP	prep	_	10	case	_	_
 9	å	å	PART	inf-merke	_	10	mark	_	_
 10	underbygge	underbygge	VERB	verb	VerbForm=Inf	2	advcl	_	_
-11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	det	_	_
+11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 12	poenger	poeng	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	10	obj	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 017902
 # text = Da Sosialistisk Venstrepartis stortingsgruppe satt på vippen og avgjorde mange saker, la hun sin ære i å være redelig og ansvarlig.
 1	Da	da	SCONJ	sbu	_	5	mark	_	_
-2	Sosialistisk	Sosialistisk	PROPN	subst	_	4	nmod	_	_
+2	Sosialistisk	Sosialistisk	PROPN	subst	_	4	nmod:poss	_	_
 3	Venstrepartis	Venstreparti	PROPN	subst	Case=Gen	2	flat:name	_	_
 4	stortingsgruppe	stortingsgruppe	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	nsubj	_	_
 5	satt	sitte	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	advcl	_	_
@@ -40032,14 +40032,14 @@
 12	,	$,	PUNCT	<komma>	_	5	punct	_	_
 13	la	legge	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 14	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
-15	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	16	det	_	_
+15	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	16	nmod:poss	_	_
 16	ære	ære	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	obj	_	_
 17	i	i	ADP	prep	_	20	case	_	_
 18	å	å	PART	inf-merke	_	20	mark	_	_
 19	være	være	AUX	verb	VerbForm=Inf	20	cop	_	_
-20	redelig	redelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	advcl	_	_
+20	redelig	redelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	advcl	_	_
 21	og	og	CCONJ	konj	_	22	cc	_	_
-22	ansvarlig	ansvarlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	conj	_	SpaceAfter=No
+22	ansvarlig	ansvarlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	conj	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	13	punct	_	_
 
 # sent_id = 017903
@@ -40089,15 +40089,15 @@
 5	Harstad	Harstad	PROPN	subst	_	2	obl	_	_
 6	med	med	ADP	prep	_	11	case	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-8	enslig	enslig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+8	enslig	enslig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 9	og	og	CCONJ	konj	_	10	cc	_	_
-10	fraskilt	fraskille	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	8	conj	_	_
+10	fraskilt	fraskille	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	8	conj	_	_
 11	mor	mor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	14	punct	_	_
 13	og	og	CCONJ	konj	_	14	cc	_	_
 14	ble	bli	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	_	_
 15	selv	selv	ADV	adv	_	14	advmod	_	_
-16	enslig	enslig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	enslig	enslig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	mor	mor	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	14	xcomp	_	_
 18	som	som	SCONJ	sbu	_	19	mark	_	_
 19	slet	slite	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	17	acl:relcl	_	_
@@ -40115,7 +40115,7 @@
 # text = Hanna traff sin Bjarne og fikk to barn til.
 1	Hanna	Hanna	PROPN	subst	Gender=Fem	2	nsubj	_	_
 2	traff	treffe	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-3	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	_
+3	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 4	Bjarne	Bjarne	PROPN	subst	Gender=Masc	2	obj	_	_
 5	og	og	CCONJ	konj	_	6	cc	_	_
 6	fikk	få	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	_	_
@@ -40128,12 +40128,12 @@
 # text = Hun var familiekjær og en dugende og stolt husmor ved siden av arbeid og politikk.
 1	Hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	cop	_	_
-3	familiekjær	familiekjær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	familiekjær	familiekjær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	og	og	CCONJ	konj	_	9	cc	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
 6	dugende	duge	ADJ	adj	VerbForm=Part	9	amod	_	_
 7	og	og	CCONJ	konj	_	8	cc	_	_
-8	stolt	stolt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	conj	_	_
+8	stolt	stolt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	conj	_	_
 9	husmor	husmor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	conj	_	_
 10	ved	ved	ADP	prep	_	11	case	_	_
 11	siden	side	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
@@ -40151,7 +40151,7 @@
 4	hadde	ha	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 5	alltid	alltid	ADV	adv	_	4	advmod	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	varm	varm	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	varm	varm	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	forsvarer	forsvarer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 9	i	i	ADP	prep	_	10	case	_	_
 10	Hanna	Hanna	PROPN	subst	Gender=Fem	8	nmod	_	_
@@ -40185,7 +40185,7 @@
 4	sykepleierelev	sykepleierelev	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	xcomp	_	_
 5	som	som	ADP	prep	_	7	case	_	_
 6	svært	svær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	advmod	_	_
-7	ung	ung	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	xcomp	_	_
+7	ung	ung	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	xcomp	_	_
 8	i	i	ADP	prep	_	11	case	_	_
 9	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
 10	tyske	tysk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	11	amod	_	_
@@ -40211,7 +40211,7 @@
 1	For	for	ADP	prep	_	2	case	_	_
 2	dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	obl	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
-4	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
+4	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	5	nsubj:pass	_	_
 5	dømt	dømme	VERB	verb	VerbForm=Part	0	root	_	_
 6	for	for	ADP	prep	_	7	case	_	_
 7	landssvik	landssvik	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	5	obl	_	SpaceAfter=No
@@ -40222,7 +40222,7 @@
 12	sone	sone	VERB	verb	VerbForm=Inf	10	xcomp	_	_
 13	etter	etter	ADP	prep	_	17	case	_	_
 14	at	at	SCONJ	sbu	_	17	mark	_	_
-15	dommen	dom	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	17	nsubj	_	_
+15	dommen	dom	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	17	nsubj:pass	_	_
 16	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	17	aux:pass	_	_
 17	anket	anke	VERB	verb	VerbForm=Part	10	advcl	_	_
 18	til	til	ADP	prep	_	19	case	_	_
@@ -40253,11 +40253,11 @@
 4	da	da	SCONJ	sbu	_	8	mark	_	_
 5	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
 6	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	cop	_	_
-7	nyvalgt	nyvalgt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	nyvalgt	nyvalgt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	stortingsrepresentant	stortingsrepresentant	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	appos	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	8	punct	_	_
 10	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	aux:pass	_	_
-11	saken	sak	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	_
+11	saken	sak	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	nsubj:pass	_	_
 12	såkalt	såkalt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	13	advmod	_	_
 13	avslørt	avsløre	VERB	verb	VerbForm=Part	0	root	_	_
 14	på	på	ADP	prep	_	15	case	_	_
@@ -40268,7 +40268,7 @@
 19	og	og	CCONJ	konj	_	29	cc	_	_
 20	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	26	det	_	_
 21	svært	svær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	22	advmod	_	_
-22	grov	grov	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	amod	_	_
+22	grov	grov	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	amod	_	_
 23	og	og	CCONJ	konj	_	25	cc	_	_
 24	personlig	personlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	25	advmod	_	_
 25	belastende	belaste	ADJ	adj	VerbForm=Part	22	conj	_	_
@@ -40320,10 +40320,10 @@
 3	praksis	praksis	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	nmod	_	_
 4	og	og	CCONJ	konj	_	7	cc	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	rettferdighetssans	rettferdighetssans	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	conj	_	_
 8	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	11	cop	_	_
-9	Hanna	Hanna	PROPN	subst	Gender=Fem	11	nmod	_	_
+9	Hanna	Hanna	PROPN	subst	Gender=Fem	11	nmod:poss	_	_
 10	Kvanmos	Kvanmo	PROPN	subst	Case=Gen	9	flat:name	_	_
 11	drivkraft	drivkraft	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	11	punct	_	_
@@ -40344,7 +40344,7 @@
 12	enkeltpersoner	enkeltperson	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	10	nmod	_	_
 13	som	som	SCONJ	sbu	_	14	mark	_	_
 14	satte	sette	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	12	acl:relcl	_	_
-15	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	16	det	_	_
+15	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	16	nmod:poss	_	_
 16	lit	lit	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	obj	_	_
 17	til	til	ADP	prep	_	22	case	_	_
 18	at	at	SCONJ	sbu	_	22	mark	_	_
@@ -40361,7 +40361,7 @@
 # text = Hun var folkevalgt i ordets rette forstand, og et ombud i maktens korridorer for småkårsfolk i hele landet.
 1	Hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	cop	_	_
-3	folkevalgt	folkevalgt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	folkevalgt	folkevalgt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	i	i	ADP	prep	_	7	case	_	_
 5	ordets	ord	NOUN	subst	Case=Gen|Definite=Def|Gender=Neut|Number=Sing	7	nmod	_	_
 6	rette	rett	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	7	amod	_	_
@@ -40411,22 +40411,22 @@
 13	å	å	PART	inf-merke	_	14	mark	_	_
 14	stole	stole	VERB	verb	VerbForm=Inf	9	conj	_	_
 15	på	på	ADP	prep	_	18	case	_	_
-16	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	18	det	_	_
+16	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	18	nmod:poss	_	_
 17	eget	egen	DET	det	Definite=Ind|Gender=Neut|Number=Sing|PronType=Prs	18	det	_	_
 18	vett	vett	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	14	obl	_	_
 19	og	og	CCONJ	konj	_	22	cc	_	_
-20	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	22	det	_	_
+20	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	22	nmod:poss	_	_
 21	egne	egen	DET	det	Number=Plur|PronType=Prs	22	det	_	_
 22	erfaringer	erfaring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	18	conj	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 017920
 # text = Våre tanker går til Hanna Kvanmos barn, barnebarn og oldebarn som hun satte så høyt og var så stolt av.
-1	Våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	2	det	_	_
+1	Våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 2	tanker	tanke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	nsubj	_	_
 3	går	gå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	til	til	ADP	prep	_	7	case	_	_
-5	Hanna	Hanna	PROPN	subst	Gender=Fem	7	nmod	_	_
+5	Hanna	Hanna	PROPN	subst	Gender=Fem	7	nmod:poss	_	_
 6	Kvanmos	Kvanmo	PROPN	subst	Case=Gen	5	flat:name	_	_
 7	barn	barn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	3	obl	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	9	punct	_	_
@@ -40441,7 +40441,7 @@
 17	og	og	CCONJ	konj	_	20	cc	_	_
 18	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	20	cop	_	_
 19	så	så	ADV	adv	_	20	advmod	_	_
-20	stolt	stolt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	conj	_	_
+20	stolt	stolt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	conj	_	_
 21	av	av	ADV	prep	_	20	advmod	_	SpaceAfter=No
 22	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -40450,7 +40450,7 @@
 1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	expl	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	_	_
 3	med	med	ADP	prep	_	5	case	_	_
-4	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	sorg	sorg	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	0	root	_	_
 6	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	_	_
 7	mottok	motta	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	advcl	_	_
@@ -40483,7 +40483,7 @@
 
 # sent_id = 017923
 # text = Finn Gustavsen ble født i Drammen i 1926.
-1	Finn	Finn	PROPN	subst	Gender=Masc	4	nsubj	_	_
+1	Finn	Finn	PROPN	subst	Gender=Masc	4	nsubj:pass	_	_
 2	Gustavsen	Gustavsen	PROPN	subst	_	1	flat:name	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	_	_
 4	født	føde	VERB	verb	VerbForm=Part	0	root	_	_
@@ -40527,7 +40527,7 @@
 4	etterlengtet	etterlengtet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	amod	_	_
 5	pusterom	pusterom	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	2	obj	_	_
 6	for	for	ADP	prep	_	8	case	_	_
-7	alternativ	alternativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	alternativ	alternativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	tenkning	tenkning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	nmod	_	_
 9	på	på	ADP	prep	_	10	case	_	_
 10	venstresiden	venstreside	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
@@ -40553,9 +40553,9 @@
 1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-4	skarp	skarp	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+4	skarp	skarp	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 5	og	og	CCONJ	konj	_	6	cc	_	_
-6	markant	markant	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	conj	_	_
+6	markant	markant	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	conj	_	_
 7	debattant	debattant	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	10	punct	_	_
 9	og	og	CCONJ	konj	_	10	cc	_	_
@@ -40614,7 +40614,7 @@
 
 # sent_id = 017931
 # text = Finn Gustavsen ble valgt inn fra Oslo, og ble den naturlige lederskikkelsen i partiet.
-1	Finn	Finn	PROPN	subst	Gender=Masc	4	nsubj	_	_
+1	Finn	Finn	PROPN	subst	Gender=Masc	4	nsubj:pass	_	_
 2	Gustavsen	Gustavsen	PROPN	subst	_	1	flat:name	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	_	_
 4	valgt	velge	VERB	verb	VerbForm=Part	0	root	_	_
@@ -40639,7 +40639,7 @@
 4	fram	fram	ADV	prep	_	3	advmod	_	_
 5	som	som	ADP	prep	_	8	case	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	moderne	moderne	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	moderne	moderne	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	politiker	politiker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	xcomp	_	_
 9	som	som	SCONJ	sbu	_	10	mark	_	_
 10	behersket	beherske	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	acl:relcl	_	_
@@ -40672,7 +40672,7 @@
 
 # sent_id = 017934
 # text = Sosialistisk Folkepartis gruppe endte med å felle Gerhardsen-regjeringen.
-1	Sosialistisk	Sosialistisk	PROPN	subst	_	3	nmod	_	_
+1	Sosialistisk	Sosialistisk	PROPN	subst	_	3	nmod:poss	_	_
 2	Folkepartis	Folkeparti	PROPN	subst	Case=Gen	1	flat:name	_	_
 3	gruppe	gruppe	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	nsubj	_	_
 4	endte	ende	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
@@ -40690,10 +40690,10 @@
 4	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	11	cop	_	_
 5	dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-7	enorm	enorm	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
-8	personlig	personlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+7	enorm	enorm	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
+8	personlig	personlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 9	og	og	CCONJ	konj	_	10	cc	_	_
-10	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	conj	_	_
+10	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	conj	_	_
 11	belastning	belastning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	11	punct	_	_
 
@@ -40706,10 +40706,10 @@
 5	fram	fram	ADV	prep	_	3	advmod	_	_
 6	som	som	ADP	prep	_	9	case	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	modig	modig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	modig	modig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	politiker	politiker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	xcomp	_	_
 10	med	med	ADP	prep	_	12	case	_	_
-11	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	integritet	integritet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nmod	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -40748,7 +40748,7 @@
 
 # sent_id = 017939
 # text = Hans popularitet blant folk var langt større enn oppslutningen om SF skulle tilsi.
-1	Hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	2	det	_	_
+1	Hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 2	popularitet	popularitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj	_	_
 3	blant	blant	ADP	prep	_	4	case	_	_
 4	folk	folk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	2	nmod	_	_
@@ -40812,7 +40812,7 @@
 6	støttet	støtte	VERB	verb	VerbForm=Part	3	acl:relcl	_	_
 7	hovedlinjene	hovedlinje	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	6	obj	_	_
 8	i	i	ADP	prep	_	10	case	_	_
-9	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	utenriks-	utenriks-	NOUN	subst	_	7	nmod	_	_
 11	og	og	CCONJ	konj	_	12	cc	_	_
 12	sikkerhetspolitikk	sikkerhetspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	conj	_	SpaceAfter=No
@@ -40897,7 +40897,7 @@
 1	I	i	ADP	prep	_	2	case	_	_
 2	1973	1973	NUM	det	Number=Plur|NumType=Card	7	obl	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
-4	Finn	Finn	PROPN	subst	Gender=Masc	7	nsubj	_	_
+4	Finn	Finn	PROPN	subst	Gender=Masc	7	nsubj:pass	_	_
 5	Gustavsen	Gustavsen	PROPN	subst	_	4	flat:name	_	_
 6	igjen	igjen	ADV	adv	_	7	advmod	_	_
 7	innvalgt	innvelge	VERB	verb	VerbForm=Part	0	root	_	_
@@ -40923,7 +40923,7 @@
 9	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
 10	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	cop	_	_
 11	ingen	ingen	DET	det	Gender=Masc|Number=Sing|Polarity=Neg	13	det	_	_
-12	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	jobb	jobb	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	conj	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -40946,7 +40946,7 @@
 15	ble	bli	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	_	_
 16	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
 17	svært	svær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	18	advmod	_	_
-18	turbulent	turbulent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	turbulent	turbulent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	periode	periode	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	xcomp	_	_
 20	for	for	ADP	prep	_	21	case	_	_
 21	partiet	parti	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	15	obl	_	SpaceAfter=No
@@ -40954,7 +40954,7 @@
 
 # sent_id = 017949
 # text = Finn Gustavsen vil bli husket som grunnleggeren av Sosialistisk Folkeparti og som den personen som i størst grad var med på å skape rom for et sterkt og uavhengig venstreparti i norsk politikk.
-1	Finn	Finn	PROPN	subst	Gender=Masc	5	nsubj	_	_
+1	Finn	Finn	PROPN	subst	Gender=Masc	5	nsubj:pass	_	_
 2	Gustavsen	Gustavsen	PROPN	subst	_	1	flat:name	_	_
 3	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 4	bli	bli	AUX	verb	VerbForm=Inf	5	aux:pass	_	_
@@ -40985,7 +40985,7 @@
 29	uavhengig	uavhengig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	27	conj	_	_
 30	venstreparti	venstreparti	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	23	obl	_	_
 31	i	i	ADP	prep	_	33	case	_	_
-32	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	33	amod	_	_
+32	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	33	amod	_	_
 33	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	23	obl	_	SpaceAfter=No
 34	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -40999,12 +40999,12 @@
 6	Finn	Finn	PROPN	subst	Gender=Masc	3	conj	_	_
 7	Gustavsen	Gustavsen	PROPN	subst	_	6	flat:name	_	_
 8	med	med	ADP	prep	_	10	case	_	_
-9	dyp	dyp	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	dyp	dyp	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	respekt	respekt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	_
 11	og	og	CCONJ	konj	_	12	cc	_	_
 12	takknemlighet	takknemlighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	conj	_	_
 13	for	for	ADP	prep	_	15	case	_	_
-14	deres	deres	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	15	det	_	_
+14	deres	deres	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 15	virke	virke	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	2	obl	_	_
 16	på	på	ADP	prep	_	17	case	_	_
 17	Stortinget	Stortinget	PROPN	subst	Gender=Neut	15	nmod	_	SpaceAfter=No
@@ -41013,7 +41013,7 @@
 20	lyser	lyse	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	_	_
 21	fred	fred	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	20	obj	_	_
 22	over	over	ADP	prep	_	24	case	_	_
-23	deres	deres	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	24	det	_	_
+23	deres	deres	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	24	nmod:poss	_	_
 24	minne	minne	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	20	obl	_	SpaceAfter=No
 25	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -41042,10 +41042,10 @@
 12	flertall	flertall	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	appos	_	_
 13	som	som	SCONJ	sbu	_	14	mark	_	_
 14	ønsket	ønske	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	12	acl:relcl	_	_
-15	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	obj	_	_
 17	og	og	CCONJ	konj	_	19	cc	_	_
-18	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	regjering	regjering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	16	conj	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -41134,7 +41134,7 @@
 1	Regjeringen	Regjeringen	PROPN	subst	_	3	nsubj	_	_
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	bygge	bygge	VERB	verb	VerbForm=Inf	0	root	_	_
-4	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+4	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 6	på	på	ADP	prep	_	9	case	_	_
 7	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
@@ -41164,7 +41164,7 @@
 3	store	stor	ADJ	adj	Degree=Pos|Number=Plur	4	amod	_	_
 4	naturressurser	naturressurs	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	2	obj	_	_
 5	og	og	CCONJ	konj	_	7	cc	_	_
-6	uberørt	uberørt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	uberørt	uberørt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	natur	natur	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	conj	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -41248,7 +41248,7 @@
 
 # sent_id = 017967
 # text = God utdanning til alle, sterke offentlige velferdstjenester og likestilling mellom kjønnene bidrar til verdiskaping i samfunnet og til bedriftenes konkurransekraft.
-1	God	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	God	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	utdanning	utdanning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	13	nsubj	_	_
 3	til	til	ADP	prep	_	4	case	_	_
 4	alle	alle	PRON	pron	Number=Plur|Person=3|PronType=Prs,Tot	2	nmod	_	SpaceAfter=No
@@ -41311,7 +41311,7 @@
 # text = Hovedlinjene i norsk utenrikspolitikk vil ligge fast.
 1	Hovedlinjene	hovedlinje	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	6	nsubj	_	_
 2	i	i	ADP	prep	_	4	case	_	_
-3	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	utenrikspolitikk	utenrikspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	nmod	_	_
 5	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 6	ligge	ligge	VERB	verb	VerbForm=Inf	0	root	_	_
@@ -41325,7 +41325,7 @@
 3	arbeide	arbeide	VERB	verb	VerbForm=Inf	0	root	_	_
 4	for	for	ADP	prep	_	7	case	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	FN-ledet	FN-lede	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	7	amod	_	_
+6	FN-ledet	FN-lede	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	7	amod	_	_
 7	verdensorden	verdensorden	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 8	på	på	ADP	prep	_	9	case	_	_
 9	grunnlag	grunnlag	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	7	nmod	_	_
@@ -41337,12 +41337,12 @@
 # text = Bærebjelkene i vårt internasjonale engasjement vil være vårt medlemskap i NATO, EØSavtalen og det forhold at Norge ikke er medlem av EU.
 1	Bærebjelkene	bærebjelke	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	9	nsubj	_	_
 2	i	i	ADP	prep	_	5	case	_	_
-3	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+3	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 4	internasjonale	internasjonal	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	5	amod	_	_
 5	engasjement	engasjement	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	1	nmod	_	_
 6	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 7	være	være	AUX	verb	VerbForm=Inf	9	cop	_	_
-8	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	9	det	_	_
+8	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 9	medlemskap	medlemskap	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	0	root	_	_
 10	i	i	ADP	prep	_	11	case	_	_
 11	NATO	NATO	NOUN	subst	Abbr=Yes	9	nmod	_	SpaceAfter=No
@@ -41401,7 +41401,7 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 3	være	være	AUX	verb	VerbForm=Inf	6	cop	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	tydelig	tydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	tydelig	tydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	fredsnasjon	fredsnasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -41527,8 +41527,8 @@
 
 # sent_id = 017983
 # text = Norsk deltakelse i ISAF-styrkene i Afghanistan skal styrkes, og mandatet for norsk deltakelse i Operation Enduring Freedom i Afghanistan vil derfor ikke bli fornyet.
-1	Norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
-2	deltakelse	deltakelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nsubj	_	_
+1	Norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
+2	deltakelse	deltakelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nsubj:pass	_	_
 3	i	i	ADP	prep	_	4	case	_	_
 4	ISAF-styrkene	ISAF-styrke	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	2	nmod	_	_
 5	i	i	ADP	prep	_	6	case	_	_
@@ -41537,9 +41537,9 @@
 8	styrkes	styrke	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	25	punct	_	_
 10	og	og	CCONJ	konj	_	25	cc	_	_
-11	mandatet	mandat	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	25	nsubj	_	_
+11	mandatet	mandat	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	25	nsubj:pass	_	_
 12	for	for	ADP	prep	_	14	case	_	_
-13	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	deltakelse	deltakelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nmod	_	_
 15	i	i	ADP	prep	_	16	case	_	_
 16	Operation	Operation	PROPN	subst	_	14	nmod	_	_
@@ -41572,7 +41572,7 @@
 
 # sent_id = 017985
 # text = Forsvaret skal tilpasses de nye sikkerhetsutfordringene.
-1	Forsvaret	Forsvaret	PROPN	subst	_	3	nsubj	_	_
+1	Forsvaret	Forsvaret	PROPN	subst	_	3	nsubj:pass	_	_
 2	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	tilpasses	tilpasse	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 4	de	de	DET	det	Number=Plur|PronType=Art	6	det	_	_
@@ -41625,11 +41625,11 @@
 5	med	med	ADP	prep	_	7	case	_	_
 6	å	å	PART	inf-merke	_	7	mark	_	_
 7	hevde	hevde	VERB	verb	VerbForm=Inf	4	acl	_	_
-8	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	suverenitet	suverenitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	_
 10	og	og	CCONJ	konj	_	11	cc	_	_
 11	sikre	sikre	VERB	verb	VerbForm=Inf	3	conj	_	_
-12	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	forvaltning	forvaltning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	obj	_	_
 14	av	av	ADP	prep	_	17	case	_	_
 15	de	de	DET	det	Number=Plur|PronType=Art	17	det	_	_
@@ -41662,7 +41662,7 @@
 5	med	med	ADP	prep	_	6	case	_	_
 6	Russland	Russland	PROPN	subst	_	4	nmod	_	_
 7	og	og	CCONJ	konj	_	10	cc	_	_
-8	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	det	_	_
+8	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	nmod:poss	_	_
 9	andre	annen	DET	det	Number=Plur|PronType=Dem	10	det	_	_
 10	partnere	partner	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	6	conj	_	_
 11	i	i	ADP	prep	_	12	case	_	_
@@ -41696,7 +41696,7 @@
 9	og	og	CCONJ	konj	_	10	cc	_	_
 10	føre	føre	VERB	verb	VerbForm=Inf	3	conj	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-12	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	europapolitikk	europapolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obj	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -41712,7 +41712,7 @@
 8	EØSavtalen	EØSavtalen	PROPN	subst	_	6	obl	_	_
 9	og	og	CCONJ	konj	_	10	cc	_	_
 10	sikre	sikre	VERB	verb	VerbForm=Inf	3	conj	_	_
-11	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	bruk	bruk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obj	_	_
 13	av	av	ADP	prep	_	16	case	_	_
 14	alle	all	DET	det	Number=Plur|PronType=Tot	16	det	_	_
@@ -41734,9 +41734,9 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	føre	føre	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-5	human	human	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+5	human	human	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 6	og	og	CCONJ	konj	_	7	cc	_	_
-7	solidarisk	solidarisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	_
+7	solidarisk	solidarisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	_
 8	flyktning-	flyktning-	NOUN	subst	_	3	obj	_	_
 9	og	og	CCONJ	konj	_	10	cc	_	_
 10	asylpolitikk	asylpolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	conj	_	SpaceAfter=No
@@ -41864,7 +41864,7 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	bidra	bidra	VERB	verb	VerbForm=Inf	0	root	_	_
 4	til	til	ADP	prep	_	6	case	_	_
-5	økt	øke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	6	amod	_	_
+5	økt	øke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	6	amod	_	_
 6	åpenhet	åpenhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obl	_	_
 7	i	i	ADP	prep	_	8	case	_	_
 8	forhandlingene	forhandling	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	6	nmod	_	_
@@ -41904,7 +41904,7 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	ha	ha	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	helhetlig	helhetlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	helhetlig	helhetlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	gjennomgang	gjennomgang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 7	av	av	ADP	prep	_	9	case	_	_
 8	WTO-forhandlingenes	WTO-forhandling	NOUN	subst	Case=Gen|Definite=Def|Gender=Fem|Number=Plur	9	nmod	_	_
@@ -41934,12 +41934,12 @@
 3	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	_	_
 4	ha	ha	VERB	verb	VerbForm=Inf	0	root	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	næringspolitikk	næringspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 8	og	og	CCONJ	konj	_	12	cc	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-10	ansvarlig	ansvarlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
-11	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+10	ansvarlig	ansvarlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
+11	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	conj	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -42013,13 +42013,13 @@
 11	med	med	ADP	prep	_	13	case	_	_
 12	å	å	PART	inf-merke	_	13	mark	_	_
 13	hindre	hindre	VERB	verb	VerbForm=Inf	10	acl	_	_
-14	sosial	sosial	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	sosial	sosial	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	dumping	dumping	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	13	obj	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 018007
 # text = Forslag om dette vil bli fremmet før jul.
-1	Forslag	forslag	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	6	nsubj	_	_
+1	Forslag	forslag	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	6	nsubj:pass	_	_
 2	om	om	ADP	prep	_	3	case	_	_
 3	dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	1	nmod	_	_
 4	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
@@ -42084,7 +42084,7 @@
 1	I	i	ADP	prep	_	2	case	_	_
 2	tillegg	tillegg	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	obl	_	_
 3	anbefales	anbefale	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
-4	Áarstova	Áarstova	PROPN	subst	_	3	nsubj	_	SpaceAfter=No
+4	Áarstova	Áarstova	PROPN	subst	_	3	nsubj:pass	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	6	punct	_	_
 6	sushirestauranten	sushirestaurant	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	conj	_	_
 7	Etika	Etika	PROPN	subst	_	6	appos	_	_
@@ -42150,7 +42150,7 @@
 1	Musikk	musikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 6	av	av	ADP	prep	_	7	case	_	_
 7	livet	liv	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	5	nmod	_	_
@@ -42160,7 +42160,7 @@
 
 # sent_id = 018018
 # text = Konserter holdes hele året, men verdt å merke seg er Summartónar, en musikkfestival som foregår rundt omkring på øyene fra juni til august.
-1	Konserter	konsert	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	2	nsubj	_	_
+1	Konserter	konsert	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	2	nsubj:pass	_	_
 2	holdes	holde	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 3	hele	hel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	4	amod	_	_
 4	året	år	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	obl	_	SpaceAfter=No
@@ -42283,7 +42283,7 @@
 6	,	$,	PUNCT	<komma>	_	7	punct	_	_
 7	pledd	pledd	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	1	conj	_	_
 8	i	i	ADP	prep	_	10	case	_	_
-9	tradisjonell	tradisjonell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	tradisjonell	tradisjonell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	strikk	strikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nmod	_	_
 11	finnes	finnes	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 12	over	over	ADP	prep	_	13	case	_	_
@@ -42332,7 +42332,7 @@
 
 # sent_id = 018031
 # text = Boken ble filmatisert og vist som serie på NRK tidligere i år.
-1	Boken	bok	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
+1	Boken	bok	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	filmatisert	filmatisere	VERB	verb	VerbForm=Part	0	root	_	_
 4	og	og	CCONJ	konj	_	5	cc	_	_
@@ -42363,7 +42363,7 @@
 2	200	200	NUM	det	Number=Plur|NumType=Card	3	nummod	_	_
 3	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	4	obl	_	_
 4	gammelt	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	amod	_	_
-5	brev	brev	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	10	nsubj	_	_
+5	brev	brev	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	10	nsubj:pass	_	_
 6	fra	fra	ADP	prep	_	7	case	_	_
 7	Napoleon	Napoleon	PROPN	subst	_	5	nmod	_	_
 8	Bonaparte	Bonaparte	PROPN	subst	_	7	flat:name	_	_
@@ -42389,7 +42389,7 @@
 5	franske	fransk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	6	amod	_	_
 6	lederen	leder	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 7	om	om	ADP	prep	_	9	case	_	_
-8	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	9	det	_	_
+8	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 9	planer	plan	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	obl	_	_
 10	om	om	ADP	prep	_	12	case	_	_
 11	å	å	PART	inf-merke	_	12	mark	_	_
@@ -42476,7 +42476,7 @@
 7	,	$,	PUNCT	<komma>	_	14	punct	_	_
 8	og	og	CCONJ	konj	_	14	cc	_	_
 9	flere	mange	ADJ	adj	Degree=Cmp	10	amod	_	_
-10	tårn	tårn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	14	nsubj	_	_
+10	tårn	tårn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	14	nsubj:pass	_	_
 11	og	og	CCONJ	konj	_	12	cc	_	_
 12	vegger	vegg	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	10	conj	_	_
 13	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	14	aux:pass	_	_
@@ -42489,7 +42489,7 @@
 
 # sent_id = 018039
 # text = De er senere blitt gjenoppbygget.
-1	De	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	_	_
+1	De	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj:pass	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 3	senere	sen	ADJ	adj	Degree=Cmp	5	advmod	_	_
 4	blitt	bli	AUX	verb	VerbForm=Part	5	aux:pass	_	_
@@ -42510,7 +42510,7 @@
 10	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	expl	_	_
 11	ventet	vente	VERB	verb	VerbForm=Part	0	root	_	_
 12	at	at	SCONJ	sbu	_	16	mark	_	_
-13	brevet	brev	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	16	nsubj	_	_
+13	brevet	brev	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	16	nsubj:pass	_	_
 14	ville	ville	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	16	aux	_	_
 15	bli	bli	AUX	verb	VerbForm=Inf	16	aux:pass	_	_
 16	solgt	selge	VERB	verb	VerbForm=Part	11	xcomp	_	_
@@ -42637,7 +42637,7 @@
 # text = I en kort tale på Malis statlige fjernsyn sa Diarra tirsdag at han går av med hele sin regjering.
 1	I	i	ADP	prep	_	4	case	_	_
 2	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-3	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	tale	tale	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obl	_	_
 5	på	på	ADP	prep	_	8	case	_	_
 6	Malis	Mali	PROPN	subst	Case=Gen	8	nmod	_	_
@@ -42652,7 +42652,7 @@
 15	av	av	ADV	prep	_	14	advmod	_	_
 16	med	med	ADP	prep	_	19	case	_	_
 17	hele	hel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	19	amod	_	_
-18	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	19	det	_	_
+18	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 19	regjering	regjering	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	obl	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	9	punct	_	_
 
@@ -42781,7 +42781,7 @@
 5	de	de	DET	det	Number=Plur|PronType=Art	6	det	_	_
 6	militære	militær	ADJ	adj	Degree=Pos|Number=Plur	3	amod	_	_
 7	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	aux:pass	_	_
-8	Diarra	Diarra	PROPN	subst	_	9	nsubj	_	_
+8	Diarra	Diarra	PROPN	subst	_	9	nsubj:pass	_	_
 9	arrestert	arrestere	VERB	verb	VerbForm=Part	0	root	_	_
 10	fordi	fordi	SCONJ	sbu	_	12	mark	_	_
 11	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nsubj	_	_
@@ -42814,7 +42814,7 @@
 18	vite	vite	VERB	verb	VerbForm=Inf	13	advcl	_	_
 19	at	at	SCONJ	sbu	_	23	mark	_	_
 20	bagasjen	bagasje	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	23	nsubj	_	_
-21	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	20	det	_	_
+21	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	20	nmod:poss	_	_
 22	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	23	cop	_	_
 23	tatt	ta	VERB	verb	VerbForm=Part	18	xcomp	_	_
 24	av	av	ADP	prep	_	25	case	_	_
@@ -42838,7 +42838,7 @@
 9	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nsubj	_	_
 10	ønsker	ønske	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	ccomp	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-12	rask	rask	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	rask	rask	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	militæraksjon	militæraksjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obj	_	_
 14	for	for	ADP	prep	_	16	case	_	_
 15	å	å	PART	inf-merke	_	16	mark	_	_
@@ -42904,7 +42904,7 @@
 
 # sent_id = 018059
 # text = Diarra ble utnevnt til statsminister i en interimsregjering noen uker etter et kupp i mars som kastet det tidligere stabile landet ut i kaos.
-1	Diarra	Diarra	PROPN	subst	_	3	nsubj	_	_
+1	Diarra	Diarra	PROPN	subst	_	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	utnevnt	utnevne	VERB	verb	VerbForm=Part	0	root	_	_
 4	til	til	ADP	prep	_	5	case	_	_
@@ -42948,8 +42948,8 @@
 2	militærregimet	militærregime	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	9	obl	_	_
 3	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
-6	statsminister	statsminister	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nsubj	_	_
+5	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
+6	statsminister	statsminister	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nsubj:pass	_	_
 7	snart	snar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
 8	bli	bli	AUX	verb	VerbForm=Inf	9	aux:pass	_	_
 9	utnevnt	utnevne	VERB	verb	VerbForm=Part	0	root	_	SpaceAfter=No
@@ -43020,7 +43020,7 @@
 8	at	at	SCONJ	sbu	_	15	mark	_	_
 9	tuaregene	tuareg	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	15	nsubj	_	_
 10	og	og	CCONJ	konj	_	13	cc	_	_
-11	deres	deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	det	_	_
+11	deres	deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 12	islamistiske	islamistisk	ADJ	adj	Degree=Pos|Number=Plur	13	amod	_	_
 13	allierte	alliert	ADJ	adj	Degree=Pos|Number=Plur	9	conj	_	_
 14	kunne	kunne	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	15	aux	_	_
@@ -43057,7 +43057,7 @@
 5	planer	plan	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	4	obj	_	_
 6	for	for	ADP	prep	_	9	case	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	militær	militær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	militær	militær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	intervensjon	intervensjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nmod	_	_
 10	og	og	CCONJ	konj	_	12	cc	_	_
 11	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	_	_
@@ -43084,7 +43084,7 @@
 8	med	med	ADP	prep	_	9	case	_	_
 9	opplæring	opplæring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	obl	_	_
 10	og	og	CCONJ	konj	_	12	cc	_	_
-11	logistisk	logistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	logistisk	logistisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	støtte	støtte	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	conj	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -43122,8 +43122,8 @@
 2	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	_
 3	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	fortsatt	fortsatt	ADV	adv	_	3	advmod	_	_
-5	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
-6	internasjonal	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+5	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
+6	internasjonal	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	skepsis	skepsis	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nsubj	_	_
 8	mot	mot	ADP	prep	_	9	case	_	_
 9	planen	plan	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	_
@@ -43178,7 +43178,7 @@
 12	soldatene	soldat	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	15	nsubj	_	_
 13	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
 14	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	15	advmod	_	_
-15	egnet	egnet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	ccomp	_	_
+15	egnet	egnet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	ccomp	_	_
 16	til	til	ADP	prep	_	18	case	_	_
 17	å	å	PART	inf-merke	_	18	mark	_	_
 18	krige	krige	VERB	verb	VerbForm=Inf	15	advcl	_	_
@@ -43211,7 +43211,7 @@
 7	i	i	ADP	prep	_	8	case	_	_
 8	Bamako	Bamako	PROPN	subst	_	6	nmod	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	_	_
-10	svak	svak	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+10	svak	svak	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 11	og	og	CCONJ	konj	_	15	cc	_	_
 12	ennå	ennå	ADV	adv	_	15	advmod	_	_
 13	ikke	ikke	PART	adv	Polarity=Neg	15	advmod	_	_
@@ -43228,7 +43228,7 @@
 24	med	med	ADP	prep	_	28	case	_	_
 25	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	28	det	_	_
 26	demokratisk	demokratisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	27	advmod	_	_
-27	valgt	velge	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	28	amod	_	_
+27	valgt	velge	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	28	amod	_	_
 28	regjering	regjering	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	22	obl	_	SpaceAfter=No
 29	.	$.	PUNCT	clb	_	10	punct	_	_
 
@@ -43239,13 +43239,13 @@
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 4	utnevnt	utnevne	VERB	verb	VerbForm=Part	0	root	_	_
 5	til	til	ADP	prep	_	7	case	_	_
-6	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	statsminister	statsminister	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 8	i	i	ADP	prep	_	9	case	_	_
 9	Mali	Mali	PROPN	subst	_	7	nmod	_	_
 10	etter	etter	ADP	prep	_	17	case	_	_
 11	at	at	SCONJ	sbu	_	17	mark	_	_
-12	forgjengeren	forgjenger	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	17	nsubj	_	_
+12	forgjengeren	forgjenger	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	17	nsubj:pass	_	_
 13	Cheick	Cheick	PROPN	subst	_	12	appos	_	_
 14	Modibo	Modibo	PROPN	subst	_	13	flat:name	_	_
 15	Diarra	Diarra	PROPN	subst	_	13	flat:name	_	_
@@ -43259,7 +43259,7 @@
 
 # sent_id = 018074
 # text = Cissoko ble utnevnt av landets midlertidige president Dioncounda Traore tirsdag kveld.
-1	Cissoko	Cissoko	PROPN	subst	_	3	nsubj	_	_
+1	Cissoko	Cissoko	PROPN	subst	_	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	utnevnt	utnevne	VERB	verb	VerbForm=Part	0	root	_	_
 4	av	av	ADP	prep	_	8	case	_	_
@@ -43286,7 +43286,7 @@
 10	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	9	obj	_	_
 11	etter	etter	ADP	prep	_	17	case	_	_
 12	at	at	SCONJ	sbu	_	17	mark	_	_
-13	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	17	nsubj	_	_
+13	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	17	nsubj:pass	_	_
 14	dagen	dag	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	17	obl	_	_
 15	før	før	ADP	prep	_	14	nmod	_	_
 16	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	17	aux:pass	_	_
@@ -43358,16 +43358,16 @@
 1	Midt	midt	ADV	adv	_	7	advmod	_	_
 2	i	i	ADP	prep	_	7	case	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	koloni	koloni	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nmod	_	_
-6	aggressiv	aggressiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	aggressiv	aggressiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	sel	sel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	7	punct	_	_
 9	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	_	_
 10	Norge	Norge	PROPN	subst	_	11	nsubj	_	_
 11	etablere	etablere	VERB	verb	VerbForm=Inf	0	root	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-13	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	forskningsstasjon	forskningsstasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obj	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	11	punct	_	_
 
@@ -43518,7 +43518,7 @@
 21	av	av	ADP	prep	_	22	case	_	_
 22	landoverflaten	landoverflate	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	_
 23	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	24	cop	_	_
-24	dekket	dekke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	4	conj	_	_
+24	dekket	dekke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	4	conj	_	_
 25	av	av	ADP	prep	_	26	case	_	_
 26	is	is	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	24	obl	_	SpaceAfter=No
 27	.	$.	PUNCT	clb	_	4	punct	_	_
@@ -43581,7 +43581,7 @@
 11	og	og	CCONJ	konj	_	12	cc	_	_
 12	steinras	steinras	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	10	conj	_	_
 13	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	_	_
-14	overhengende	overhengende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	conj	_	SpaceAfter=No
+14	overhengende	overhengende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	conj	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 018095
@@ -43591,7 +43591,7 @@
 3	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	_
 5	ekstremt	ekstrem	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
-6	kraftig	kraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	kraftig	kraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	vind	vind	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nsubj	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	10	punct	_	_
 9	hele	hel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	10	amod	_	_
@@ -43615,7 +43615,7 @@
 13	som	som	SCONJ	sbu	_	14	mark	_	_
 14	verner	verne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	acl:relcl	_	_
 15	om	om	ADP	prep	_	17	case	_	_
-16	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	17	det	_	_
+16	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
 17	revir	revir	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	14	obl	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -43643,7 +43643,7 @@
 1	-	$-	PUNCT	<strek>	_	10	punct	_	_
 2	Selv	selv	ADV	adv	_	3	advmod	_	_
 3	om	om	SCONJ	sbu	_	6	mark	_	_
-4	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	5	det	_	_
+4	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	folk	folk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	6	nsubj	_	_
 6	bruker	bruke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	advcl	_	_
 7	beskyttelse	beskyttelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
@@ -43715,9 +43715,9 @@
 10	bakken	bakke	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
 11	som	som	SCONJ	sbu	_	13	mark	_	_
 12	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	cop	_	_
-13	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+13	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 14	av	av	ADP	prep	_	16	case	_	_
-15	illeluktende	illeluktende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	illeluktende	illeluktende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	selmøkk	selmøkk	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	13	obl	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -43765,7 +43765,7 @@
 17	bad	bad	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	13	conj	_	_
 18	og	og	CCONJ	konj	_	19	cc	_	_
 19	oppholdsrom	oppholdsrom	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	13	conj	_	_
-20	utstyrt	utstyre	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	2	conj	_	_
+20	utstyrt	utstyre	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	2	conj	_	_
 21	med	med	ADP	prep	_	23	case	_	_
 22	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	23	det	_	_
 23	laboratorium	laboratorium	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	20	obl	_	SpaceAfter=No
@@ -43786,7 +43786,7 @@
 2	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
 3	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	6	obl	_	_
 4	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
-5	stasjonen	stasjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
+5	stasjonen	stasjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	nsubj:pass	_	_
 6	fraktes	frakte	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 7	til	til	ADP	prep	_	8	case	_	_
 8	Bouvetøya	Bouvetøya	PROPN	subst	Gender=Fem	6	obl	_	_

--- a/data/converted/no_bokmaal-ud-test.conllu
+++ b/data/converted/no_bokmaal-ud-test.conllu
@@ -13,7 +13,7 @@
 10	"	$"	PUNCT	<anf>	_	9	punct	_	_
 11	og	og	CCONJ	konj	_	14	cc	_	_
 12	"	$"	PUNCT	<anf>	_	14	punct	_	SpaceAfter=No
-13	livgivende	livgivende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	livgivende	livgivende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	kontrast	kontrast	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	conj	_	SpaceAfter=No
 15	"	$"	PUNCT	<anf>	_	14	punct	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	5	punct	_	_
@@ -26,7 +26,7 @@
 4	landskap	landskap	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	2	obj	_	_
 5	som	som	SCONJ	sbu	_	7	mark	_	_
 6	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
-7	såret	såre	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	4	amod	_	_
+7	såret	såre	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	4	amod	_	_
 8	og	og	CCONJ	konj	_	10	cc	_	_
 9	i	i	ADP	prep	_	10	case	_	_
 10	tilbaketrekning	tilbaketrekning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	conj	_	SpaceAfter=No
@@ -48,7 +48,7 @@
 3	senere	sen	ADJ	adj	Degree=Cmp	1	conj	_	_
 4	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	hjemsøkt	hjemsøke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	7	amod	_	_
+6	hjemsøkt	hjemsøke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	7	amod	_	_
 7	verden	verden	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nsubj	_	_
 8	måtte	måtte	AUX	verb	VerbForm=Inf	9	aux	_	_
 9	innse	innse	VERB	verb	VerbForm=Inf	0	root	_	_
@@ -133,7 +133,7 @@
 1	Dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 3	som	som	ADP	prep	_	6	case	_	_
-4	George	George	PROPN	subst	Gender=Masc	6	nmod	_	_
+4	George	George	PROPN	subst	Gender=Masc	6	nmod:poss	_	_
 5	Orwells	Orwell	PROPN	subst	Case=Gen	4	flat:name	_	_
 6	nytale	nytale	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	11	punct	_	_
@@ -170,7 +170,7 @@
 4	dem	de	PRON	pron	Case=Acc|Number=Plur|Person=3|PronType=Prs	2	nmod	_	_
 5	som	som	SCONJ	sbu	_	6	mark	_	_
 6	tegner	tegne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	_	_
-7	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	det	_	_
+7	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	hus	hus	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	6	obj	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	4	punct	_	_
 10	prøver	prøve	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -201,7 +201,7 @@
 35	stundom	stundom	ADV	adv	_	38	advmod	_	_
 36	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	38	cop	_	_
 37	mer	mye	ADJ	adj	Degree=Cmp	38	advmod	_	_
-38	takknemlig	takknemlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	29	conj	_	_
+38	takknemlig	takknemlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	29	conj	_	_
 39	å	å	PART	inf-merke	_	40	mark	_	_
 40	forene	forene	VERB	verb	VerbForm=Inf	38	advcl	_	_
 41	med	med	ADP	prep	_	42	case	_	_
@@ -224,7 +224,7 @@
 5	bransjen	bransje	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 6	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux:pass	_	_
 7	slike	slik	DET	det	Number=Plur|PronType=Dem	8	det	_	_
-8	avvik	avvik	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	9	nsubj	_	_
+8	avvik	avvik	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	9	nsubj:pass	_	_
 9	forsøkt	forsøke	VERB	verb	VerbForm=Part	0	root	_	_
 10	bannlyst	bannlyse	VERB	verb	VerbForm=Part	9	ccomp	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	15	punct	_	_
@@ -267,7 +267,7 @@
 8	at	at	SCONJ	sbu	_	15	mark	_	_
 9	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	expl	_	_
 10	blant	blant	ADP	prep	_	12	case	_	_
-11	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	det	_	_
+11	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 12	tonekunstnere	tonekunstner	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	15	obl	_	_
 13	fortsatt	fortsatt	ADV	adv	_	15	advmod	_	_
 14	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
@@ -372,7 +372,7 @@
 4	Singapore	Singapore	PROPN	subst	_	2	conj	_	_
 5	kanskje	kanskje	ADV	adv	_	8	advmod	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	engelsk	engelsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	engelsk	engelsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	fot	fot	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	8	punct	_	_
 
@@ -385,7 +385,7 @@
 5	vokser	vokse	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	_	_
 6	Og	og	CCONJ	konj	_	9	cc	_	_
 7	livet	liv	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	9	nsubj	_	_
-8	ditt	din	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+8	ditt	din	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 9	blir	bli	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	_	_
 10	mindre	liten	ADJ	adj	Degree=Cmp	13	advmod	_	_
 11	og	og	CCONJ	konj	_	12	cc	_	_
@@ -508,7 +508,7 @@
 4	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 5	vært	være	AUX	verb	VerbForm=Part	7	cop	_	_
 6	relativt	relativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	advmod	_	_
-7	lav	lav	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+7	lav	lav	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 8	i	i	ADP	prep	_	9	case	_	_
 9	Europa	Europa	PROPN	subst	_	7	obl	_	_
 10	gjennom	gjennom	ADP	prep	_	12	case	_	_
@@ -546,10 +546,10 @@
 12	klart	klare	VERB	verb	VerbForm=Part	8	acl	_	_
 13	å	å	PART	inf-merke	_	14	mark	_	_
 14	kombinere	kombinere	VERB	verb	VerbForm=Inf	12	xcomp	_	_
-15	geografisk	geografisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	geografisk	geografisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	utvidelse	utvidelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	obj	_	_
 17	og	og	CCONJ	konj	_	19	cc	_	_
-18	innholdsmessig	innholdsmessig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	innholdsmessig	innholdsmessig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	fordypelse	fordypelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	conj	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -590,9 +590,9 @@
 17	med	med	ADP	prep	_	23	case	_	_
 18	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
 19	i	i	ADP	prep	_	21	case	_	_
-20	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	amod	_	_
+20	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	amod	_	_
 21	grad	grad	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	22	obl	_	_
-22	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	amod	_	_
+22	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	amod	_	_
 23	valuta	valuta	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	nmod	_	_
 24	og	og	CCONJ	konj	_	27	cc	_	_
 25	til	til	ADP	prep	_	27	case	_	_
@@ -602,7 +602,7 @@
 29	å	å	PART	inf-merke	_	30	mark	_	_
 30	etablere	etablere	VERB	verb	VerbForm=Inf	27	acl	_	_
 31	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	33	det	_	_
-32	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	33	amod	_	_
+32	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	33	amod	_	_
 33	utenriks-	utenriks-	NOUN	subst	_	30	obj	_	_
 34	og	og	CCONJ	konj	_	35	cc	_	_
 35	sikkerhetspolitikk	sikkerhetspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	33	conj	_	SpaceAfter=No
@@ -628,7 +628,7 @@
 16	endepunkt	endepunkt	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	13	obj	_	_
 17	og	og	CCONJ	konj	_	24	cc	_	_
 18	at	at	SCONJ	sbu	_	24	mark	_	_
-19	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	24	nsubj	_	_
+19	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	24	nsubj:pass	_	_
 20	heller	heller	ADV	adv	_	24	advmod	_	_
 21	ikke	ikke	PART	adv	Polarity=Neg	24	advmod	_	_
 22	lenger	lenge	ADJ	adj	Degree=Cmp	24	advmod	_	_
@@ -673,7 +673,7 @@
 10	,	$,	PUNCT	<komma>	_	9	punct	_	_
 11	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	22	aux	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-13	hel	hel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	hel	hel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	serie	serie	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	nmod	_	_
 15	stater	stat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	22	nsubj	_	_
 16	fra	fra	ADP	prep	_	19	case	_	_
@@ -746,7 +746,7 @@
 # text = Noe mer usikker er Moldova, Hviterussland og Georgia og sogar kanskje også andre stater i Kaukasus.
 1	Noe	noen	DET	det	Gender=Neut|Number=Sing|PronType=Ind	2	det	_	_
 2	mer	mye	ADJ	adj	Degree=Cmp	3	advmod	_	_
-3	usikker	usikker	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	usikker	usikker	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
 5	Moldova	Moldova	PROPN	subst	_	3	nsubj	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	7	punct	_	_
@@ -857,7 +857,7 @@
 2	eneste	eneste	NUM	det	Definite=Def|NumType=Card	21	nsubj:outer	_	_
 3	som	som	SCONJ	sbu	_	9	mark	_	_
 4	på	på	ADP	prep	_	6	case	_	_
-5	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	sikt	sikt	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	obl	_	_
 7	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 8	kunne	kunne	AUX	verb	VerbForm=Inf	9	aux	_	_
@@ -865,8 +865,8 @@
 10	liv	liv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	obj	_	_
 11	i	i	ADP	prep	_	15	case	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
-13	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
-14	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+13	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
+14	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	EU-debatt	EU-debatt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	9	punct	_	_
 17	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	21	cop	_	_
@@ -899,7 +899,7 @@
 
 # sent_id = 018150
 # text = Enstemmig godkjennelse av traktater er svært krevende.
-1	Enstemmig	enstemmig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Enstemmig	enstemmig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	godkjennelse	godkjennelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj	_	_
 3	av	av	ADP	prep	_	4	case	_	_
 4	traktater	traktat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	2	nmod	_	_
@@ -910,10 +910,10 @@
 
 # sent_id = 018151
 # text = Utkastet til en konstitusjonell traktat ble stemt ned i Frankrike og Nederland i 2005.
-1	Utkastet	utkast	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	nsubj	_	_
+1	Utkastet	utkast	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	nsubj:pass	_	_
 2	til	til	ADP	prep	_	5	case	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	konstitusjonell	konstitusjonell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	konstitusjonell	konstitusjonell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	traktat	traktat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	nmod	_	_
 6	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
 7	stemt	stemme	VERB	verb	VerbForm=Part	0	root	_	_
@@ -928,7 +928,7 @@
 
 # sent_id = 018152
 # text = Lisboa-traktaten, som skulle redde de nye institusjonelle elementene, ble så forkastet i Irland.
-1	Lisboa-traktaten	Lisboa-traktaten	PROPN	subst	_	13	nsubj	_	SpaceAfter=No
+1	Lisboa-traktaten	Lisboa-traktaten	PROPN	subst	_	13	nsubj:pass	_	SpaceAfter=No
 2	,	$,	PUNCT	<komma>	_	5	punct	_	_
 3	som	som	SCONJ	sbu	_	5	mark	_	_
 4	skulle	skulle	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux	_	_
@@ -986,7 +986,7 @@
 # text = De økonomiske krisepakkene vedtas først og fremst på nasjonalstatsnivå; EUs miljøsatsing er full av særordninger av alle mulige slag.
 1	De	de	DET	det	Number=Plur|PronType=Art	3	det	_	_
 2	økonomiske	økonomisk	ADJ	adj	Degree=Pos|Number=Plur	3	amod	_	_
-3	krisepakkene	krisepakke	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	4	nsubj	_	_
+3	krisepakkene	krisepakke	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	4	nsubj:pass	_	_
 4	vedtas	vedta	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 5	først	først	ADV	adv	_	4	advmod	_	_
 6	og	og	CCONJ	konj	_	7	cc	_	_
@@ -997,7 +997,7 @@
 11	EUs	EU	PROPN	subst	Abbr=Yes|Case=Gen	12	nmod	_	_
 12	miljøsatsing	miljøsatsing	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	14	nsubj	_	_
 13	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	_	_
-14	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	conj	_	_
+14	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	conj	_	_
 15	av	av	ADP	prep	_	16	case	_	_
 16	særordninger	særordning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	14	obl	_	_
 17	av	av	ADP	prep	_	20	case	_	_
@@ -1046,7 +1046,7 @@
 7	å	å	PART	inf-merke	_	8	mark	_	_
 8	lede	lede	VERB	verb	VerbForm=Inf	6	acl	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-10	seriøs	seriøs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	seriøs	seriøs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	organisasjon	organisasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obj	_	_
 12	på	på	ADV	prep	_	8	advmod	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	6	punct	_	_
@@ -1059,7 +1059,7 @@
 4	området	område	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	11	obl	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	_	_
 6	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	utenriks-	utenriks-	NOUN	subst	_	11	nsubj	_	SpaceAfter=No
 9	og	og	CCONJ	konj	_	10	cc	_	_
 10	sikkerhetspolitikk	sikkerhetspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	conj	_	_
@@ -1128,7 +1128,7 @@
 22	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	23	aux	_	_
 23	hatt	ha	VERB	verb	VerbForm=Part	19	acl:relcl	_	_
 24	i	i	ADP	prep	_	26	case	_	_
-25	internasjonal	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	amod	_	_
+25	internasjonal	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	amod	_	_
 26	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	23	obl	_	SpaceAfter=No
 27	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -1136,7 +1136,7 @@
 # sent_id = 018164
 # text = En ny metode på Ullevål universitetssykehus gjør at premature og syke nyfødte nå kan ligge uforstyrret og småsove mens sykepleierne tar blodprøver.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	metode	metode	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj	_	_
 4	på	på	ADP	prep	_	5	case	_	_
 5	Ullevål	Ullevål	PROPN	subst	_	3	nmod	_	_
@@ -1150,7 +1150,7 @@
 13	nå	nå	ADV	adv	_	15	advmod	_	_
 14	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	_	_
 15	ligge	ligge	VERB	verb	VerbForm=Inf	7	xcomp	_	_
-16	uforstyrret	uforstyrret	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	xcomp	_	_
+16	uforstyrret	uforstyrret	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	xcomp	_	_
 17	og	og	CCONJ	konj	_	18	cc	_	_
 18	småsove	småsove	VERB	verb	VerbForm=Inf	15	conj	_	_
 19	mens	mens	SCONJ	sbu	_	21	mark	_	_
@@ -1190,7 +1190,7 @@
 # newpar
 # sent_id = 018166
 # text = Johannes og Tilda Borg ble født etter bare 25 uker i mamma Therese Fosholt Moes mage.
-1	Johannes	Johannes	PROPN	subst	Gender=Masc	6	nsubj	_	_
+1	Johannes	Johannes	PROPN	subst	Gender=Masc	6	nsubj:pass	_	_
 2	og	og	CCONJ	konj	_	3	cc	_	_
 3	Tilda	Tilda	PROPN	subst	_	1	conj	_	_
 4	Borg	Borg	PROPN	subst	_	3	flat:name	_	_
@@ -1293,7 +1293,7 @@
 # text = Men en ny metode for blodprøvetaking av premature skal innebære mindre smerte og forstyrrelse for barnet.
 1	Men	men	CCONJ	konj	_	10	cc	_	_
 2	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-3	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	metode	metode	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nsubj	_	_
 5	for	for	ADP	prep	_	6	case	_	_
 6	blodprøvetaking	blodprøvetaking	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	nmod	_	_
@@ -1342,7 +1342,7 @@
 5	de	de	DET	det	Number=Plur|PronType=Art	7	det	_	_
 6	hyppigste	hyppig	ADJ	adj	Definite=Def|Degree=Sup	7	amod	_	_
 7	smertestimuliene	smertestimulus	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	3	nmod	_	_
-8	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	9	nsubj	_	_
+8	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	9	nsubj:pass	_	_
 9	utsettes	utsette	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	7	acl:relcl	_	_
 10	for	for	ADV	prep	_	9	advmod	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	14	punct	_	_
@@ -1417,7 +1417,7 @@
 # newpar
 # sent_id = 018176
 # text = Kapillær hælprøve (se faktaboks) er tradisjonelt den mest brukte metoden for blodprøvetaking av små barn, selv om forskning viser at den er smertefull.
-1	Kapillær	kapillær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Kapillær	kapillær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	hælprøve	hælprøve	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	12	nsubj	_	_
 3	(	$(	PUNCT	<parentes-beg>	_	4	punct	_	SpaceAfter=No
 4	se	se	VERB	verb	Mood=Imp|VerbForm=Fin	12	parataxis	_	_
@@ -1442,7 +1442,7 @@
 23	at	at	SCONJ	sbu	_	26	mark	_	_
 24	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	26	nsubj	_	_
 25	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	26	cop	_	_
-26	smertefull	smertefull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	ccomp	_	SpaceAfter=No
+26	smertefull	smertefull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	ccomp	_	SpaceAfter=No
 27	.	$.	PUNCT	clb	_	12	punct	_	_
 
 # sent_id = 018177
@@ -1472,7 +1472,7 @@
 # text = - Ved kapillær hælprøve må man snitte inn i vevet og klemme blodet ut.
 1	-	$-	PUNCT	<strek>	_	7	punct	_	_
 2	Ved	ved	ADP	prep	_	4	case	_	_
-3	kapillær	kapillær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	kapillær	kapillær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	hælprøve	hælprøve	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	obl	_	_
 5	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 6	man	man	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|PronType=Prs	7	nsubj	_	_
@@ -1514,7 +1514,7 @@
 1	-	$-	PUNCT	<strek>	_	10	punct	_	_
 2	Fordelen	fordel	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	nsubj:outer	_	_
 3	med	med	ADP	prep	_	5	case	_	_
-4	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+4	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	metode	metode	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	nmod	_	_
 6	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	_	_
 7	at	at	SCONJ	sbu	_	10	mark	_	_
@@ -1546,7 +1546,7 @@
 6	ikke	ikke	PART	adv	Polarity=Neg	5	advmod	_	_
 7	på	på	ADP	prep	_	11	case	_	_
 8	at	at	SCONJ	sbu	_	11	mark	_	_
-9	prøven	prøve	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	nsubj	_	_
+9	prøven	prøve	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	nsubj:pass	_	_
 10	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux:pass	_	_
 11	tatt	ta	VERB	verb	VerbForm=Part	5	advcl	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -1557,7 +1557,7 @@
 2	krever	kreve	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	bare	bare	ADV	adv	_	2	advmod	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	punktering	punktering	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 7	i	i	ADP	prep	_	8	case	_	_
 8	venen	vene	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
@@ -1597,12 +1597,12 @@
 8	største	stor	ADJ	adj	Definite=Def|Degree=Sup	9	amod	_	_
 9	avdeling	avdeling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	1	nmod	_	_
 10	i	i	ADP	prep	_	12	case	_	_
-11	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	12	det	_	_
+11	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 12	slag	slag	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	8	obl	_	_
 13	med	med	ADP	prep	_	15	case	_	_
 14	900	900	NUM	det	Number=Plur|NumType=Card	15	nummod	_	_
 15	pasienter	pasient	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	9	obl	_	_
-16	innlagt	innlegge	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	15	xcomp	_	_
+16	innlagt	innlegge	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	15	xcomp	_	_
 17	hvert	hver	DET	det	Gender=Neut|Number=Sing|PronType=Tot	18	det	_	_
 18	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	16	obl	_	SpaceAfter=No
 19	,	$,	PUNCT	<komma>	_	9	punct	_	_
@@ -1611,7 +1611,7 @@
 22	besluttet	beslutte	VERB	verb	VerbForm=Part	0	root	_	_
 23	at	at	SCONJ	sbu	_	31	mark	_	_
 24	alle	all	DET	det	Number=Plur|PronType=Tot	25	det	_	_
-25	blodprøver	blodprøve	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	31	nsubj	_	SpaceAfter=No
+25	blodprøver	blodprøve	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	31	nsubj:pass	_	SpaceAfter=No
 26	,	$,	PUNCT	<komma>	_	25	punct	_	_
 27	om	om	ADP	prep	_	28	case	_	_
 28	mulig	mulig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	31	advmod	_	SpaceAfter=No
@@ -1663,7 +1663,7 @@
 11	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	_	_
 12	bestemme	bestemme	VERB	verb	VerbForm=Inf	3	advcl	_	_
 13	når	når	SCONJ	sbu	_	15	mark	_	_
-14	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
+14	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj:pass	_	_
 15	gjøres	gjøre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	12	advcl	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -1689,13 +1689,13 @@
 1	Da	da	ADV	adv	_	6	advmod	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	_	_
 3	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	expl	_	_
-4	klinisk-kjemisk	klinisk-kjemisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	klinisk-kjemisk	klinisk-kjemisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	avdelings	avdeling	NOUN	subst	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing	6	nmod	_	_
 6	rutiner	rutine	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	0	root	_	_
 7	som	som	SCONJ	sbu	_	8	mark	_	_
 8	avgjorde	avgjøre	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	acl:relcl	_	_
 9	når	når	ADV	adv	_	12	advmod	_	_
-10	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nsubj	_	_
+10	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nsubj:pass	_	_
 11	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	12	aux:pass	_	_
 12	gjort	gjøre	VERB	verb	VerbForm=Part	8	xcomp	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	6	punct	_	_
@@ -1727,7 +1727,7 @@
 23	og	og	CCONJ	konj	_	24	cc	_	_
 24	trøtt	trøtt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	22	conj	_	_
 25	når	når	SCONJ	sbu	_	27	mark	_	_
-26	prøven	prøve	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	27	nsubj	_	_
+26	prøven	prøve	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	27	nsubj:pass	_	_
 27	utføres	utføre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	22	advcl	_	SpaceAfter=No
 28	,	$,	PUNCT	<komma>	_	2	punct	_	_
 29	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -1748,7 +1748,7 @@
 10	hver	hver	DET	det	Gender=Masc|Number=Sing|PronType=Tot	12	det	_	_
 11	smertefulle	smertefull	ADJ	adj	Degree=Pos|Number=Plur	12	amod	_	_
 12	stimuli	stimulus	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	obl	_	_
-13	barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	15	nsubj	_	_
+13	barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	15	nsubj:pass	_	_
 14	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux:pass	_	_
 15	utsatt	utsette	VERB	verb	VerbForm=Part	12	acl:relcl	_	_
 16	for	for	ADV	prep	_	15	advmod	_	SpaceAfter=No
@@ -1762,7 +1762,7 @@
 3	Fosholt	Fosholt	PROPN	subst	_	1	flat:name	_	_
 4	Moe	Moe	PROPN	subst	_	1	flat:name	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
-6	positiv	positiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+6	positiv	positiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 7	til	til	ADP	prep	_	8	case	_	_
 8	metoden	metode	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	6	punct	_	_
@@ -1834,7 +1834,7 @@
 2	på	på	ADP	prep	_	3	case	_	_
 3	Ullevål	Ullevål	PROPN	subst	_	1	nmod	_	_
 4	innebærer	innebære	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-5	økt	øke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	6	amod	_	_
+5	økt	øke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	6	amod	_	_
 6	ressursbruk	ressursbruk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 7	ved	ved	ADP	prep	_	8	case	_	_
 8	avdelingen	avdeling	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
@@ -1965,9 +1965,9 @@
 10	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	_	_
 11	ha	ha	AUX	verb	VerbForm=Inf	12	aux	_	_
 12	fått	få	VERB	verb	VerbForm=Part	0	root	_	_
-13	teknisk	teknisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+13	teknisk	teknisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 14	og	og	CCONJ	konj	_	15	cc	_	_
-15	praktisk	praktisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	conj	_	_
+15	praktisk	praktisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	conj	_	_
 16	opplæring	opplæring	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obj	_	_
 17	i	i	ADP	prep	_	18	case	_	_
 18	løpet	løp	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	12	obl	_	_
@@ -2035,7 +2035,7 @@
 # sent_id = 018203
 # text = Lykkelig uvitende
 1	Lykkelig	lykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	2	advmod	_	_
-2	uvitende	uvitende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+2	uvitende	uvitende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 
 # newpar
 # sent_id = 018204
@@ -2054,7 +2054,7 @@
 # newpar
 # sent_id = 018206
 # text = Retrograd amnesi.
-1	Retrograd	retrograd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Retrograd	retrograd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	amnesi	amnesi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 3	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -2086,7 +2086,7 @@
 2	Aamot	Aamot	PROPN	subst	_	1	flat:name	_	_
 3	husker	huske	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	ikke	ikke	PART	adv	Polarity=Neg	3	advmod	_	_
-5	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	det	_	_
+5	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 6	første	første	ADJ	adj	Degree=Pos|Number=Plur|NumType=Ord	8	amod	_	_
 7	27	27	NUM	det	Number=Plur|NumType=Card	8	nummod	_	_
 8	leveår	leveår	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	3	obj	_	SpaceAfter=No
@@ -2185,9 +2185,9 @@
 4	meter	meter	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 5	lange	lang	ADJ	adj	Degree=Pos|Number=Plur	0	root	_	_
 6	og	og	CCONJ	konj	_	7	cc	_	_
-7	surret	surret	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	_
+7	surret	surret	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	_
 8	med	med	ADP	prep	_	10	case	_	_
-9	sort	sort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	sort	sort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	tape	tape	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -2214,7 +2214,7 @@
 1	-	$-	PUNCT	<strek>	_	6	punct	_	_
 2	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
 3	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	_	_
-4	dine	din	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	6	det	_	_
+4	dine	din	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 5	første	første	ADJ	adj	Degree=Pos|Number=Plur|NumType=Ord	6	amod	_	_
 6	slalåmski	slalåmski	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	0	root	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	9	punct	_	_
@@ -2226,7 +2226,7 @@
 13	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	16	cop	_	_
 14	åtte	åtte	NUM	det	Number=Plur|NumType=Card	15	nummod	_	_
 15	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	16	obl	_	_
-16	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	advcl	_	SpaceAfter=No
+16	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	advcl	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	6	punct	_	_
 
 # sent_id = 018218
@@ -2286,7 +2286,7 @@
 11	,	$,	PUNCT	<komma>	_	12	punct	_	_
 12	hvem	hvem	PRON	pron	Animacy=Hum|PronType=Int	6	conj	_	_
 13	moren	mor	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	12	nsubj	_	_
-14	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	13	det	_	_
+14	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 15	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	12	cop	_	_
 16	eller	eller	CCONJ	konj	_	17	cc	_	_
 17	hva	hva	PRON	pron	PronType=Int	12	conj	_	_
@@ -2393,7 +2393,7 @@
 1	Alt	alt	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
 2	fra	fra	ADP	prep	_	3	case	_	_
 3	livet	liv	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	1	nmod	_	_
-4	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	_
+4	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	_
 5	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	_	_
 6	slettet	slette	VERB	verb	VerbForm=Part	0	root	_	_
 7	fra	fra	ADP	prep	_	8	case	_	_
@@ -2441,7 +2441,7 @@
 21	ble	bli	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	_	_
 22	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	21	nsubj	_	_
 23	så	så	ADV	adv	_	24	advmod	_	_
-24	lykkelig	lykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	xcomp	_	_
+24	lykkelig	lykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	xcomp	_	_
 25	at	at	SCONJ	sbu	_	27	mark	_	_
 26	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	27	nsubj	_	_
 27	hadde	ha	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	23	advcl	_	_
@@ -2457,7 +2457,7 @@
 # text = Reiser, hans første kjæreste, russetiden - alt var slettet.
 1	Reiser	reise	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	11	nsubj	_	SpaceAfter=No
 2	,	$,	PUNCT	<komma>	_	5	punct	_	_
-3	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+3	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 4	første	første	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing|NumType=Ord	5	amod	_	_
 5	kjæreste	kjæreste	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	conj	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	7	punct	_	_
@@ -2476,7 +2476,7 @@
 4	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 5	at	at	SCONJ	sbu	_	9	mark	_	_
 6	livet	liv	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	9	nsubj	_	_
-7	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+7	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 8	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 9	ramlet	ramle	VERB	verb	VerbForm=Part	3	xcomp	_	_
 10	på	på	ADP	prep	_	11	case	_	_
@@ -2524,7 +2524,7 @@
 4	og	og	CCONJ	konj	_	5	cc	_	_
 5	historien	historie	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	conj	_	_
 6	om	om	ADP	prep	_	8	case	_	_
-7	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+7	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	liv	liv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	5	nmod	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -2543,7 +2543,7 @@
 11	Kina	Kina	PROPN	subst	_	9	obl	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	15	punct	_	_
 13	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
-14	livsbejaendes	livsbejaende	ADJ	adj	Case=Gen|Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	livsbejaendes	livsbejaende	ADJ	adj	Case=Gen|Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	film	film	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	conj	_	_
 16	om	om	ADP	prep	_	18	case	_	_
 17	å	å	PART	inf-merke	_	18	mark	_	_
@@ -2577,7 +2577,7 @@
 2	hadde	ha	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux	_	_
 3	forlatt	forlate	VERB	verb	VerbForm=Part	0	root	_	_
 4	vennene	venn	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	3	obj	_	_
-5	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	4	det	_	_
+5	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 6	på	på	ADP	prep	_	8	case	_	_
 7	jorda	jord	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	8	compound	_	_
 8	rundt-turen	rundt-tur	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
@@ -2646,7 +2646,7 @@
 3	Kina	Kina	PROPN	subst	_	1	obl	_	_
 4	med	med	ADP	prep	_	7	case	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	plakat	plakat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
 8	:	$:	PUNCT	clb	_	1	punct	_	_
 
@@ -2668,7 +2668,7 @@
 2	etterlyser	etterlyse	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	man	man	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|PronType=Prs	2	nsubj	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	savnet	savne	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	6	amod	_	_
+5	savnet	savne	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	6	amod	_	_
 6	nordmann	nordmann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 7	i	i	ADP	prep	_	8	case	_	_
 8	Kina	Kina	PROPN	subst	_	2	obl	_	SpaceAfter=No
@@ -2738,7 +2738,7 @@
 1	Hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	føler	føle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	lettet	lette	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	2	xcomp	_	SpaceAfter=No
+4	lettet	lette	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	2	xcomp	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	8	punct	_	_
 6	men	men	CCONJ	konj	_	8	cc	_	_
 7	bekymringen	bekymring	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
@@ -2799,7 +2799,7 @@
 8	igjen	igjen	ADV	adv	_	6	advmod	_	_
 9	koden	kode	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	obj	_	_
 10	til	til	ADP	prep	_	12	case	_	_
-11	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	12	det	_	_
+11	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 12	e-mailadresse	e-mailadresse	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	nmod	_	_
 13	som	som	SCONJ	sbu	_	16	mark	_	_
 14	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	_	_
@@ -2860,7 +2860,7 @@
 # text = Ingenting i mitt liv ligner den assosiasjonen jeg får fra «bekymring», som består av en del farger i ujevn, opphakket sammensetning...
 1	Ingenting	ingenting	PRON	pron	Number=Sing	5	nsubj	_	_
 2	i	i	ADP	prep	_	4	case	_	_
-3	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	_
+3	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 4	liv	liv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	1	nmod	_	_
 5	ligner	ligne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
@@ -2879,9 +2879,9 @@
 19	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	20	nmod	_	_
 20	farger	farge	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	16	obl	_	_
 21	i	i	ADP	prep	_	25	case	_	_
-22	ujevn	ujevn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	SpaceAfter=No
+22	ujevn	ujevn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	SpaceAfter=No
 23	,	$,	PUNCT	<komma>	_	22	punct	_	_
-24	opphakket	opphakket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	opphakket	opphakket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	sammensetning	sammensetning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	20	nmod	_	SpaceAfter=No
 26	...	$...	PUNCT	clb	_	5	punct	_	_
 
@@ -2969,7 +2969,7 @@
 
 # sent_id = 018259
 # text = Masse hilsen og klem fra Øyvind Vind.
-1	Masse	masse	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Masse	masse	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	hilsen	hilsen	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 3	og	og	CCONJ	konj	_	4	cc	_	_
 4	klem	klem	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	conj	_	_
@@ -3014,9 +3014,9 @@
 
 # sent_id = 018262
 # text = Retrograd og anterograd.
-1	Retrograd	retrograd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+1	Retrograd	retrograd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 2	og	og	CCONJ	konj	_	3	cc	_	_
-3	anterograd	anterograd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	1	conj	_	SpaceAfter=No
+3	anterograd	anterograd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	1	conj	_	SpaceAfter=No
 4	.	$.	PUNCT	clb	_	1	punct	_	_
 
 # sent_id = 018263
@@ -3044,7 +3044,7 @@
 10	skjedde	skje	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	acl:relcl	_	_
 11	før	før	SCONJ	sbu	_	15	mark	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-13	antatt	anta	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	14	amod	_	_
+13	antatt	anta	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	14	amod	_	_
 14	skade	skade	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	nsubj	_	_
 15	inntraff	inntreffe	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	advcl	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	19	punct	_	_
@@ -3074,7 +3074,7 @@
 2	som	som	SCONJ	sbu	_	3	mark	_	_
 3	lider	lide	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	1	acl:relcl	_	_
 4	av	av	ADP	prep	_	6	case	_	_
-5	anterograd	anterograd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	anterograd	anterograd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	amnesi	amnesi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 7	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	problemer	problem	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	7	obj	_	_
@@ -3125,9 +3125,9 @@
 18	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	17	advmod	_	_
 19	om	om	ADP	prep	_	21	case	_	_
 20	hvor	hvor	ADV	adv	_	21	advmod	_	_
-21	kompleks	kompleks	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	advcl	_	_
+21	kompleks	kompleks	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	advcl	_	_
 22	hjernen	hjerne	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	21	nsubj	_	_
-23	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	22	det	_	_
+23	vår	vår	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	22	nmod:poss	_	_
 24	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	21	cop	_	SpaceAfter=No
 25	.	$.	PUNCT	clb	_	7	punct	_	_
 
@@ -3212,7 +3212,7 @@
 6	sette	sette	VERB	verb	VerbForm=Inf	4	xcomp	_	_
 7	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	6	obj	_	_
 8	godt	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
-9	fast	fast	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	xcomp	_	_
+9	fast	fast	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	xcomp	_	_
 10	i	i	ADP	prep	_	11	case	_	_
 11	langtidshukommelsen	langtidshukommelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	4	punct	_	_
@@ -3250,7 +3250,7 @@
 2	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	ha	ha	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	permanent	permanent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	permanent	permanent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	blokkering	blokkering	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 7	i	i	ADP	prep	_	8	case	_	_
 8	hjernen	hjerne	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	SpaceAfter=No
@@ -3390,7 +3390,7 @@
 1	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	moren	mor	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	ccomp	_	_
-4	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	SpaceAfter=No
+4	din	din	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	3	punct	_	_
 6	sa	si	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 7	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
@@ -3484,7 +3484,7 @@
 5	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
 6	følt	føle	VERB	verb	VerbForm=Part	0	root	_	_
 7	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	6	obj	_	_
-8	deprimert	deprimert	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	xcomp	_	SpaceAfter=No
+8	deprimert	deprimert	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	xcomp	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	6	punct	_	_
 
 # sent_id = 018292
@@ -3546,7 +3546,7 @@
 1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	følte	føle	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	uvel	uvel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	xcomp	_	SpaceAfter=No
+4	uvel	uvel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	xcomp	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	7	punct	_	_
 6	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	expl	_	_
 7	knøt	knyte	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	_	_
@@ -3630,7 +3630,7 @@
 10	men	men	CCONJ	konj	_	14	cc	_	_
 11	likevel	likevel	ADV	adv	_	14	advmod	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-13	konstant	konstant	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	konstant	konstant	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	følelse	følelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	conj	_	_
 15	av	av	ADP	prep	_	16	case	_	_
 16	lykke	lykke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
@@ -3692,7 +3692,7 @@
 3	historien	historie	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
 4	om	om	ADP	prep	_	5	case	_	_
 5	livet	liv	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	nmod	_	_
-6	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+6	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 7	bør	burde	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 8	bli	bli	VERB	verb	VerbForm=Inf	2	xcomp	_	_
 9	til	til	ADP	prep	_	11	case	_	_
@@ -3707,7 +3707,7 @@
 3	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 4	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	_
 5	vært	være	AUX	verb	VerbForm=Part	6	cop	_	_
-6	heldig	heldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+6	heldig	heldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 7	med	med	ADP	prep	_	8	case	_	_
 8	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nmod	_	_
 9	som	som	SCONJ	sbu	_	10	mark	_	_
@@ -3721,7 +3721,7 @@
 3	jo	jo	ADV	adv	_	7	advmod	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 5	helt	hel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
-6	unik	unik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	unik	unik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	situasjon	situasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	7	punct	_	_
 
@@ -3804,7 +3804,7 @@
 22	historiene	historie	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	20	obj	_	_
 23	om	om	ADP	prep	_	24	case	_	_
 24	livet	liv	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	22	nmod	_	_
-25	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	24	det	_	SpaceAfter=No
+25	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	24	nmod:poss	_	SpaceAfter=No
 26	,	$,	PUNCT	<komma>	_	27	punct	_	_
 27	vist	vise	VERB	verb	VerbForm=Part	16	conj	_	_
 28	ham	han	PRON	pron	Animacy=Hum|Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	27	iobj	_	_
@@ -3873,16 +3873,16 @@
 5	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
 6	så	se	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	advcl	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	åpen	åpen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	åpen	åpen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	dør	dør	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
 10	og	og	CCONJ	konj	_	11	cc	_	_
 11	lasset	lasse	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	_	_
 12	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
 13	tomme	tom	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	14	amod	_	_
 14	harddisken	harddisk	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	obj	_	_
-15	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	xcomp	_	_
+15	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	xcomp	_	_
 16	av	av	ADP	prep	_	18	case	_	_
-17	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	kunnskap	kunnskap	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obl	_	SpaceAfter=No
 19	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -3928,7 +3928,7 @@
 9	bolig	bolig	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obj	_	_
 10	i	i	ADP	prep	_	11	case	_	_
 11	kroppen	kropp	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	obl	_	_
-12	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	SpaceAfter=No
+12	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	SpaceAfter=No
 13	?	$?	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 018318
@@ -3976,16 +3976,16 @@
 # sent_id = 018320
 # text = En voksen, intelligent mann på 27 år er ikke lett å overbevise.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-2	voksen	voksen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	SpaceAfter=No
+2	voksen	voksen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	2	punct	_	_
-4	intelligent	intelligent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	intelligent	intelligent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	mann	mann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nsubj	_	_
 6	på	på	ADP	prep	_	8	case	_	_
 7	27	27	NUM	det	Number=Plur|NumType=Card	8	nummod	_	_
 8	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nmod	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	_	_
 10	ikke	ikke	PART	adv	Polarity=Neg	11	advmod	_	_
-11	lett	lett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+11	lett	lett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 12	å	å	PART	inf-merke	_	13	mark	_	_
 13	overbevise	overbevise	VERB	verb	VerbForm=Inf	11	advcl	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	11	punct	_	_
@@ -4097,7 +4097,7 @@
 8	for	for	ADP	prep	_	9	case	_	_
 9	meg	jeg	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=1|PronType=Prs	11	obl	_	_
 10	helt	hel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	11	advmod	_	_
-11	naturlig	naturlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+11	naturlig	naturlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	11	punct	_	_
 
 # sent_id = 018328
@@ -4108,7 +4108,7 @@
 4	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
 5	bra	bra	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	2	advmod	_	_
 6	i	i	ADP	prep	_	8	case	_	_
-7	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+7	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	lykke	lykke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -4117,9 +4117,9 @@
 1	Om	om	SCONJ	sbu	_	4	mark	_	_
 2	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 3	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	cop	_	_
-4	overlykkelig	overlykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	advcl	_	_
+4	overlykkelig	overlykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	advcl	_	_
 5	eller	eller	CCONJ	konj	_	6	cc	_	_
-6	overfladisk	overfladisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	conj	_	_
+6	overfladisk	overfladisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	conj	_	_
 7	vet	vite	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	ccomp	_	_
 8	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	_	_
 9	ikke	ikke	PART	adv	Polarity=Neg	7	advmod	_	SpaceAfter=No
@@ -4253,7 +4253,7 @@
 1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	ønsker	ønske	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	at	at	SCONJ	sbu	_	6	mark	_	_
-4	huset	hus	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	nsubj	_	_
+4	huset	hus	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	nsubj:pass	_	_
 5	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 6	fylles	fylle	VERB	verb	VerbForm=Inf|Voice=Pass	2	xcomp	_	_
 7	opp	opp	ADV	prep	_	6	advmod	_	_
@@ -4318,7 +4318,7 @@
 1	I	i	ADP	prep	_	2	case	_	_
 2	filmen	film	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 3	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux:pass	_	_
-4	Øyvind	Øyvind	PROPN	subst	Gender=Masc	5	nsubj	_	_
+4	Øyvind	Øyvind	PROPN	subst	Gender=Masc	5	nsubj:pass	_	_
 5	fortalt	fortelle	VERB	verb	VerbForm=Part	0	root	_	_
 6	at	at	SCONJ	sbu	_	9	mark	_	_
 7	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nsubj	_	_
@@ -4373,7 +4373,7 @@
 4	fascinerer	fascinere	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	_	_
 5	av	av	ADP	prep	_	8	case	_	_
 6	én	én	NUM	det	Gender=Masc|Number=Sing|NumType=Card	8	nummod	_	_
-7	enkel	enkel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	enkel	enkel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	grunn	grunn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
 9	:	$:	PUNCT	clb	_	2	punct	_	_
 
@@ -4401,7 +4401,7 @@
 4	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
 5	produkt	produkt	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	0	root	_	_
 6	av	av	ADP	prep	_	8	case	_	_
-7	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	det	_	_
+7	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	minner	minne	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nmod	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	11	punct	_	_
 10	men	men	CCONJ	konj	_	11	cc	_	_
@@ -4419,11 +4419,11 @@
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 3	ikke	ikke	PART	adv	Polarity=Neg	6	advmod	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	trist	trist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	trist	trist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	film	film	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	ccomp	_	_
 7	om	om	ADP	prep	_	10	case	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-9	trist	trist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	trist	trist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	skjebne	skjebne	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nmod	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	6	punct	_	_
 12	understreker	understreke	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -4540,7 +4540,7 @@
 2	besitter	besitte	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	velutviklet	velutviklet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	velutviklet	velutviklet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	evne	evne	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 7	til	til	ADP	prep	_	9	case	_	_
 8	å	å	PART	inf-merke	_	9	mark	_	_
@@ -4555,7 +4555,7 @@
 
 # sent_id = 018355
 # text = Dette skapes både gjennom kresent ordvalg og det som aldri utsies direkte.
-1	Dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
+1	Dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj:pass	_	_
 2	skapes	skape	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 3	både	både	CCONJ	konj	_	6	cc	_	_
 4	gjennom	gjennom	ADP	prep	_	6	case	_	_
@@ -4601,7 +4601,7 @@
 5	ros	ros	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	iobj	_	_
 6	risle	risle	VERB	verb	VerbForm=Inf	2	xcomp	_	_
 7	over	over	ADP	prep	_	10	case	_	_
-8	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	det	_	_
+8	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	nmod:poss	_	_
 9	fremste	fremre	ADJ	adj	Definite=Def|Degree=Sup	10	amod	_	_
 10	oversettere	oversetter	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	6	obl	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	12	punct	_	_
@@ -4701,7 +4701,7 @@
 9	dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
 10	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	cop	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-12	allegorisk	allegorisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	allegorisk	allegorisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	roman	roman	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	conj	_	_
 14	om	om	ADP	prep	_	16	case	_	_
 15	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	16	det	_	_
@@ -4773,7 +4773,7 @@
 16	folkegrupper	folkegruppe	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	11	nmod	_	_
 17	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	21	aux	_	_
 18	vært	være	AUX	verb	VerbForm=Part	21	cop	_	_
-19	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	21	det	_	_
+19	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	21	nmod:poss	_	_
 20	trofaste	trofast	ADJ	adj	Degree=Pos|Number=Plur	21	amod	_	_
 21	følgesvenner	følgesvenn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	2	conj	_	_
 22	i	i	ADP	prep	_	24	case	_	_
@@ -4799,7 +4799,7 @@
 7	samtidsroman	samtidsroman	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 8	som	som	ADP	prep	_	11	case	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-10	historisk	historisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	historisk	historisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	roman	roman	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 
 # newpar
@@ -4807,7 +4807,7 @@
 # text = Den rapporten Brodeck mer eller mindre tvinges til å skrive, er historien om hvordan mennene i denne landsbyen på 400 sjeler tok livet av de Anderer, «den andre», denne merkelige og uutgrunnelige mannen som var ankommet for kort tid siden, og som ingen kunne plassere, kategorisere, rubrisere.
 1	Den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	2	det	_	_
 2	rapporten	rapport	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	_
-3	Brodeck	Brodeck	PROPN	subst	_	7	nsubj	_	_
+3	Brodeck	Brodeck	PROPN	subst	_	7	nsubj:pass	_	_
 4	mer	mye	ADJ	adj	Degree=Cmp	7	advmod	_	_
 5	eller	eller	CCONJ	konj	_	6	cc	_	_
 6	mindre	liten	ADJ	adj	Degree=Cmp	4	conj	_	_
@@ -4847,7 +4847,7 @@
 40	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	41	cop	_	_
 41	ankommet	ankomme	VERB	verb	VerbForm=Part	38	acl:relcl	_	_
 42	for	for	ADP	prep	_	44	case	_	_
-43	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	44	amod	_	_
+43	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	44	amod	_	_
 44	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	41	obl	_	_
 45	siden	siden	ADV	adv	_	44	advmod	_	SpaceAfter=No
 46	,	$,	PUNCT	<komma>	_	51	punct	_	_
@@ -4887,7 +4887,7 @@
 4	for	for	ADP	prep	_	11	case	_	_
 5	at	at	SCONJ	sbu	_	11	mark	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	eventuell	eventuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	eventuell	eventuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	omverden	omverden	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nsubj	_	_
 9	både	både	CCONJ	konj	_	11	cc	_	_
 10	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	_	_
@@ -4902,13 +4902,13 @@
 # text = Med nærmest obskøn ironi forutsettes det at han har spesielle forutsetninger for det.
 1	Med	med	ADP	prep	_	4	case	_	_
 2	nærmest	nær	ADJ	adj	Definite=Ind|Degree=Sup	3	advmod	_	_
-3	obskøn	obskøn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	obskøn	obskøn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	ironi	ironi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 5	forutsettes	forutsette	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 6	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	expl	_	_
 7	at	at	SCONJ	sbu	_	9	mark	_	_
 8	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nsubj	_	_
-9	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	csubj	_	_
+9	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	csubj:pass	_	_
 10	spesielle	spesiell	ADJ	adj	Degree=Pos|Number=Plur	11	amod	_	_
 11	forutsetninger	forutsetning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	9	obj	_	_
 12	for	for	ADP	prep	_	13	case	_	_
@@ -4917,7 +4917,7 @@
 
 # sent_id = 018370
 # text = Han ble sendt til konsentrasjonsleiren etter å ha vært utpekt av landsbylederne overfor okkupantene.
-1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	sendt	sende	VERB	verb	VerbForm=Part	0	root	_	_
 4	til	til	ADP	prep	_	5	case	_	_
@@ -4950,7 +4950,7 @@
 13	og	og	CCONJ	konj	_	20	cc	_	_
 14	etter	etter	ADP	prep	_	18	case	_	_
 15	at	at	SCONJ	sbu	_	18	mark	_	_
-16	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	nsubj	_	_
+16	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	nsubj:pass	_	_
 17	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	18	aux:pass	_	_
 18	deportert	deportere	VERB	verb	VerbForm=Part	20	advcl	_	SpaceAfter=No
 19	,	$,	PUNCT	<komma>	_	18	punct	_	_
@@ -4960,7 +4960,7 @@
 23	okkupantsoldater	okkupantsoldat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	22	nsubj	_	_
 24	og	og	CCONJ	konj	_	25	cc	_	_
 25	landsbyboere	landsbyboer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	23	conj	_	_
-26	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	28	det	_	_
+26	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	28	nmod:poss	_	_
 27	unge	ung	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	28	amod	_	_
 28	hustru	hustru	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	22	obj	_	SpaceAfter=No
 29	,	$,	PUNCT	<komma>	_	33	punct	_	_
@@ -5008,7 +5008,7 @@
 28	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	31	cop	_	_
 29	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	31	nsubj	_	_
 30	ikke	ikke	PART	adv	Polarity=Neg	31	advmod	_	_
-31	hevngjerrig	hevngjerrig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	conj	_	SpaceAfter=No
+31	hevngjerrig	hevngjerrig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	conj	_	SpaceAfter=No
 32	.	$.	PUNCT	clb	_	6	punct	_	_
 
 # newpar
@@ -5034,7 +5034,7 @@
 18	;	$;	PUNCT	clb	_	23	punct	_	_
 19	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	23	nsubj	_	_
 20	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	23	cop	_	_
-21	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	23	det	_	_
+21	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	23	nmod:poss	_	_
 22	siste	sist	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	23	amod	_	_
 23	tilflukt	tilflukt	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	16	conj	_	_
 24	i	i	ADP	prep	_	26	case	_	_
@@ -5148,14 +5148,14 @@
 
 # sent_id = 018383
 # text = Glemmen skole i Fredrikstad vil bli holdt stengt i to dager.
-1	Glemmen	Glemmen	PROPN	subst	_	7	nsubj	_	_
+1	Glemmen	Glemmen	PROPN	subst	_	7	nsubj:pass	_	_
 2	skole	skole	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	flat:name	_	_
 3	i	i	ADP	prep	_	4	case	_	_
 4	Fredrikstad	Fredrikstad	PROPN	subst	_	1	nmod	_	_
 5	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 6	bli	bli	AUX	verb	VerbForm=Inf	7	aux:pass	_	_
 7	holdt	holde	VERB	verb	VerbForm=Part	0	root	_	_
-8	stengt	stenge	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	7	xcomp	_	_
+8	stengt	stenge	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	7	xcomp	_	_
 9	i	i	ADP	prep	_	11	case	_	_
 10	to	to	NUM	det	Number=Plur|NumType=Card	11	nummod	_	_
 11	dager	dag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	7	obl	_	SpaceAfter=No
@@ -5235,12 +5235,12 @@
 13	fremsatt	fremsette	VERB	verb	VerbForm=Part	8	acl	_	_
 14	trussel	trussel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	obj	_	_
 15	om	om	ADP	prep	_	17	case	_	_
-16	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	voldshandling	voldshandling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	14	nmod	_	_
 18	rettet	rette	VERB	verb	VerbForm=Part	14	acl:relcl	_	_
 19	mot	mot	ADP	prep	_	20	case	_	_
 20	Glemmen	Glemmen	PROPN	subst	_	18	obl	_	_
-21	videregående	videregående	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	flat:name	_	_
+21	videregående	videregående	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	flat:name	_	_
 22	skole	skole	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	20	flat:name	_	_
 23	i	i	ADP	prep	_	24	case	_	_
 24	Fredrikstad	Fredrikstad	PROPN	subst	_	20	nmod	_	SpaceAfter=No
@@ -5248,7 +5248,7 @@
 
 # sent_id = 018389
 # text = Skolen ble evakuert på grunn av trusselen.
-1	Skolen	skole	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
+1	Skolen	skole	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	evakuert	evakuere	VERB	verb	VerbForm=Part	0	root	_	_
 4	på	på	ADP	prep	_	5	case	_	_
@@ -5283,7 +5283,7 @@
 9	anser	anse	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	_	_
 10	trusselsituasjonen	trusselsituasjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	obj	_	_
 11	som	som	ADP	prep	_	12	case	_	_
-12	avklart	avklare	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	9	xcomp	_	SpaceAfter=No
+12	avklart	avklare	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	9	xcomp	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 018392
@@ -5327,7 +5327,7 @@
 2	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
 3	øyenvtine	øyenvtine	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	8	obl	_	_
 4	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
-5	personen	person	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
+5	personen	person	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj:pass	_	_
 6	ha	ha	AUX	verb	VerbForm=Inf	8	aux	_	_
 7	blitt	bli	AUX	verb	VerbForm=Part	8	aux:pass	_	_
 8	pågrepet	pågripe	VERB	verb	VerbForm=Part	0	root	_	_
@@ -5347,7 +5347,7 @@
 # text = - En gutt ble lagt i jern av tre menn med maskinpistoler, sier Heidi Jansson til Aftenposten.no
 1	-	$-	PUNCT	<strek>	_	5	punct	_	_
 2	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-3	gutt	gutt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj	_	_
+3	gutt	gutt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj:pass	_	_
 4	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	lagt	legge	VERB	verb	VerbForm=Part	14	ccomp	_	_
 6	i	i	ADP	prep	_	7	case	_	_
@@ -5372,7 +5372,7 @@
 4	ikke	ikke	PART	adv	Polarity=Neg	3	advmod	_	_
 5	personen	person	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 6	særlig	særlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	advmod	_	_
-7	overrasket	overraske	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	3	xcomp	_	SpaceAfter=No
+7	overrasket	overraske	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	3	xcomp	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 018396
@@ -5381,7 +5381,7 @@
 2	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
 3	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	_	_
 4	ganske	ganske	ADV	adv	_	5	advmod	_	_
-5	rolig	rolig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	ccomp	_	_
+5	rolig	rolig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	ccomp	_	_
 6	da	da	SCONJ	sbu	_	8	mark	_	_
 7	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
 8	la	legge	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	advcl	_	_
@@ -5415,7 +5415,7 @@
 4	kjenner	kjenne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	acl:relcl	_	_
 5	til	til	ADV	prep	_	4	advmod	_	_
 6	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	_	_
-7	elevene	elev	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	9	nsubj	_	_
+7	elevene	elev	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	9	nsubj:pass	_	_
 8	blitt	bli	AUX	verb	VerbForm=Part	9	aux:pass	_	_
 9	fortalt	fortelle	VERB	verb	VerbForm=Part	0	root	_	_
 10	at	at	SCONJ	sbu	_	12	mark	_	_
@@ -5449,7 +5449,7 @@
 4	blitt	bli	AUX	verb	VerbForm=Part	5	aux:pass	_	_
 5	fremsatt	fremsette	VERB	verb	VerbForm=Part	0	root	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	voldstrussel	voldstrussel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obj	_	_
 9	på	på	ADP	prep	_	10	case	_	_
 10	Internett	Internett	PROPN	subst	Gender=Neut	5	obl	_	SpaceAfter=No
@@ -5525,7 +5525,7 @@
 12	av	av	ADP	prep	_	13	case	_	_
 13	elever	elev	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	11	nmod	_	_
 14	og	og	CCONJ	konj	_	15	cc	_	_
-15	ansatt	ansatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	conj	_	_
+15	ansatt	ansatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	conj	_	_
 16	i	i	ADP	prep	_	17	case	_	_
 17	samarbeid	samarbeid	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	10	obl	_	_
 18	med	med	ADP	prep	_	20	case	_	_
@@ -5551,7 +5551,7 @@
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
 4	over	over	ADP	prep	_	5	case	_	_
 5	1000	1000	NUM	det	Number=Plur|NumType=Card	6	nummod	_	_
-6	personer	person	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	nsubj	_	_
+6	personer	person	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	nsubj:pass	_	_
 7	blitt	bli	AUX	verb	VerbForm=Part	8	aux:pass	_	_
 8	evkuert	evakuere	VERB	verb	VerbForm=Part	0	root	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	8	punct	_	_
@@ -5567,7 +5567,7 @@
 7	måtte	måtte	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	aux	_	_
 8	forlate	forlate	VERB	verb	VerbForm=Inf	2	advcl	_	_
 9	eiendelene	eiendel	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	8	obj	_	_
-10	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	9	det	_	_
+10	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 11	inne	inne	ADP	prep	_	13	case	_	_
 12	i	i	ADP	prep	_	13	case	_	_
 13	skolebygningen	skolebygning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	obl	_	_
@@ -5577,13 +5577,13 @@
 17	da	da	SCONJ	sbu	_	19	mark	_	_
 18	trusselsituasjonen	trusselsituasjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	19	nsubj	_	_
 19	ble	bli	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	advcl	_	_
-20	kjent	kjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	xcomp	_	SpaceAfter=No
+20	kjent	kjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	xcomp	_	SpaceAfter=No
 21	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 018407
 # text = Personlige eiendeler, PC-er og klær ble lagt igjen da elevene ble evkuert.
 1	Personlige	personlig	ADJ	adj	Degree=Pos|Number=Plur	2	amod	_	_
-2	eiendeler	eiendel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	nsubj	_	SpaceAfter=No
+2	eiendeler	eiendel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	nsubj:pass	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	4	punct	_	_
 4	PC-er	PC	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	2	conj	_	_
 5	og	og	CCONJ	konj	_	6	cc	_	_
@@ -5592,7 +5592,7 @@
 8	lagt	legge	VERB	verb	VerbForm=Part	0	root	_	_
 9	igjen	igjen	ADV	adv	_	8	advmod	_	_
 10	da	da	SCONJ	sbu	_	13	mark	_	_
-11	elevene	elev	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	13	nsubj	_	_
+11	elevene	elev	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	13	nsubj:pass	_	_
 12	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	aux:pass	_	_
 13	evkuert	evakuere	VERB	verb	VerbForm=Part	8	advcl	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	8	punct	_	_
@@ -5643,13 +5643,13 @@
 12	,	$,	PUNCT	<komma>	_	17	punct	_	_
 13	og	og	CCONJ	konj	_	17	cc	_	_
 14	at	at	SCONJ	sbu	_	17	mark	_	_
-15	denne	denne	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	17	nsubj	_	_
+15	denne	denne	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	17	nsubj:pass	_	_
 16	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	17	aux:pass	_	_
 17	gjennomført	gjennomføre	VERB	verb	VerbForm=Part	5	conj	_	_
 18	i	i	ADP	prep	_	19	case	_	_
 19	løpet	løp	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	17	obl	_	_
 20	av	av	ADP	prep	_	22	case	_	_
-21	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	amod	_	_
+21	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	amod	_	_
 22	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	19	nmod	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -5720,7 +5720,7 @@
 1	Vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	godt	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	4	advmod	_	_
-4	trent	trene	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	14	ccomp	_	_
+4	trent	trene	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	14	ccomp	_	_
 5	etter	etter	ADP	prep	_	7	case	_	_
 6	flere	mange	ADJ	adj	Degree=Cmp	7	amod	_	_
 7	evakueringsøvelser	evakueringsøvelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	4	obl	_	SpaceAfter=No
@@ -5745,7 +5745,7 @@
 5	oppleved	oppleve	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 6	situasjonen	situasjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	obj	_	_
 7	som	som	ADP	prep	_	8	case	_	_
-8	kaotisk	kaotisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	xcomp	_	SpaceAfter=No
+8	kaotisk	kaotisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	xcomp	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 018416
@@ -5782,7 +5782,7 @@
 8	folk	folk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	9	nsubj	_	_
 9	skjønner	skjønne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	advcl	_	_
 10	hvor	hvor	ADV	adv	_	11	advmod	_	_
-11	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	ccomp	_	_
+11	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	ccomp	_	_
 12	situasjonen	situasjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	nsubj	_	_
 13	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	11	cop	_	SpaceAfter=No
 14	,	$,	PUNCT	<komma>	_	6	punct	_	_
@@ -5844,13 +5844,13 @@
 5	også	også	ADV	adv	_	12	advmod	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
 7	annen	annen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Dem	8	det	_	_
-8	skole	skole	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	nsubj	_	_
+8	skole	skole	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	nsubj:pass	_	_
 9	i	i	ADP	prep	_	10	case	_	_
 10	byen	by	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	12	punct	_	_
 12	Frederik	Frederik	PROPN	subst	_	8	appos	_	_
 13	II	II	DET	det	PronType=Prs	12	flat:name	_	_
-14	videregående	videregående	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	flat:name	_	_
+14	videregående	videregående	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	flat:name	_	_
 15	skole	skole	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	flat:name	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	12	punct	_	_
 17	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	18	aux:pass	_	_
@@ -5917,7 +5917,7 @@
 # sent_id = 018427
 # text = Mens heroin og kokain må fraktes halve jorden rundt før stoffet når Norge, lager rusmisbrukere i Hordaland GHB hjemme.
 1	Mens	mens	SCONJ	sbu	_	6	mark	_	_
-2	heroin	heroin	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	6	nsubj	_	_
+2	heroin	heroin	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	6	nsubj:pass	_	_
 3	og	og	CCONJ	konj	_	4	cc	_	_
 4	kokain	kokain	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	2	conj	_	_
 5	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
@@ -5942,7 +5942,7 @@
 # sent_id = 018428
 # text = Tre personer ble nylig funnet bevisstløse i Bergen Kino etter en overdose av GHB.
 1	Tre	tre	NUM	det	Number=Plur|NumType=Card	2	nummod	_	_
-2	personer	person	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	nsubj	_	_
+2	personer	person	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	nsubj:pass	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 4	nylig	nylig	ADV	adv	_	5	advmod	_	_
 5	funnet	finne	VERB	verb	VerbForm=Part	0	root	_	_
@@ -6023,7 +6023,7 @@
 14	,	$,	PUNCT	<komma>	_	19	punct	_	_
 15	og	og	CCONJ	konj	_	19	cc	_	_
 16	ytterligere	ytterligere	ADJ	adj	Degree=Pos|Number=Plur	17	amod	_	_
-17	andre	annen	DET	det	Number=Plur|PronType=Dem	19	nsubj	_	_
+17	andre	annen	DET	det	Number=Plur|PronType=Dem	19	nsubj:pass	_	_
 18	blitt	bli	AUX	verb	VerbForm=Part	19	aux:pass	_	_
 19	pågrepet	pågripe	VERB	verb	VerbForm=Part	10	conj	_	_
 20	med	med	ADP	prep	_	21	case	_	_
@@ -6032,7 +6032,7 @@
 
 # sent_id = 018434
 # text = Karl Edvin Endresen ble arrestert da han i mai delte ut GHB under et kunstprosjekt.
-1	Karl	Karl	PROPN	subst	Gender=Masc	5	nsubj	_	_
+1	Karl	Karl	PROPN	subst	Gender=Masc	5	nsubj:pass	_	_
 2	Edvin	Edvin	PROPN	subst	_	1	flat:name	_	_
 3	Endresen	Endresen	PROPN	subst	_	1	flat:name	_	_
 4	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
@@ -6068,7 +6068,7 @@
 15	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	19	expl	_	_
 16	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	cop	_	_
 17	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
-18	smal	smal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	smal	smal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	sak	sak	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	ccomp	_	_
 20	å	å	PART	inf-merke	_	21	mark	_	_
 21	lage	lage	VERB	verb	VerbForm=Inf	19	csubj	_	_
@@ -6182,7 +6182,7 @@
 13	,	$,	PUNCT	<komma>	_	5	punct	_	_
 14	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 15	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-16	narkoman	narkoman	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	narkoman	narkoman	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	mann	mann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nsubj	_	_
 18	i	i	ADP	prep	_	19	case	_	_
 19	20-årene	20-år	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	17	nmod	_	SpaceAfter=No
@@ -6236,7 +6236,7 @@
 5	,	$,	PUNCT	<komma>	_	10	punct	_	_
 6	der	der	SCONJ	sbu	_	10	mark	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	mann	mann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nsubj	_	_
+8	mann	mann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nsubj:pass	_	_
 9	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	aux:pass	_	_
 10	pågrepet	pågripe	VERB	verb	VerbForm=Part	3	acl:relcl	_	_
 11	for	for	ADP	prep	_	12	case	_	_
@@ -6250,14 +6250,14 @@
 2	Vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
 3	vet	vite	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	ccomp	_	_
 4	at	at	SCONJ	sbu	_	6	mark	_	_
-5	ingrediensene	ingrediens	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	6	nsubj	_	_
+5	ingrediensene	ingrediens	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	6	nsubj:pass	_	_
 6	bestilles	bestille	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	3	ccomp	_	_
 7	på	på	ADP	prep	_	8	case	_	_
 8	nettet	nett	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	obl	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	13	punct	_	_
 10	og	og	CCONJ	konj	_	13	cc	_	_
 11	at	at	SCONJ	sbu	_	13	mark	_	_
-12	GHB	GHB	PROPN	subst	_	13	nsubj	_	_
+12	GHB	GHB	PROPN	subst	_	13	nsubj:pass	_	_
 13	produseres	produsere	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	6	conj	_	_
 14	i	i	ADP	prep	_	15	case	_	_
 15	Os	Os	PROPN	subst	_	13	obl	_	SpaceAfter=No
@@ -6274,7 +6274,7 @@
 # sent_id = 018446
 # text = En stor andel av dem som er blitt tatt med GHB i Os er folk som ikke tilhører de vanlige rusbelastede miljøene.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	andel	andel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	nsubj	_	_
 4	av	av	ADP	prep	_	5	case	_	_
 5	dem	de	PRON	pron	Case=Acc|Number=Plur|Person=3|PronType=Prs	3	nmod	_	_
@@ -6401,7 +6401,7 @@
 25	utbredelsen	utbredelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	24	obj	_	_
 26	på	på	ADP	prep	_	29	case	_	_
 27	noen	noen	DET	det	Gender=Masc|Number=Sing|PronType=Ind	29	det	_	_
-28	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	29	amod	_	_
+28	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	29	amod	_	_
 29	måte	måte	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	24	obl	_	SpaceAfter=No
 30	,	$,	PUNCT	<komma>	_	18	punct	_	_
 31	skriver	skrive	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -6420,7 +6420,7 @@
 4	politiet	politi	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	5	nsubj	_	_
 5	sett	se	VERB	verb	VerbForm=Part	0	root	_	_
 6	at	at	SCONJ	sbu	_	16	mark	_	_
-7	GHB	GHB	PROPN	subst	_	16	nsubj	_	_
+7	GHB	GHB	PROPN	subst	_	16	nsubj:pass	_	_
 8	-	$-	PUNCT	<strek>	_	12	punct	_	_
 9	som	som	SCONJ	sbu	_	12	mark	_	_
 10	egentlig	egentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	12	advmod	_	_
@@ -6430,7 +6430,7 @@
 14	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	cop	_	_
 15	blitt	bli	AUX	verb	VerbForm=Part	16	aux:pass	_	_
 16	tilsatt	tilsette	VERB	verb	VerbForm=Part	5	xcomp	_	_
-17	gul	gul	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	gul	gul	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	konditorfarge	konditorfarge	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	obj	_	_
 19	og	og	CCONJ	konj	_	20	cc	_	_
 20	tappet	tappe	VERB	verb	VerbForm=Part	16	conj	_	_
@@ -6469,7 +6469,7 @@
 7	advarte	advare	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 8	mot	mot	ADP	prep	_	11	case	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-10	tydelig	tydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	tydelig	tydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	økning	økning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obl	_	_
 12	i	i	ADP	prep	_	13	case	_	_
 13	bruken	bruk	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	_
@@ -6489,13 +6489,13 @@
 6	å	å	PART	inf-merke	_	7	mark	_	_
 7	ha	ha	VERB	verb	VerbForm=Inf	4	advcl	_	_
 8	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
-9	uforutsigbar	uforutsigbar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	uforutsigbar	uforutsigbar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	styrke	styrke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 018455
 # text = Det produseres på ymse vis, og kvaliteten varierer sterkt.
-1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
+1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj:pass	_	_
 2	produseres	produsere	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 3	på	på	ADP	prep	_	5	case	_	_
 4	ymse	ymis	ADJ	adj	Degree=Pos|Number=Plur	5	amod	_	_
@@ -6575,7 +6575,7 @@
 7	med	med	ADP	prep	_	8	case	_	_
 8	alkohol	alkohol	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 9	eller	eller	CCONJ	konj	_	11	cc	_	_
-10	sedativ	sedativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	sedativ	sedativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	medisin	medisin	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	conj	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -6659,7 +6659,7 @@
 # sent_id = 018465
 # text = En uvirkelig sommer.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	uvirkelig	uvirkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	uvirkelig	uvirkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	sommer	sommer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 4	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -6706,7 +6706,7 @@
 # sent_id = 018471
 # text = En internasjonal utfordring.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	internasjonal	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	internasjonal	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	utfordring	utfordring	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 4	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -6727,7 +6727,7 @@
 2	Murud	Murud	PROPN	subst	_	1	flat:name	_	_
 3	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	sprek	sprek	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	sprek	sprek	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	69-åring	69-åring	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -6741,7 +6741,7 @@
 6	til	til	ADP	prep	_	10	case	_	_
 7	at	at	SCONJ	sbu	_	10	mark	_	_
 8	kroppen	kropp	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	_
-9	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+9	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 10	gikk	gå	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	advcl	_	_
 11	i	i	ADP	prep	_	12	case	_	_
 12	oppløsning	oppløsning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	obl	_	SpaceAfter=No
@@ -6776,7 +6776,7 @@
 5	form	form	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	obl	_	_
 6	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	_	_
 7	hobbyen	hobby	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
-8	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	SpaceAfter=No
+8	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	7	punct	_	_
 
 # sent_id = 018477
@@ -6832,7 +6832,7 @@
 5	hadde	ha	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 6	Sverre	Sverre	PROPN	subst	Gender=Masc	5	nsubj	_	_
 7	Murud	Murud	PROPN	subst	_	6	flat:name	_	_
-8	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	10	det	_	_
+8	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	10	nmod:poss	_	_
 9	siste	sist	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	10	amod	_	_
 10	arbeidsdag	arbeidsdag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obj	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	5	punct	_	_
@@ -6859,13 +6859,13 @@
 7	blir	bli	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
 9	fryktelig	fryktelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	10	advmod	_	_
-10	kvalm	kvalm	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	xcomp	_	_
+10	kvalm	kvalm	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	xcomp	_	_
 11	og	og	CCONJ	konj	_	12	cc	_	_
 12	får	få	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	conj	_	_
 13	bare	bare	ADV	adv	_	12	advmod	_	_
 14	i	i	ADP	prep	_	15	case	_	_
 15	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	12	obl	_	_
-16	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	havregrøt	havregrøt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obj	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	7	punct	_	_
 
@@ -6885,7 +6885,7 @@
 12	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
 13	ektemannen	ektemann	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	nsubj	_	_
 14	helt	hel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	15	advmod	_	_
-15	gul	gul	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+15	gul	gul	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	15	punct	_	_
 
 # sent_id = 018483
@@ -6937,7 +6937,7 @@
 
 # sent_id = 018485
 # text = Han, som barna alltid har tenkt på som så sterk, kjøres til Akershus Universitetssykehus i ambulanse.
-1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	SpaceAfter=No
+1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	nsubj:pass	_	SpaceAfter=No
 2	,	$,	PUNCT	<komma>	_	7	punct	_	_
 3	som	som	SCONJ	sbu	_	7	mark	_	_
 4	barna	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	7	nsubj	_	_
@@ -6947,7 +6947,7 @@
 8	på	på	ADV	prep	_	7	advmod	_	_
 9	som	som	ADP	prep	_	11	case	_	_
 10	så	så	ADV	adv	_	11	advmod	_	_
-11	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	xcomp	_	SpaceAfter=No
+11	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	xcomp	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	1	punct	_	_
 13	kjøres	kjøre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 14	til	til	ADP	prep	_	15	case	_	_
@@ -6968,11 +6968,11 @@
 7	som	som	SCONJ	sbu	_	10	mark	_	_
 8	aldri	aldri	ADV	adv	_	10	advmod	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	_	_
-10	syk	syk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	SpaceAfter=No
+10	syk	syk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	14	punct	_	_
 12	som	som	SCONJ	sbu	_	14	mark	_	_
 13	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	_	_
-14	forsiktig	forsiktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	conj	_	_
+14	forsiktig	forsiktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	conj	_	_
 15	med	med	ADP	prep	_	16	case	_	_
 16	alkohol	alkohol	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	obl	_	_
 17	og	og	CCONJ	konj	_	20	cc	_	_
@@ -7020,7 +7020,7 @@
 3	snart	snar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
 4	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 5	få	få	VERB	verb	VerbForm=Inf	1	acl:relcl	_	_
-6	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+6	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 7	tredje	tredje	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing|NumType=Ord	8	amod	_	_
 8	barnebarn	barnebarn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	5	obj	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	5	punct	_	_
@@ -7081,7 +7081,7 @@
 20	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	23	nsubj	_	_
 21	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	23	cop	_	_
 22	arvelig	arvelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	23	advmod	_	_
-23	disponert	disponere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	19	amod	_	_
+23	disponert	disponere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	19	amod	_	_
 24	for	for	ADV	prep	_	23	advmod	_	SpaceAfter=No
 25	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -7175,7 +7175,7 @@
 7	enn	enn	ADP	prep	_	8	case	_	_
 8	tran	tran	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	obl	_	_
 9	og	og	CCONJ	konj	_	11	cc	_	_
-10	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	ølgjær	ølgjær	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	conj	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	18	punct	_	_
 13	men	men	CCONJ	konj	_	18	cc	_	_
@@ -7187,7 +7187,7 @@
 19	Fortodol	Fortodol	PROPN	subst	_	18	obj	_	_
 20	av	av	ADP	prep	_	22	case	_	_
 21	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-22	bekjent	bekjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	advmod	_	SpaceAfter=No
+22	bekjent	bekjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	advmod	_	SpaceAfter=No
 23	,	$,	PUNCT	<komma>	_	25	punct	_	_
 24	som	som	SCONJ	sbu	_	25	mark	_	_
 25	syntes	synes	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	22	acl:relcl	_	_
@@ -7246,7 +7246,7 @@
 8	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nsubj	_	_
 9	snart	snar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	10	advmod	_	_
 10	blir	bli	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	ccomp	_	_
-11	frisk	frisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	xcomp	_	_
+11	frisk	frisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	xcomp	_	_
 12	igjen	igjen	ADV	adv	_	11	advmod	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	7	punct	_	_
 
@@ -7273,7 +7273,7 @@
 
 # sent_id = 018500
 # text = 69-åringen er blitt undersøkt med alle hjelpemidler.
-1	69-åringen	69-åring	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
+1	69-åringen	69-åring	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj:pass	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	blitt	bli	AUX	verb	VerbForm=Part	4	aux:pass	_	_
 4	undersøkt	undersøke	VERB	verb	VerbForm=Part	0	root	_	_
@@ -7419,7 +7419,7 @@
 7	ektemannen	ektemann	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 8	og	og	CCONJ	konj	_	9	cc	_	_
 9	faren	far	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	conj	_	_
-10	deres	deres	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	det	_	SpaceAfter=No
+10	deres	deres	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	nmod:poss	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	3	punct	_	_
 12	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 13	legene	lege	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	12	nsubj	_	_
@@ -7467,7 +7467,7 @@
 9	,	$,	PUNCT	<komma>	_	5	punct	_	_
 10	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 11	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nsubj	_	_
-12	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	tro	tro	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	obj	_	_
 14	på	på	ADP	prep	_	5	case	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	10	punct	_	_
@@ -7668,7 +7668,7 @@
 17	deg	du	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=2|PronType=Prs	16	iobj	_	_
 18	og	og	CCONJ	konj	_	19	cc	_	_
 19	meg	jeg	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=1|PronType=Prs	17	conj	_	_
-20	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	amod	_	_
+20	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	amod	_	_
 21	helse	helse	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	16	obj	_	SpaceAfter=No
 22	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -7752,7 +7752,7 @@
 # text = Markedsføringen lovet stor virkning av produktene, som skulle øke potensen, virke oppkvikkende eller være slankende.
 1	Markedsføringen	markedsføring	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 2	lovet	love	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-3	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	virkning	virkning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	obj	_	_
 5	av	av	ADP	prep	_	6	case	_	_
 6	produktene	produkt	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	4	nmod	_	SpaceAfter=No
@@ -7800,7 +7800,7 @@
 7	tre	tre	NUM	det	Number=Plur|NumType=Card	8	nummod	_	_
 8	ganger	gang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	9	obl	_	_
 9	så	så	ADV	adv	_	10	advmod	_	_
-10	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+10	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 11	som	som	ADP	prep	_	12	case	_	_
 12	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	obl	_	_
 13	Legemiddelverket	Legemiddelverket	PROPN	subst	_	14	nsubj	_	_
@@ -7842,14 +7842,14 @@
 12	synefrin	synefrin	NOUN	subst	_	10	conj	_	_
 13	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	_	_
 14	være	være	AUX	verb	VerbForm=Inf	15	cop	_	_
-15	farlig	farlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	advcl	_	_
+15	farlig	farlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	advcl	_	_
 16	for	for	ADP	prep	_	17	case	_	_
 17	folk	folk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	15	obl	_	_
 18	med	med	ADP	prep	_	19	case	_	_
 19	hjertesykdom	hjertesykdom	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	nmod	_	_
 20	eller	eller	CCONJ	konj	_	23	cc	_	_
 21	annen	annen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Dem	23	det	_	_
-22	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	amod	_	_
+22	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	amod	_	_
 23	sykdom	sykdom	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	conj	_	SpaceAfter=No
 24	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -7871,7 +7871,7 @@
 # sent_id = 018535
 # text = - Efedrin, et reseptpliktig sentralstimulerende middel, ble påvist i liten mengde i ett av de oppkvikkende tilskuddene.
 1	-	$-	PUNCT	<strek>	_	10	punct	_	_
-2	Efedrin	efedrin	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nsubj	_	SpaceAfter=No
+2	Efedrin	efedrin	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nsubj:pass	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	7	punct	_	_
 4	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
 5	reseptpliktig	reseptpliktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	amod	_	_
@@ -7881,7 +7881,7 @@
 9	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	aux:pass	_	_
 10	påvist	påvise	VERB	verb	VerbForm=Part	0	root	_	_
 11	i	i	ADP	prep	_	13	case	_	_
-12	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	mengde	mengde	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obl	_	_
 14	i	i	ADP	prep	_	15	case	_	_
 15	ett	én	NUM	det	Gender=Neut|Number=Sing|NumType=Card	10	obl	_	_
@@ -7926,14 +7926,14 @@
 10	egentlig	egentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	11	advmod	_	_
 11	inneholder	inneholde	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	ccomp	_	_
 12	når	når	SCONJ	sbu	_	15	mark	_	_
-13	stoffene	stoff	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	15	nsubj	_	_
+13	stoffene	stoff	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	15	nsubj:pass	_	_
 14	ikke	ikke	PART	adv	Polarity=Neg	15	advmod	_	_
 15	oppgis	oppgi	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	11	advcl	_	_
 16	i	i	ADP	prep	_	17	case	_	_
 17	merkingen	merking	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	obl	_	SpaceAfter=No
 18	,	$,	PUNCT	<komma>	_	23	punct	_	_
 19	og	og	CCONJ	konj	_	23	cc	_	_
-20	kosttilskuddene	kosttilskudd	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	23	nsubj	_	_
+20	kosttilskuddene	kosttilskudd	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	23	nsubj:pass	_	_
 21	tvert	tvert	ADV	adv	_	22	advmod	_	_
 22	imot	imot	ADV	prep	_	23	advmod	_	_
 23	markedsføres	markedsføre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	15	conj	_	_
@@ -7969,7 +7969,7 @@
 19	behov	behov	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	18	nsubj	_	_
 20	for	for	ADP	prep	_	23	case	_	_
 21	mer	mye	ADJ	adj	Degree=Cmp	22	advmod	_	_
-22	systematisk	systematisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	amod	_	_
+22	systematisk	systematisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	amod	_	_
 23	kontroll	kontroll	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	nmod	_	_
 24	av	av	ADP	prep	_	25	case	_	_
 25	kosttilskudd	kosttilskudd	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	23	nmod	_	SpaceAfter=No
@@ -7982,7 +7982,7 @@
 3	bør	burde	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 4	også	også	ADV	adv	_	5	advmod	_	_
 5	omfatte	omfatte	VERB	verb	VerbForm=Inf	9	ccomp	_	_
-6	kjemisk	kjemisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	kjemisk	kjemisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	analyse	analyse	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	obj	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	5	punct	_	_
 9	sa	si	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
@@ -8000,7 +8000,7 @@
 21	da	da	SCONJ	sbu	_	28	mark	_	_
 22	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
 23	endelige	endelig	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	24	amod	_	_
-24	rapporten	rapport	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	28	nsubj	_	_
+24	rapporten	rapport	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	28	nsubj:pass	_	_
 25	fra	fra	ADP	prep	_	26	case	_	_
 26	undersøkelsen	undersøkelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	24	nmod	_	_
 27	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	28	aux:pass	_	_
@@ -8172,7 +8172,7 @@
 15	når	når	ADV	adv	_	18	advmod	_	_
 16	databasen	database	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	18	nsubj	_	_
 17	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	cop	_	_
-18	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	ccomp	_	SpaceAfter=No
+18	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	ccomp	_	SpaceAfter=No
 19	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 018548
@@ -8219,7 +8219,7 @@
 7	all	all	DET	det	Gender=Masc|Number=Sing|PronType=Tot	8	det	_	_
 8	dokumentasjon	dokumentasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nsubj	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	_	_
-10	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	ccomp	_	_
+10	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	ccomp	_	_
 11	nok	nok	ADV	adv	_	10	advmod	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	20	punct	_	_
 13	eller	eller	CCONJ	konj	_	20	cc	_	_
@@ -8320,7 +8320,7 @@
 # sent_id = 018554
 # text = Leveren hans produserer ikke lenger så mye protein som den skal, og vannet holder seg ikke inni blodårene, men begynner å sive fra årene hans og ut i vevet og buken.
 1	Leveren	lever	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
-2	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	1	det	_	_
+2	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	1	nmod:poss	_	_
 3	produserer	produsere	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	ikke	ikke	PART	adv	Polarity=Neg	5	advmod	_	_
 5	lenger	lenge	ADJ	adj	Degree=Cmp	3	advmod	_	_
@@ -8345,7 +8345,7 @@
 24	sive	sive	VERB	verb	VerbForm=Inf	22	xcomp	_	_
 25	fra	fra	ADP	prep	_	26	case	_	_
 26	årene	åre	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	24	obl	_	_
-27	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	26	det	_	_
+27	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	26	nmod:poss	_	_
 28	og	og	CCONJ	konj	_	31	cc	_	_
 29	ut	ut	ADP	prep	_	31	case	_	_
 30	i	i	ADP	prep	_	31	case	_	_
@@ -8361,8 +8361,8 @@
 3	svikter	svikte	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	8	punct	_	_
 5	og	og	CCONJ	konj	_	8	cc	_	_
-6	blodet	blod	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	8	nsubj	_	_
-7	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+6	blodet	blod	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	8	nsubj:pass	_	_
+7	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 8	forgiftes	forgifte	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	3	conj	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -8377,7 +8377,7 @@
 7	og	og	CCONJ	konj	_	8	cc	_	_
 8	gjøre	gjøre	VERB	verb	VerbForm=Inf	5	conj	_	_
 9	pasienter	pasient	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	obj	_	_
-10	forvirret	forvirret	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	xcomp	_	SpaceAfter=No
+10	forvirret	forvirret	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	xcomp	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	12	punct	_	_
 12	urolige	urolig	ADJ	adj	Degree=Pos|Number=Plur	10	conj	_	_
 13	og	og	CCONJ	konj	_	14	cc	_	_
@@ -8430,7 +8430,7 @@
 17	dem	de	PRON	pron	Case=Acc|Number=Plur|Person=3|PronType=Prs	16	iobj	_	_
 18	hente	hente	VERB	verb	VerbForm=Inf	16	xcomp	_	_
 19	jakken	jakke	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	18	obj	_	_
-20	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	19	det	_	_
+20	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 21	...	$...	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 018560
@@ -8447,7 +8447,7 @@
 10	1.	1.	ADJ	adj	Number=Plur|NumType=Ord	11	amod	_	_
 11	juli	juli	NOUN	subst	Gender=Masc	12	obl	_	_
 12	overføres	overføre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	2	conj	_	_
-13	Sverre	Sverre	PROPN	subst	Gender=Masc	12	nsubj	_	_
+13	Sverre	Sverre	PROPN	subst	Gender=Masc	12	nsubj:pass	_	_
 14	til	til	ADP	prep	_	15	case	_	_
 15	Rikshospitalet	Rikshospitalet	PROPN	subst	_	12	obl	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	19	punct	_	_
@@ -8477,14 +8477,14 @@
 3	i	i	ADP	prep	_	4	case	_	_
 4	tillegg	tillegg	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	2	obl	_	_
 5	for	for	ADV	adv	_	6	advmod	_	_
-6	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	sirkulasjon	sirkulasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 8	til	til	ADP	prep	_	9	case	_	_
 9	hjertet	hjerte	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	nmod	_	_
 10	og	og	CCONJ	konj	_	13	cc	_	_
 11	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	cop	_	_
 12	for	for	ADV	adv	_	13	advmod	_	_
-13	syk	syk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	conj	_	_
+13	syk	syk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	conj	_	_
 14	for	for	ADP	prep	_	17	case	_	_
 15	to	to	NUM	det	Number=Plur|NumType=Card	17	nummod	_	_
 16	omfattende	omfattende	ADJ	adj	Degree=Pos|Number=Plur	17	amod	_	_
@@ -8591,7 +8591,7 @@
 15	sykepleier	sykepleier	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	conj	_	_
 16	Sverre	Sverre	PROPN	subst	Gender=Masc	11	obj	_	_
 17	i	i	ADP	prep	_	19	case	_	_
-18	riktig	riktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	riktig	riktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	stilling	stilling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	obl	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -8673,7 +8673,7 @@
 4	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 5	ikke	ikke	PART	adv	Polarity=Neg	3	advmod	_	_
 6	pusten	pust	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obj	_	_
-7	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+7	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 8	lenger	lenge	ADJ	adj	Degree=Cmp	3	advmod	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -8681,7 +8681,7 @@
 # text = Sverre er død, kl. 04.30.
 1	Sverre	Sverre	PROPN	subst	Gender=Masc	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	død	død	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+3	død	død	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	6	punct	_	_
 5	kl.	kl.	NOUN	subst	Abbr=Yes	6	obl	_	_
 6	04.30	04.30	NUM	det	Number=Plur|NumType=Card	3	obl	_	SpaceAfter=No
@@ -8702,7 +8702,7 @@
 11	»	$"	PUNCT	<anf>	_	10	punct	_	_
 12	ved	ved	ADP	prep	_	13	case	_	_
 13	sengen	seng	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
-14	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	13	det	_	SpaceAfter=No
+14	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	13	nmod:poss	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 018576
@@ -8877,7 +8877,7 @@
 6	tidspunktet	tidspunkt	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	obl	_	_
 7	Fortodol	Fortodol	PROPN	subst	_	3	obj	_	_
 8	til	til	ADP	prep	_	10	case	_	_
-9	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	alvorlig	alvorlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	leversvikt	leversvikt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 11	både	både	CCONJ	konj	_	13	cc	_	_
 12	i	i	ADP	prep	_	13	case	_	_
@@ -8891,7 +8891,7 @@
 20	to	to	NUM	det	Number=Plur|NumType=Card	21	nummod	_	_
 21	tilfeller	tilfelle	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	10	nmod	_	_
 22	med	med	ADP	prep	_	24	case	_	_
-23	dødelig	dødelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	24	amod	_	_
+23	dødelig	dødelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	24	amod	_	_
 24	utgang	utgang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
 25	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -8990,7 +8990,7 @@
 
 # sent_id = 018590
 # text = Den sendes til Sverige, og 25. mars avsløres det:
-1	Den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
+1	Den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj:pass	_	_
 2	sendes	sende	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 3	til	til	ADP	prep	_	4	case	_	_
 4	Sverige	Sverige	PROPN	subst	_	2	obl	_	SpaceAfter=No
@@ -9043,7 +9043,7 @@
 8	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	expl	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	_	_
 10	faren	far	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	ccomp	_	_
-11	deres	deres	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	10	det	_	_
+11	deres	deres	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	10	nmod:poss	_	_
 12	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
 13	står	stå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	acl:relcl	_	_
 14	om	om	ADV	prep	_	13	advmod	_	SpaceAfter=No
@@ -9155,7 +9155,7 @@
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
 13	74	74	NUM	det	Number=Plur|NumType=Card	14	nummod	_	_
 14	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	15	obl	_	_
-15	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	mann	mann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	dislocated	_	_
 17	fra	fra	ADP	prep	_	18	case	_	_
 18	California	California	PROPN	subst	_	16	nmod	_	SpaceAfter=No
@@ -9167,7 +9167,7 @@
 2	Donsbach	Donsbach	PROPN	subst	_	1	flat:name	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	kjent	kjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	kjent	kjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	størrelse	størrelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 7	innen	innen	ADP	prep	_	10	case	_	_
 8	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
@@ -9198,14 +9198,14 @@
 # text = For en drøy måned siden ble han arrestert, tiltalt for elleve grove forbrytelser.
 1	For	for	ADP	prep	_	4	case	_	_
 2	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-3	drøy	drøy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	drøy	drøy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	måned	måned	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obl	_	_
 5	siden	siden	ADV	adv	_	4	advmod	_	_
 6	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	aux:pass	_	_
-7	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
+7	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj:pass	_	_
 8	arrestert	arrestere	VERB	verb	VerbForm=Part	0	root	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	10	punct	_	_
-10	tiltalt	tiltale	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	8	xcomp	_	_
+10	tiltalt	tiltale	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	8	xcomp	_	_
 11	for	for	ADP	prep	_	14	case	_	_
 12	elleve	elleve	NUM	det	Number=Plur|NumType=Card	14	nummod	_	_
 13	grove	grov	ADJ	adj	Degree=Pos|Number=Plur	14	amod	_	_
@@ -9256,7 +9256,7 @@
 9	som	som	ADP	prep	_	10	case	_	_
 10	kiropraktor	kiropraktor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	xcomp	_	_
 11	og	og	CCONJ	konj	_	13	cc	_	_
-12	naturmedisinsk	naturmedisinsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	naturmedisinsk	naturmedisinsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	lege	lege	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	conj	_	SpaceAfter=No
 14	,	$,	PUNCT	<komma>	_	16	punct	_	_
 15	men	men	CCONJ	konj	_	16	cc	_	_
@@ -9275,7 +9275,7 @@
 
 # sent_id = 018603
 # text = Han er også blitt tatt i å selge Fortodol tilsatt nimesulid, som hjemmebehandling mot kreft i bukspyttkjertelen.
-1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
+1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	nsubj:pass	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 3	også	også	ADV	adv	_	5	advmod	_	_
 4	blitt	bli	AUX	verb	VerbForm=Part	5	aux:pass	_	_
@@ -9374,7 +9374,7 @@
 
 # sent_id = 018609
 # text = Det skal ikke kombineres med andre legemidler som kan påvirke leveren.
-1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
+1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj:pass	_	_
 2	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	ikke	ikke	PART	adv	Polarity=Neg	4	advmod	_	_
 4	kombineres	kombinere	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
@@ -9456,7 +9456,7 @@
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
 4	utsagn	utsagn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	0	root	_	_
-5	daglig	daglig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	daglig	daglig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	leder	leder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	nsubj	_	_
 7	i	i	ADP	prep	_	8	case	_	_
 8	Bringwell	Bringwell	PROPN	subst	_	6	nmod	_	_
@@ -9568,7 +9568,7 @@
 31	å	å	PART	inf-merke	_	32	mark	_	_
 32	gi	gi	VERB	verb	VerbForm=Inf	29	xcomp	_	_
 33	ekstra	ekstra	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	34	advmod	_	_
-34	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	35	amod	_	_
+34	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	35	amod	_	_
 35	effekt	effekt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	32	obj	_	SpaceAfter=No
 36	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -9607,7 +9607,7 @@
 4	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 5	lenge	lenge	ADJ	adj	Degree=Pos	7	advmod	_	_
 6	vært	være	AUX	verb	VerbForm=Part	7	cop	_	_
-7	kontroversiell	kontroversiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+7	kontroversiell	kontroversiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 8	i	i	ADP	prep	_	9	case	_	_
 9	USA	USA	PROPN	subst	Abbr=Yes	7	obl	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	14	punct	_	_
@@ -9627,7 +9627,7 @@
 # text = Men produktene hans er godt dokumentert, og det har fulgt gode analysesertifikater med alle leveranser til oss.
 1	Men	men	CCONJ	konj	_	6	cc	_	_
 2	produktene	produkt	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	6	nsubj	_	_
-3	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	2	det	_	_
+3	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 5	godt	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
 6	dokumentert	dokumentere	VERB	verb	VerbForm=Part	0	root	_	SpaceAfter=No
@@ -9677,7 +9677,7 @@
 3	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	2	obj	_	_
 4	bare	bare	ADV	adv	_	2	advmod	_	_
 5	til	til	ADP	prep	_	7	case	_	_
-6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 7	leverandør	leverandør	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	_
 8	-	$-	PUNCT	<strek>	_	9	punct	_	_
 9	Hela	Hela	PROPN	subst	_	7	appos	_	_
@@ -9737,21 +9737,21 @@
 19	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	nsubj	_	_
 20	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	ccomp	_	_
 21	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
-22	unik	unik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	amod	_	_
+22	unik	unik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	amod	_	_
 23	helsekompetanse	helsekompetanse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	20	obj	_	SpaceAfter=No
 24	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 018629
 # text = - Donsbach er uten tvil blitt lurt av sine indiske råvare-underleverandører.
 1	-	$-	PUNCT	<strek>	_	7	punct	_	_
-2	Donsbach	Donsbach	PROPN	subst	_	7	nsubj	_	_
+2	Donsbach	Donsbach	PROPN	subst	_	7	nsubj:pass	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
 4	uten	uten	ADP	prep	_	5	case	_	_
 5	tvil	tvil	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obl	_	_
 6	blitt	bli	AUX	verb	VerbForm=Part	7	aux:pass	_	_
 7	lurt	lure	VERB	verb	VerbForm=Part	0	root	_	_
 8	av	av	ADP	prep	_	11	case	_	_
-9	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	det	_	_
+9	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 10	indiske	indisk	ADJ	adj	Degree=Pos|Number=Plur	11	amod	_	_
 11	råvare-underleverandører	råvare-underleverandør	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	7	obl	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	7	punct	_	_
@@ -9821,7 +9821,7 @@
 # text = - Men flere av disse produseres nå i Sverige, og vi kontrollerer at alle Donsbach-produktene kun inneholder det som deklareres, sier Claesson - som allerede denne måneden begynner å produsere Fortodol igjen.
 1	-	$-	PUNCT	<strek>	_	6	punct	_	_
 2	Men	men	CCONJ	konj	_	6	cc	_	_
-3	flere	mange	ADJ	adj	Degree=Cmp	6	nsubj	_	_
+3	flere	mange	ADJ	adj	Degree=Cmp	6	nsubj:pass	_	_
 4	av	av	ADP	prep	_	5	case	_	_
 5	disse	disse	PRON	pron	Number=Plur|Person=3|PronType=Prs	3	nmod	_	_
 6	produseres	produsere	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	23	ccomp	_	_
@@ -9861,7 +9861,7 @@
 2	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 3	skjer	skje	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	på	på	ADP	prep	_	7	case	_	_
-5	Hela	Hela	PROPN	subst	_	7	nmod	_	_
+5	Hela	Hela	PROPN	subst	_	7	nmod:poss	_	_
 6	Pharmas	Pharma	PROPN	subst	Case=Gen	5	flat:name	_	_
 7	fabrikk	fabrikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 8	i	i	ADP	prep	_	9	case	_	_
@@ -9870,7 +9870,7 @@
 11	hvor	hvor	ADV	adv	_	13	advmod	_	_
 12	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	_	_
 13	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	acl:relcl	_	_
-14	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	kontroll	kontroll	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	obj	_	_
 16	med	med	ADP	prep	_	17	case	_	_
 17	produksjonen	produksjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	SpaceAfter=No
@@ -9918,7 +9918,7 @@
 12	å	å	PART	inf-merke	_	15	mark	_	_
 13	være	være	AUX	verb	VerbForm=Inf	15	cop	_	_
 14	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	15	advmod	_	_
-15	trygg	trygg	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	xcomp	_	SpaceAfter=No
+15	trygg	trygg	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	xcomp	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 018637
@@ -9977,7 +9977,7 @@
 8	alkoholbaserte	alkoholbasere	ADJ	adj	Number=Plur|VerbForm=Part	9	amod	_	_
 9	ekstrakter	ekstrakt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	7	obj	_	_
 10	av	av	ADP	prep	_	12	case	_	_
-11	grønn	grønn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	grønn	grønn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	te	te	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nmod	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	5	punct	_	_
 14	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
@@ -10013,12 +10013,12 @@
 
 # sent_id = 018641
 # text = Urter som er forbudt fordi de anses som helsefarlige, er i kosttilskudd blitt erstattet av legemidler.
-1	Urter	urt	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	15	nsubj	_	_
+1	Urter	urt	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	15	nsubj:pass	_	_
 2	som	som	SCONJ	sbu	_	4	mark	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 4	forbudt	forby	VERB	verb	VerbForm=Part	1	acl:relcl	_	_
 5	fordi	fordi	SCONJ	sbu	_	7	mark	_	_
-6	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	_	_
+6	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj:pass	_	_
 7	anses	anse	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	4	advcl	_	_
 8	som	som	ADP	prep	_	9	case	_	_
 9	helsefarlige	helsefarlig	ADJ	adj	Degree=Pos|Number=Plur	7	xcomp	_	SpaceAfter=No
@@ -10049,7 +10049,7 @@
 13	av	av	ADP	prep	_	14	case	_	_
 14	Aristolochia-arter	Aristolochia-art	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	12	nmod	_	_
 15	i	i	ADP	prep	_	17	case	_	_
-16	kinesisk	kinesisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	kinesisk	kinesisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	slankemedisin	slankemedisin	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
 18	,	$,	PUNCT	<komma>	_	23	punct	_	_
 19	og	og	CCONJ	konj	_	23	cc	_	_
@@ -10070,9 +10070,9 @@
 34	som	som	SCONJ	sbu	_	36	mark	_	_
 35	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	36	aux	_	_
 36	skape	skape	VERB	verb	VerbForm=Inf	33	acl:relcl	_	_
-37	fysisk	fysisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	40	amod	_	_
+37	fysisk	fysisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	40	amod	_	_
 38	og	og	CCONJ	konj	_	39	cc	_	_
-39	mental	mental	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	37	conj	_	_
+39	mental	mental	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	37	conj	_	_
 40	balanse	balanse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	36	obj	_	SpaceAfter=No
 41	)	$)	PUNCT	<parentes-slutt>	_	33	punct	_	_
 42	preparater	preparat	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	28	obj	_	SpaceAfter=No
@@ -10097,7 +10097,7 @@
 2	Norge	Norge	PROPN	subst	_	3	obl	_	_
 3	kreves	kreve	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 4	ikke	ikke	PART	adv	Polarity=Neg	3	advmod	_	_
-5	forhåndsgodkjenning	forhåndsgodkjenning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	nsubj	_	_
+5	forhåndsgodkjenning	forhåndsgodkjenning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	nsubj:pass	_	_
 6	av	av	ADP	prep	_	8	case	_	_
 7	hverken	hverken	CCONJ	konj	_	8	cc	_	_
 8	mat	mat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nmod	_	_
@@ -10110,7 +10110,7 @@
 15	helsekostmarkedet	helsekostmarked	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	13	nmod	_	_
 16	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	20	cop	_	_
 17	i	i	ADP	prep	_	19	case	_	_
-18	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	grad	grad	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	20	obl	_	_
 20	overlatt	overlate	VERB	verb	VerbForm=Part	3	conj	_	_
 21	til	til	ADP	prep	_	22	case	_	_
@@ -10126,7 +10126,7 @@
 4	fint	fin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	3	advmod	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	3	punct	_	_
 6	mener	mene	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-7	daglig	daglig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	daglig	daglig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	leder	leder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nsubj	_	_
 9	Turid	Turid	PROPN	subst	Gender=Fem	8	flat:name	_	_
 10	Backer	Backer	PROPN	subst	_	8	flat:name	_	_
@@ -10173,7 +10173,7 @@
 # text = Derfor har våre medlemmer frivillig underlagt seg en produktkontroll.
 1	Derfor	derfor	ADV	adv	_	6	advmod	_	_
 2	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
-3	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	4	det	_	_
+3	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 4	medlemmer	medlem	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	6	nsubj	_	_
 5	frivillig	frivillig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
 6	underlagt	underlegge	VERB	verb	VerbForm=Part	0	root	_	_
@@ -10238,7 +10238,7 @@
 18	,	$,	PUNCT	<komma>	_	9	punct	_	_
 19	godkjennes	godkjenne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	28	ccomp	_	_
 20	ikke	ikke	PART	adv	Polarity=Neg	19	advmod	_	_
-21	produktet	produkt	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	19	nsubj	_	_
+21	produktet	produkt	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	19	nsubj:pass	_	_
 22	og	og	CCONJ	konj	_	23	cc	_	_
 23	kommer	komme	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	conj	_	_
 24	ikke	ikke	PART	adv	Polarity=Neg	23	advmod	_	_
@@ -10301,7 +10301,7 @@
 2	i	i	ADP	prep	_	3	case	_	_
 3	Europa	Europa	PROPN	subst	_	1	nmod	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
-5	lei	lei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+5	lei	lei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 6	av	av	ADP	prep	_	9	case	_	_
 7	å	å	PART	inf-merke	_	9	mark	_	_
 8	bli	bli	AUX	verb	VerbForm=Inf	9	aux:pass	_	_
@@ -10333,7 +10333,7 @@
 5	kapslene	kapsel	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	6	nsubj	_	_
 6	inneholdt	inneholde	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	så	så	ADV	adv	_	8	advmod	_	_
-8	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	gurkemeie	gurkemeie	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
 10	som	som	SCONJ	sbu	_	12	mark	_	_
 11	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	_	_
@@ -10391,7 +10391,7 @@
 # sent_id = 018659
 # text = 51 produkter er blitt stoppet på grunn av feil eller mangler, funn av tungmetaller (4), sprøytemidler (2), mikroorganismer (1), genmodifiserte stoffer (1) eller at det ikke var samsvar mellom analysen og deklarasjonen på pakken.
 1	51	51	NUM	det	Number=Plur|NumType=Card	2	nummod	_	_
-2	produkter	produkt	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nsubj	_	_
+2	produkter	produkt	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nsubj:pass	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	blitt	bli	AUX	verb	VerbForm=Part	5	aux:pass	_	_
 5	stoppet	stoppe	VERB	verb	VerbForm=Part	0	root	_	_
@@ -10440,7 +10440,7 @@
 
 # sent_id = 018660
 # text = Mange av disse ble godkjent senere, da manglene var korrigert.
-1	Mange	mange	ADJ	adj	Degree=Pos|Number=Plur	5	nsubj	_	_
+1	Mange	mange	ADJ	adj	Degree=Pos|Number=Plur	5	nsubj:pass	_	_
 2	av	av	ADP	prep	_	3	case	_	_
 3	disse	disse	PRON	pron	Number=Plur|Person=3|PronType=Prs	1	nmod	_	_
 4	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
@@ -10475,7 +10475,7 @@
 # sent_id = 018662
 # text = - Kvalitet må bygges inn trinn for trinn.
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
-2	Kvalitet	kvalitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj	_	_
+2	Kvalitet	kvalitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj:pass	_	_
 3	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 4	bygges	bygge	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 5	inn	inn	ADV	prep	_	4	advmod	_	_
@@ -10493,7 +10493,7 @@
 5	etterkant	etterkant	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	_
 6	gir	gi	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	falsk	falsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	falsk	falsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	trygghet	trygghet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	SpaceAfter=No
 10	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -10523,7 +10523,7 @@
 22	legemidler	legemiddel	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	19	obl	_	SpaceAfter=No
 23	,	$,	PUNCT	<komma>	_	26	punct	_	_
 24	med	med	ADP	prep	_	26	case	_	_
-25	fullstendig	fullstendig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	amod	_	_
+25	fullstendig	fullstendig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	amod	_	_
 26	produktinformasjon	produktinformasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	nmod	_	SpaceAfter=No
 27	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -10533,7 +10533,7 @@
 2	I	i	ADP	prep	_	3	case	_	_
 3	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	4	obl	_	_
 4	innføres	innføre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
-5	ordningen	ordning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
+5	ordningen	ordning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj:pass	_	_
 6	i	i	ADP	prep	_	7	case	_	_
 7	EØS	EØS	PROPN	subst	_	4	obl	_	SpaceAfter=No
 8	.	$.	PUNCT	clb	_	4	punct	_	_
@@ -10557,7 +10557,7 @@
 15	for	for	ADP	prep	_	17	case	_	_
 16	å	å	PART	inf-merke	_	17	mark	_	_
 17	søke	søke	VERB	verb	VerbForm=Inf	14	acl	_	_
-18	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	19	det	_	_
+18	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	19	nmod:poss	_	_
 19	produkter	produkt	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	17	obj	_	_
 20	inn	inn	ADP	prep	_	23	case	_	_
 21	under	under	ADP	prep	_	23	case	_	_
@@ -10671,7 +10671,7 @@
 3	2008	2008	NUM	det	Number=Plur|NumType=Card	2	nmod	_	_
 4	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 5	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	expl	_	_
-6	varm	varm	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	varm	varm	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	sol	sol	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	nsubj	_	_
 8	på	på	ADP	prep	_	9	case	_	_
 9	Kløfta	Kløfta	PROPN	subst	_	4	obl	_	SpaceAfter=No
@@ -10690,14 +10690,14 @@
 9	Ullensaker	Ullensaker	PROPN	subst	_	12	nsubj	_	_
 10	kirke	kirke	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	flat:name	_	_
 11	nesten	nesten	ADV	adv	_	12	advmod	_	_
-12	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	SpaceAfter=No
+12	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 018673
 # text = Foran en hvit kiste står Rune og Ståle og forteller om en pappa som alltid var der.
 1	Foran	foran	ADP	prep	_	4	case	_	_
 2	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-3	hvit	hvit	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	hvit	hvit	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	kiste	kiste	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 5	står	stå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	Rune	Rune	PROPN	subst	Gender=Masc	5	nsubj	_	_
@@ -10745,7 +10745,7 @@
 7	og	og	CCONJ	konj	_	10	cc	_	_
 8	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	cop	_	_
 9	så	så	ADV	adv	_	10	advmod	_	_
-10	flink	flink	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	conj	_	_
+10	flink	flink	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	conj	_	_
 11	med	med	ADP	prep	_	12	case	_	_
 12	hendene	hånd	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	10	obl	_	_
 13	at	at	SCONJ	sbu	_	17	mark	_	_
@@ -10779,7 +10779,7 @@
 14	døde	dø	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	advcl	_	_
 15	av	av	ADP	prep	_	18	case	_	_
 16	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
-17	fatal	fatal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	fatal	fatal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	leversvikt	leversvikt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	obl	_	_
 19	som	som	SCONJ	sbu	_	20	mark	_	_
 20	førte	føre	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	18	acl:relcl	_	_
@@ -10823,7 +10823,7 @@
 26	forverre	forverre	VERB	verb	VerbForm=Inf	23	advcl	_	_
 27	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	30	det	_	_
 28	allerede	allerede	ADV	adv	_	29	advmod	_	_
-29	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	30	amod	_	_
+29	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	30	amod	_	_
 30	lever	lever	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	26	obj	_	SpaceAfter=No
 31	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -10879,7 +10879,7 @@
 2	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	expl	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 4	på	på	ADP	prep	_	6	case	_	_
-5	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	17	ccomp	_	_
 7	at	at	SCONJ	sbu	_	9	mark	_	_
 8	pasienter	pasient	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	9	nsubj	_	_
@@ -10887,7 +10887,7 @@
 10	å	å	PART	inf-merke	_	11	mark	_	_
 11	opplyse	opplyse	VERB	verb	VerbForm=Inf	9	xcomp	_	_
 12	legene	lege	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	11	obj	_	_
-13	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	det	_	_
+13	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 14	om	om	ADP	prep	_	15	case	_	_
 15	dette	dette	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nmod	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	6	punct	_	_
@@ -11115,7 +11115,7 @@
 6	bli	bli	VERB	verb	VerbForm=Inf	0	root	_	_
 7	i	i	ADP	prep	_	8	case	_	_
 8	overkant	overkant	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obl	_	_
-9	tøff	tøff	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	xcomp	_	_
+9	tøff	tøff	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	xcomp	_	_
 10	for	for	ADP	prep	_	11	case	_	_
 11	henne	hun	PRON	pron	Animacy=Hum|Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	9	obl	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	6	punct	_	_
@@ -11183,7 +11183,7 @@
 8	halvtimes	halvtime	NOUN	subst	Case=Gen|Definite=Ind|Gender=Masc|Number=Sing	9	nmod	_	_
 9	overtalelse	overtalelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obl	_	_
 10	og	og	CCONJ	konj	_	12	cc	_	_
-11	grov	grov	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	grov	grov	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	køsniking	køsniking	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	conj	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	9	punct	_	_
 14	på	på	ADP	prep	_	15	case	_	_
@@ -11215,14 +11215,14 @@
 11	,	$,	PUNCT	<komma>	_	13	punct	_	_
 12	med	med	ADP	prep	_	13	case	_	_
 13	capsen	caps	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	obl	_	_
-14	dratt	dra	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	13	xcomp	_	_
+14	dratt	dra	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	13	xcomp	_	_
 15	langt	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	18	advmod	_	_
 16	ned	ned	ADP	prep	_	18	case	_	_
 17	over	over	ADP	prep	_	18	case	_	_
 18	ansiktet	ansikt	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	14	obl	_	SpaceAfter=No
 19	,	$,	PUNCT	<komma>	_	13	punct	_	_
 20	med	med	ADP	prep	_	23	case	_	_
-21	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	23	det	_	_
+21	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	23	nmod:poss	_	_
 22	to	to	NUM	det	Number=Plur|NumType=Card	23	nummod	_	_
 23	venner	venn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	2	obl	_	SpaceAfter=No
 24	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -11237,7 +11237,7 @@
 6	33,3	33,3	NUM	det	Number=Plur|NumType=Card	7	nummod	_	SpaceAfter=No
 7	%	%	NOUN	subst	_	9	obl	_	_
 8	Paradise	Paradise	PROPN	subst	_	9	compound	_	_
-9	Hotel-infiltrert	Hotel-infiltrere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	10	amod	_	_
+9	Hotel-infiltrert	Hotel-infiltrere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	10	amod	_	_
 10	trio	trio	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	10	punct	_	_
 
@@ -11306,7 +11306,7 @@
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 3	faktisk	faktisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
 4	ganske	ganske	ADV	adv	_	5	advmod	_	_
-5	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+5	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # newpar
@@ -11333,7 +11333,7 @@
 11	ut	ut	ADP	prep	_	13	case	_	_
 12	av	av	ADP	prep	_	13	case	_	_
 13	prosecco-vorspielene	prosecco-vorspiel	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	10	obl	_	_
-14	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	det	_	_
+14	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 15	for	for	ADP	prep	_	17	case	_	_
 16	å	å	PART	inf-merke	_	17	mark	_	_
 17	jakte	jakte	VERB	verb	VerbForm=Inf	10	advcl	_	_
@@ -11397,7 +11397,7 @@
 18	disse	disse	DET	det	Number=Plur|PronType=Dem	19	det	_	_
 19	menneskene	menneske	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	16	obl	_	_
 20	at	at	SCONJ	sbu	_	23	mark	_	_
-21	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	23	nsubj	_	_
+21	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	23	nsubj:pass	_	_
 22	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	23	aux:pass	_	_
 23	oppfattet	oppfatte	VERB	verb	VerbForm=Part	16	csubj	_	_
 24	rike	rik	ADJ	adj	Degree=Pos|Number=Plur	23	xcomp	_	SpaceAfter=No
@@ -11410,7 +11410,7 @@
 31	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	32	nsubj	_	_
 32	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	23	advcl	_	_
 33	studiegjelden	studiegjeld	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	32	obj	_	_
-34	trøkket	trøkke	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	32	xcomp	_	_
+34	trøkket	trøkke	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	32	xcomp	_	_
 35	så	så	ADV	adv	_	36	advmod	_	_
 36	langt	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	39	advmod	_	_
 37	inn	inn	ADP	prep	_	39	case	_	_
@@ -11486,7 +11486,7 @@
 30	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	32	det	_	_
 31	kjønnsykdomfremkallende	kjønnsykdomfremkalle	ADJ	adj	VerbForm=Part	32	amod	_	_
 32	festingen	festing	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	29	obj	_	_
-33	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	32	det	_	_
+33	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	32	nmod:poss	_	_
 34	til	til	ADP	prep	_	35	case	_	_
 35	fredager	fredag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	29	obl	_	_
 36	og	og	CCONJ	konj	_	37	cc	_	_
@@ -11538,7 +11538,7 @@
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	_	_
 10	guttevalpene	guttevalp	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	12	nsubj	_	_
 11	sterkt	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	12	advmod	_	_
-12	representert	representere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	3	conj	_	SpaceAfter=No
+12	representert	representere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	3	conj	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	19	punct	_	_
 14	og	og	CCONJ	konj	_	19	cc	_	_
 15	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	19	nsubj	_	_
@@ -11569,7 +11569,7 @@
 10	alle	alle	PRON	pron	Number=Plur|Person=3|PronType=Prs,Tot	11	nsubj	_	_
 11	går	gå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	acl:relcl	_	_
 12	likt	lik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	13	advmod	_	_
-13	kledd	kle	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	11	xcomp	_	SpaceAfter=No
+13	kledd	kle	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	11	xcomp	_	SpaceAfter=No
 14	;	$;	PUNCT	clb	_	15	punct	_	_
 15	Ralph	Ralph	PROPN	subst	_	7	dislocated	_	_
 16	Lauren	Lauren	PROPN	subst	_	15	flat:name	_	_
@@ -11714,7 +11714,7 @@
 1	Men	men	CCONJ	konj	_	5	cc	_	_
 2	tilbake	tilbake	ADP	prep	_	5	case	_	_
 3	til	til	ADP	prep	_	5	case	_	_
-4	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+4	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	situasjon	situasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -11722,7 +11722,7 @@
 # text = Jeg og mine to venner klarte omsider å presse oss ut i bakgården der en stygg DJ ingen har hørt om (ikledd Ralph Lauren og Volt-klær, selvsagt) spilte club-musikk (en forferdelig sjanger som burde kriminaliseres umiddelbart) mens han " steket " med hånda ut mot massene av ekle, kåte ungdommer - jeg holder hardt tilbake på nazi-referansene mine nå.
 1	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	_
 2	og	og	CCONJ	konj	_	5	cc	_	_
-3	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	5	det	_	_
+3	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 4	to	to	NUM	det	Number=Plur|NumType=Card	5	nummod	_	_
 5	venner	venn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	1	conj	_	_
 6	klarte	klare	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
@@ -11735,7 +11735,7 @@
 13	bakgården	bakgård	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 14	der	der	SCONJ	sbu	_	31	mark	_	_
 15	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-16	stygg	stygg	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	stygg	stygg	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	DJ	DJ	NOUN	subst	Abbr=Yes|Gender=Masc	31	nsubj	_	_
 18	ingen	ingen	PRON	pron	Number=Plur|Person=3|PronType=Prs	20	nsubj	_	_
 19	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	20	aux	_	_
@@ -11754,7 +11754,7 @@
 32	club-musikk	club-musikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	31	obj	_	_
 33	(	$(	PUNCT	<parentes-beg>	_	36	punct	_	SpaceAfter=No
 34	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	36	det	_	_
-35	forferdelig	forferdelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	36	amod	_	_
+35	forferdelig	forferdelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	36	amod	_	_
 36	sjanger	sjanger	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	32	appos	_	_
 37	som	som	SCONJ	sbu	_	39	mark	_	_
 38	burde	burde	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	39	aux	_	_
@@ -11783,7 +11783,7 @@
 61	tilbake	tilbake	ADP	prep	_	63	case	_	_
 62	på	på	ADP	prep	_	63	case	_	_
 63	nazi-referansene	nazi-referanse	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	59	obl	_	_
-64	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	63	det	_	_
+64	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	63	nmod:poss	_	_
 65	nå	nå	ADV	adv	_	59	advmod	_	SpaceAfter=No
 66	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -11805,7 +11805,7 @@
 13	de	de	DET	det	Number=Plur|PronType=Art	15	det	_	_
 14	vonde	vond	ADJ	adj	Degree=Pos|Number=Plur	15	amod	_	_
 15	opplevelsene	opplevelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	11	nmod	_	_
-16	dine	din	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	15	det	_	SpaceAfter=No
+16	dine	din	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	15	nmod:poss	_	SpaceAfter=No
 17	*	*	PUNCT	symb	_	2	punct	_	_
 
 # newpar
@@ -11821,7 +11821,7 @@
 1	Vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
 2	fant	finne	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	plass	plass	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 6	der	der	SCONJ	sbu	_	9	mark	_	_
 7	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	expl	_	_
@@ -11847,7 +11847,7 @@
 10	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	nsubj	_	_
 11	kun	kun	ADV	adv	_	9	advmod	_	_
 12	at	at	SCONJ	sbu	_	16	mark	_	_
-13	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	16	nsubj	_	_
+13	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	16	nsubj:pass	_	_
 14	ikke	ikke	PART	adv	Polarity=Neg	16	advmod	_	_
 15	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	16	aux:pass	_	_
 16	jokket	jokke	VERB	verb	VerbForm=Part	9	xcomp	_	_
@@ -11896,15 +11896,15 @@
 20	og	og	CCONJ	konj	_	28	cc	_	_
 21	med	med	ADP	prep	_	27	case	_	_
 22	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	27	det	_	_
-23	konstant	konstant	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	27	amod	_	_
+23	konstant	konstant	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	27	amod	_	_
 24	tjue	tjue	NUM	det	Number=Plur|NumType=Card	25	nummod	_	_
 25	meter	meter	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	26	obl	_	_
-26	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	27	amod	_	_
+26	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	27	amod	_	_
 27	kø	kø	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	28	obl	_	_
 28	tok	ta	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	16	conj	_	_
 29	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	28	expl	_	_
 30	ikke	ikke	PART	adv	Polarity=Neg	28	advmod	_	_
-31	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	32	amod	_	_
+31	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	32	amod	_	_
 32	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	28	obj	_	_
 33	før	før	SCONJ	sbu	_	41	mark	_	_
 34	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	37	det	_	_
@@ -11937,7 +11937,7 @@
 14	fordi	fordi	SCONJ	sbu	_	17	mark	_	_
 15	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	_	_
 16	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	cop	_	_
-17	redd	redd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	advcl	_	_
+17	redd	redd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	advcl	_	_
 18	for	for	ADP	prep	_	22	case	_	_
 19	at	at	SCONJ	sbu	_	22	mark	_	_
 20	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	22	expl	_	_
@@ -11979,7 +11979,7 @@
 56	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	57	det	_	_
 57	hav	hav	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	54	nmod	_	_
 58	av	av	ADP	prep	_	60	case	_	_
-59	selvbekreftende	selvbekreftende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	60	amod	_	_
+59	selvbekreftende	selvbekreftende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	60	amod	_	_
 60	fyllesex	fyllesex	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	57	nmod	_	SpaceAfter=No
 61	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -11991,7 +11991,7 @@
 3	ønske	ønske	VERB	verb	VerbForm=Inf	0	root	_	_
 4	at	at	SCONJ	sbu	_	10	mark	_	_
 5	sammendraget	sammendrag	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	10	nsubj	_	_
-6	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+6	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 7	fra	fra	ADP	prep	_	8	case	_	_
 8	gårsdagen	gårsdag	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 9	også	også	ADV	adv	_	10	advmod	_	_
@@ -12013,7 +12013,7 @@
 25	desverre	dessverre	ADV	adv	_	24	advmod	_	_
 26	ikke	ikke	PART	adv	Polarity=Neg	24	advmod	_	_
 27	verdigheten	verdighet	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	24	obj	_	_
-28	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	27	det	_	_
+28	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	27	nmod:poss	_	_
 29	til	til	ADV	prep	_	24	advmod	_	SpaceAfter=No
 30	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -12109,7 +12109,7 @@
 20	forstod	forstå	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 21	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	_	_
 22	at	at	SCONJ	sbu	_	26	mark	_	_
-23	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	24	det	_	_
+23	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	24	nmod:poss	_	_
 24	tid	tid	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	26	nsubj	_	_
 25	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	26	cop	_	_
 26	kommet	komme	VERB	verb	VerbForm=Part	20	xcomp	_	SpaceAfter=No
@@ -12121,7 +12121,7 @@
 2	drakk	drikke	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	opp	opp	ADV	prep	_	2	advmod	_	_
 4	ølet	øl	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	obj	_	_
-5	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	SpaceAfter=No
+5	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	7	punct	_	_
 7	kavet	kave	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	_	_
 8	meg	jeg	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=1|PronType=Prs	7	obj	_	_
@@ -12142,7 +12142,7 @@
 2	halvtime	halvtime	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nsubj	_	_
 3	av	av	ADP	prep	_	4	case	_	_
 4	livet	liv	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	nmod	_	_
-5	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	det	_	_
+5	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 6	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	_	_
 7	borte	borte	ADP	prep	_	0	root	_	_
 8	for	for	ADP	prep	_	9	case	_	_
@@ -12174,7 +12174,7 @@
 # text = Advare leserne mine mot å bli " slik " .
 1	Advare	advare	VERB	verb	VerbForm=Inf	0	root	_	_
 2	leserne	leser	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	1	obj	_	_
-3	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	2	det	_	_
+3	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 4	mot	mot	ADP	prep	_	6	case	_	_
 5	å	å	PART	inf-merke	_	6	mark	_	_
 6	bli	bli	VERB	verb	VerbForm=Inf	1	advcl	_	_
@@ -12211,7 +12211,7 @@
 2	handler	handle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	om	om	ADP	prep	_	6	case	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	morbid	morbid	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	morbid	morbid	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	form	form	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	_
 7	for	for	ADP	prep	_	8	case	_	_
 8	selvbekreftelse	selvbekreftelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nmod	_	_
@@ -12221,7 +12221,7 @@
 12	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
 13	liv	liv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	obl	_	_
 14	av	av	ADP	prep	_	16	case	_	_
-15	innestengt	innestengt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	innestengt	innestengt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	fylleangst	fylleangst	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nmod	_	_
 17	som	som	SCONJ	sbu	_	19	mark	_	_
 18	bare	bare	ADV	adv	_	19	advmod	_	_
@@ -12251,9 +12251,9 @@
 2	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 4	fått	få	VERB	verb	VerbForm=Part	0	root	_	_
-5	bekreftet	bekrefte	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	4	xcomp	_	_
+5	bekreftet	bekrefte	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	4	xcomp	_	_
 6	myten	myte	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	obj	_	_
-7	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	SpaceAfter=No
+7	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	11	punct	_	_
 9	og	og	CCONJ	konj	_	11	cc	_	_
 10	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	_	_
@@ -12284,7 +12284,7 @@
 11	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux	_	_
 12	ikke	ikke	PART	adv	Polarity=Neg	13	advmod	_	_
 13	få	få	VERB	verb	VerbForm=Inf	4	conj	_	_
-14	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	15	det	_	_
+14	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 15	penger	penge	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	13	obj	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -12360,7 +12360,7 @@
 1	I	i	ADP	prep	_	2	case	_	_
 2	sommer	sommer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
-4	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
+4	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj:pass	_	_
 5	kontaktet	kontakte	VERB	verb	VerbForm=Part	0	root	_	_
 6	av	av	ADP	prep	_	7	case	_	_
 7	journalist	journalist	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
@@ -12443,7 +12443,7 @@
 # text = "Så søt kjole du har" og «så fine hårspenner, er de nye?" bare ramler ut nærmest av seg selv uten at hjernen har rukket å bli koblet på.
 1	"	$"	PUNCT	<anf>	_	4	punct	_	SpaceAfter=No
 2	Så	så	ADV	adv	_	3	advmod	_	_
-3	søt	søt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	søt	søt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	kjole	kjole	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	20	nsubj	_	_
 5	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	6	nsubj	_	_
 6	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	_	SpaceAfter=No
@@ -12500,7 +12500,7 @@
 7	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nmod	_	_
 8	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	9	nsubj	_	_
 9	får	få	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	acl:relcl	_	_
-10	positiv	positiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	positiv	positiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	oppmerksomhet	oppmerksomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	obj	_	_
 12	for	for	ADV	prep	_	9	advmod	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	24	punct	_	_
@@ -12542,7 +12542,7 @@
 16	ting	ting	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	10	obl	_	_
 17	enn	enn	ADP	prep	_	19	case	_	_
 18	hvor	hvor	ADV	adv	_	19	advmod	_	_
-19	nydelig	nydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	advcl	_	_
+19	nydelig	nydelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	advcl	_	_
 20	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	19	nsubj	_	_
 21	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	cop	_	_
 22	(	$(	PUNCT	<parentes-beg>	_	24	punct	_	SpaceAfter=No
@@ -12554,7 +12554,7 @@
 28	akkurat	akkurat	ADV	adv	_	30	advmod	_	_
 29	som	som	ADP	prep	_	30	case	_	_
 30	brødrene	bror	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	24	obl	_	_
-31	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	30	det	_	SpaceAfter=No
+31	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	30	nmod:poss	_	SpaceAfter=No
 32	)	$)	PUNCT	<parentes-slutt>	_	24	punct	_	SpaceAfter=No
 33	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -12587,10 +12587,10 @@
 25	når	når	SCONJ	sbu	_	27	mark	_	_
 26	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	27	nsubj	_	_
 27	blir	bli	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	24	advcl	_	_
-28	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	27	xcomp	_	_
+28	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	27	xcomp	_	_
 29	(	$(	PUNCT	<parentes-beg>	_	32	punct	_	SpaceAfter=No
 30	>	>	SYM	symb	_	32	cc	_	_
-31	olympisk	olympisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	32	amod	_	_
+31	olympisk	olympisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	32	amod	_	_
 32	mester	mester	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	parataxis	_	SpaceAfter=No
 33	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -12608,7 +12608,7 @@
 # text = Er du bevisst på hva du snakker om med småjenter?
 1	Er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
 2	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
-3	bevisst	bevisst	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	bevisst	bevisst	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	på	på	ADP	prep	_	7	case	_	_
 5	hva	hva	PRON	pron	PronType=Int	7	obl	_	_
 6	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	7	nsubj	_	_
@@ -12767,7 +12767,7 @@
 27	rom	rom	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	24	obj	_	_
 28	i	i	ADP	prep	_	29	case	_	_
 29	hjertet	hjerte	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	27	nmod	_	_
-30	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	29	det	_	SpaceAfter=No
+30	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	29	nmod:poss	_	SpaceAfter=No
 31	»	$"	PUNCT	<anf>	_	22	punct	_	_
 32	og	og	CCONJ	konj	_	34	cc	_	_
 33	«	$"	PUNCT	<anf>	_	34	punct	_	SpaceAfter=No
@@ -12855,7 +12855,7 @@
 10	opp	opp	ADV	prep	_	9	advmod	_	_
 11	i	i	ADP	prep	_	12	case	_	_
 12	Facebookfeeden	Facebookfeed	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
-13	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	12	det	_	SpaceAfter=No
+13	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	12	nmod:poss	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	9	punct	_	_
 
 # sent_id = 018780
@@ -13017,7 +13017,7 @@
 5	om	om	ADP	prep	_	7	case	_	_
 6	å	å	PART	inf-merke	_	7	mark	_	_
 7	pushe	pushe	VERB	verb	VerbForm=Inf	4	advcl	_	_
-8	ensidig	ensidig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	ensidig	ensidig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	baby-	baby-	NOUN	subst	_	7	obj	_	_
 10	og	og	CCONJ	konj	_	11	cc	_	_
 11	familielykke	familielykke	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	conj	_	SpaceAfter=No
@@ -13029,7 +13029,7 @@
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 3	bare	bare	ADV	adv	_	6	advmod	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	enkelt	enkelt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	enkelt	enkelt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	aktør	aktør	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 7	i	i	ADP	prep	_	10	case	_	_
 8	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
@@ -13039,7 +13039,7 @@
 12	produsenter	produsent	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	10	nmod	_	_
 13	som	som	SCONJ	sbu	_	14	mark	_	_
 14	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	acl:relcl	_	_
-15	kommersiell	kommersiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	kommersiell	kommersiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	interesse	interesse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	obj	_	_
 17	av	av	ADP	prep	_	19	case	_	_
 18	å	å	PART	inf-merke	_	19	mark	_	_
@@ -13134,7 +13134,7 @@
 18	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	19	nsubj	_	_
 19	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	conj	_	_
 20	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-21	kommersiell	kommersiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	amod	_	_
+21	kommersiell	kommersiell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	amod	_	_
 22	interesse	interesse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	obj	_	_
 23	i	i	ADP	prep	_	25	case	_	_
 24	å	å	PART	inf-merke	_	25	mark	_	_
@@ -13144,7 +13144,7 @@
 28	selve	selve	DET	det	Definite=Def|PronType=Prs	29	det	_	_
 29	nøkkelen	nøkkel	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	25	xcomp	_	_
 30	til	til	ADP	prep	_	32	case	_	_
-31	fullkommen	fullkommen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	32	amod	_	_
+31	fullkommen	fullkommen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	32	amod	_	_
 32	lykke	lykke	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	29	nmod	_	SpaceAfter=No
 33	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -13189,7 +13189,7 @@
 4	å	å	PART	inf-merke	_	5	mark	_	_
 5	tro	tro	VERB	verb	VerbForm=Inf	3	csubj	_	_
 6	at	at	SCONJ	sbu	_	10	mark	_	_
-7	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	_	_
+7	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj:pass	_	_
 8	ikke	ikke	PART	adv	Polarity=Neg	10	advmod	_	_
 9	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux:pass	_	_
 10	påvirket	påvirke	VERB	verb	VerbForm=Part	5	xcomp	_	_
@@ -13323,7 +13323,7 @@
 7	så	så	ADV	adv	_	10	advmod	_	_
 8	helt	hel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
 9	utrolig	utrolig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	10	advmod	_	_
-10	sur	sur	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	xcomp	_	SpaceAfter=No
+10	sur	sur	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	xcomp	_	SpaceAfter=No
 11	!	$!	PUNCT	clb	_	3	punct	_	_
 
 # newpar
@@ -13353,7 +13353,7 @@
 22	deg	du	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=2|PronType=Prs	21	iobj	_	_
 23	heller	heller	ADV	adv	_	21	advmod	_	_
 24	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	26	det	_	_
-25	feit	feit	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	amod	_	_
+25	feit	feit	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	amod	_	_
 26	bonus	bonus	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	21	obj	_	_
 27	for	for	ADP	prep	_	29	case	_	_
 28	å	å	PART	inf-merke	_	29	mark	_	_
@@ -13362,7 +13362,7 @@
 31	sånn	sånn	ADV	adv	_	32	advmod	_	_
 32	at	at	SCONJ	sbu	_	37	mark	_	_
 33	kona	kone	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	37	nsubj	_	_
-34	di	din	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	33	det	_	_
+34	di	din	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	33	nmod:poss	_	_
 35	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	37	aux	_	_
 36	være	være	AUX	verb	VerbForm=Inf	37	cop	_	_
 37	hjemme	hjemme	ADP	prep	_	29	advcl	_	_
@@ -13375,7 +13375,7 @@
 # text = Pappaperm er viktig av mange grunner, en av dem er at det gjør det enklere for fedre å trumfe gjennom hjemmetid overfor motvillige arbeidsgivere.
 1	Pappaperm	pappaperm	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	av	av	ADP	prep	_	6	case	_	_
 5	mange	mange	ADJ	adj	Degree=Pos|Number=Plur	6	amod	_	_
 6	grunner	grunn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	obl	_	SpaceAfter=No
@@ -13472,12 +13472,12 @@
 # text = "Mannen min sitter på en svært verdifull kompetanse i den prosessen som selskapet er i nå", sier kona i det anonyme paret Aftenposten har intervjuet.
 1	"	$"	PUNCT	<anf>	_	4	punct	_	SpaceAfter=No
 2	Mannen	mann	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
-3	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	2	det	_	_
+3	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 4	sitter	sitte	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	20	ccomp	_	_
 5	på	på	ADP	prep	_	9	case	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
 7	svært	svær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	8	advmod	_	_
-8	verdifull	verdifull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	verdifull	verdifull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	kompetanse	kompetanse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 10	i	i	ADP	prep	_	12	case	_	_
 11	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
@@ -13507,7 +13507,7 @@
 3	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 4	hadde	ha	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	advcl	_	_
 5	så	så	ADV	adv	_	6	advmod	_	_
-6	verdifull	verdifull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	verdifull	verdifull	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	kompetanse	kompetanse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	4	punct	_	_
 9	ble	bli	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
@@ -13553,7 +13553,7 @@
 4	umistelige	umistelig	ADJ	adj	Degree=Pos|Number=Plur	0	root	_	_
 5	i	i	ADP	prep	_	6	case	_	_
 6	jobben	jobb	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	obl	_	_
-7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 8	enn	enn	ADP	prep	_	9	case	_	_
 9	kvinner	kvinne	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	3	obl	_	SpaceAfter=No
 10	?	$?	PUNCT	clb	_	4	punct	_	_
@@ -13603,7 +13603,7 @@
 11	leder	leder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	xcomp	_	_
 12	i	i	ADP	prep	_	15	case	_	_
 13	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
-14	nyopprettet	nyopprette	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	15	amod	_	_
+14	nyopprettet	nyopprette	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	15	amod	_	_
 15	bedrift	bedrift	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nmod	_	_
 16	da	da	SCONJ	sbu	_	18	mark	_	_
 17	tiden	tid	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	18	nsubj	_	_
@@ -13638,7 +13638,7 @@
 18	borte	borte	ADP	prep	_	13	csubj	_	_
 19	i	i	ADP	prep	_	22	case	_	_
 20	så	så	ADV	adv	_	21	advmod	_	_
-21	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	amod	_	_
+21	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	amod	_	_
 22	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	18	obl	_	SpaceAfter=No
 23	,	$,	PUNCT	<komma>	_	13	punct	_	_
 24	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -13665,7 +13665,7 @@
 2	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	expl	_	_
 3	for	for	ADV	adv	_	4	advmod	_	_
 4	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
-5	forlangt	forlange	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	_
+5	forlangt	forlange	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	_
 6	at	at	SCONJ	sbu	_	8	mark	_	_
 7	menn	mann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	nsubj	_	_
 8	planlegger	planlegge	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	csubj	_	_
@@ -13696,13 +13696,13 @@
 3	leder	leder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	xcomp	_	_
 4	i	i	ADP	prep	_	7	case	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	nyopprettet	nyopprette	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	7	amod	_	_
+6	nyopprettet	nyopprette	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	7	amod	_	_
 7	bedrift	bedrift	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nmod	_	_
 8	når	når	SCONJ	sbu	_	10	mark	_	_
 9	man	man	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|PronType=Prs	10	nsubj	_	_
 10	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	advcl	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-12	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	baby	baby	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obj	_	_
 14	og	og	CCONJ	konj	_	15	cc	_	_
 15	vet	vite	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	conj	_	_
@@ -13718,7 +13718,7 @@
 25	bare	bare	ADV	adv	_	29	advmod	_	_
 26	helt	hel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	27	advmod	_	_
 27	ekstremt	ekstrem	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	28	advmod	_	_
-28	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	29	amod	_	_
+28	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	29	amod	_	_
 29	planlegging	planlegging	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	0	root	_	_
 30	og	og	CCONJ	konj	_	31	cc	_	_
 31	vitner	vitne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	29	conj	_	_
@@ -13732,13 +13732,13 @@
 39	omstendigheter	omstendighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	42	obl	_	_
 40	ville	ville	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	42	aux	_	_
 41	vært	være	AUX	verb	VerbForm=Part	42	cop	_	_
-42	interessert	interessere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	34	amod	_	_
+42	interessert	interessere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	34	amod	_	_
 43	i	i	ADP	prep	_	46	case	_	_
 44	å	å	PART	inf-merke	_	46	mark	_	_
 45	være	være	AUX	verb	VerbForm=Inf	46	cop	_	_
 46	hjemme	hjemme	ADP	prep	_	42	advcl	_	_
 47	med	med	ADP	prep	_	50	case	_	_
-48	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	50	det	_	_
+48	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	50	nmod:poss	_	_
 49	eget	egen	DET	det	Definite=Ind|Gender=Neut|Number=Sing|PronType=Prs	50	det	_	_
 50	avkom	avkom	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	46	obl	_	SpaceAfter=No
 51	.	$.	PUNCT	clb	_	29	punct	_	_
@@ -13765,7 +13765,7 @@
 3	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 5	så	så	ADV	adv	_	6	advmod	_	_
-6	uerstattelig	uerstattelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+6	uerstattelig	uerstattelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 7	av	av	ADP	prep	_	8	case	_	_
 8	meg	jeg	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=1|PronType=Prs	6	obl	_	SpaceAfter=No
 9	!	$!	PUNCT	clb	_	6	punct	_	_
@@ -13784,7 +13784,7 @@
 9	stedet	sted	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	11	obl	_	_
 10	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	_	_
 11	sette	sette	VERB	verb	VerbForm=Inf	3	advcl	_	_
-12	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	13	det	_	_
+12	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 13	karriere	karriere	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obj	_	_
 14	til	til	ADP	prep	_	15	case	_	_
 15	side	side	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	obl	_	_
@@ -13803,7 +13803,7 @@
 4	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	expl	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	løsning	løsning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	ccomp	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -13841,7 +13841,7 @@
 2	blir	bli	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
 4	seriøst	seriøs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
-5	grinete	grinete	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	xcomp	_	SpaceAfter=No
+5	grinete	grinete	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	xcomp	_	SpaceAfter=No
 6	!	$!	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 018828
@@ -13865,7 +13865,7 @@
 7	2000	2000	NUM	det	Number=Plur|NumType=Card	6	nmod	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	6	punct	_	_
 9	skriver	skrive	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-10	daværende	daværende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	daværende	daværende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	byrettsjustitiarius	byrettsjustitiarius	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nsubj	_	_
 12	Erik	Erik	PROPN	subst	Gender=Masc	11	flat:name	_	_
 13	Elstad	Elstad	PROPN	subst	_	11	flat:name	_	_
@@ -13901,14 +13901,14 @@
 8	mer	mye	ADJ	adj	Degree=Cmp	9	amod	_	_
 9	varsomhet	varsomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	obj	_	_
 10	i	i	ADP	prep	_	12	case	_	_
-11	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	12	det	_	_
+11	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 12	engasjement	engasjement	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	7	obl	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	2	punct	_	_
 14	noe	noe	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Ind,Prs	2	dislocated	_	_
 15	Justisdepartementet	Justisdepartementet	PROPN	subst	_	16	nsubj	_	_
 16	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	acl:relcl	_	_
 17	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	16	obj	_	_
-18	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	xcomp	_	_
+18	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	xcomp	_	_
 19	i	i	ADV	prep	_	18	advmod	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	14	punct	_	_
 
@@ -13916,7 +13916,7 @@
 # text = En veldig ubehagelig opplevelse.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
 2	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	3	advmod	_	_
-3	ubehagelig	ubehagelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	ubehagelig	ubehagelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	opplevelse	opplevelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 5	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -13972,7 +13972,7 @@
 
 # sent_id = 018836
 # text = Anmeldelsen blir henlagt, men er likevel et tema under rettssaken.
-1	Anmeldelsen	anmeldelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
+1	Anmeldelsen	anmeldelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj:pass	_	_
 2	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux:pass	_	_
 3	henlagt	henlegge	VERB	verb	VerbForm=Part	0	root	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	9	punct	_	_
@@ -14029,24 +14029,24 @@
 
 # sent_id = 018840
 # text = Bertelsen blir beskyldt for å ha vært forutinntatt, sjikanerende og kvinnefiendtlig.
-1	Bertelsen	Bertelsen	PROPN	subst	_	3	nsubj	_	_
+1	Bertelsen	Bertelsen	PROPN	subst	_	3	nsubj:pass	_	_
 2	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux:pass	_	_
 3	beskyldt	beskylde	VERB	verb	VerbForm=Part	0	root	_	_
 4	for	for	ADP	prep	_	8	case	_	_
 5	å	å	PART	inf-merke	_	8	mark	_	_
 6	ha	ha	AUX	verb	VerbForm=Inf	8	aux	_	_
 7	vært	være	AUX	verb	VerbForm=Part	8	cop	_	_
-8	forutinntatt	forutinntatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	advcl	_	SpaceAfter=No
+8	forutinntatt	forutinntatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	advcl	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	10	punct	_	_
 10	sjikanerende	sjikanere	ADJ	adj	VerbForm=Part	8	conj	_	_
 11	og	og	CCONJ	konj	_	12	cc	_	_
-12	kvinnefiendtlig	kvinnefiendtlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	conj	_	SpaceAfter=No
+12	kvinnefiendtlig	kvinnefiendtlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	conj	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 018841
 # text = - Arrogant.
 1	-	$-	PUNCT	<strek>	_	2	punct	_	_
-2	Arrogant	arrogant	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+2	Arrogant	arrogant	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 3	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 018842
@@ -14082,7 +14082,7 @@
 8	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 9	føle	føle	VERB	verb	VerbForm=Inf	5	csubj	_	_
 10	deg	du	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=2|PronType=Prs	9	obj	_	_
-11	trygg	trygg	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	xcomp	_	_
+11	trygg	trygg	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	xcomp	_	_
 12	når	når	SCONJ	sbu	_	14	mark	_	_
 13	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	14	nsubj	_	_
 14	kommer	komme	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	advcl	_	_
@@ -14095,7 +14095,7 @@
 # sent_id = 018845
 # text = Men jeg ble møtt av det helt motsatte, sier tanten til barna striden dreide seg om.
 1	Men	men	CCONJ	konj	_	4	cc	_	_
-2	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
+2	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj:pass	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	_	_
 4	møtt	møte	VERB	verb	VerbForm=Part	10	ccomp	_	_
 5	av	av	ADP	prep	_	8	case	_	_
@@ -14167,7 +14167,7 @@
 2	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 3	likevel	likevel	ADV	adv	_	8	advmod	_	_
 4	for	for	ADP	prep	_	6	case	_	_
-5	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+5	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 6	avgjørelse	avgjørelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obl	_	_
 7	ikke	ikke	PART	adv	Polarity=Neg	8	advmod	_	_
 8	funnet	finne	VERB	verb	VerbForm=Part	0	root	_	_
@@ -14216,7 +14216,7 @@
 3	ikke	ikke	PART	adv	Polarity=Neg	4	advmod	_	_
 4	fikk	få	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	1	acl:relcl	_	_
 5	like	like	ADV	adv	_	6	advmod	_	_
-6	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	oppmerksomhet	oppmerksomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	obj	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	1	punct	_	_
 9	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	cop	_	_
@@ -14309,7 +14309,7 @@
 7	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
 8	kritisert	kritisere	VERB	verb	VerbForm=Part	4	csubj	_	_
 9	for	for	ADP	prep	_	11	case	_	_
-10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	rolle	rolle	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -14325,7 +14325,7 @@
 8	som	som	SCONJ	sbu	_	9	mark	_	_
 9	skrev	skrive	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	acl:relcl	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-11	korrekt	korrekt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	korrekt	korrekt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	dom	dom	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obj	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -14357,7 +14357,7 @@
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
 9	vendetta	vendetta	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obl	_	_
 10	fra	fra	ADP	prep	_	12	case	_	_
-11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	det	_	_
+11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 12	ledere	leder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	6	obl	_	_
 13	i	i	ADP	prep	_	14	case	_	_
 14	Bergen	Bergen	PROPN	subst	_	12	nmod	_	_
@@ -14393,7 +14393,7 @@
 5	Ove	Ove	PROPN	subst	Gender=Masc	4	flat:name	_	_
 6	Kjell	Kjell	PROPN	subst	Gender=Masc	4	flat:name	_	_
 7	Hole	Hole	PROPN	subst	_	4	flat:name	_	_
-8	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	xcomp	_	_
+8	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	xcomp	_	_
 9	over	over	ADP	prep	_	12	case	_	_
 10	at	at	SCONJ	sbu	_	12	mark	_	_
 11	Bertelsen	Bertelsen	PROPN	subst	_	12	nsubj	_	_
@@ -14407,7 +14407,7 @@
 19	uten	uten	ADP	prep	_	20	case	_	_
 20	bruk	bruk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obl	_	_
 21	av	av	ADP	prep	_	22	case	_	_
-22	sakkyndig	sakkyndig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	amod	_	SpaceAfter=No
+22	sakkyndig	sakkyndig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	amod	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 018864
@@ -14483,7 +14483,7 @@
 1	Både	både	CCONJ	konj	_	2	cc	_	_
 2	Bertelsen	Bertelsen	PROPN	subst	_	6	nsubj	_	_
 3	og	og	CCONJ	konj	_	5	cc	_	_
-4	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+4	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	advokat	advokat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	conj	_	_
 6	mener	mene	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 7	Domstolsadministrasjonen	Domstolsadministrasjonen	PROPN	subst	_	11	nsubj	_	_
@@ -14636,7 +14636,7 @@
 2	hadde	ha	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	med	med	ADP	prep	_	4	case	_	_
 4	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	2	obl	_	_
-5	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+5	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 6	advokat	advokat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	8	punct	_	_
 8	Georg	Georg	PROPN	subst	Gender=Masc	6	appos	_	_
@@ -14671,7 +14671,7 @@
 14	om	om	SCONJ	sbu	_	17	mark	_	_
 15	Bertelsen	Bertelsen	PROPN	subst	_	17	nsubj	_	_
 16	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	cop	_	_
-17	skikket	skikket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	advcl	_	_
+17	skikket	skikket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	advcl	_	_
 18	til	til	ADP	prep	_	21	case	_	_
 19	å	å	PART	inf-merke	_	21	mark	_	_
 20	være	være	AUX	verb	VerbForm=Inf	21	cop	_	_
@@ -14817,7 +14817,7 @@
 5	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 6	da	da	ADV	adv	_	7	advmod	_	_
 7	sittet	sitte	VERB	verb	VerbForm=Part	0	root	_	_
-8	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	xcomp	_	_
+8	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	xcomp	_	_
 9	i	i	ADP	prep	_	10	case	_	_
 10	retten	rett	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
 11	og	og	CCONJ	konj	_	12	cc	_	_
@@ -14873,7 +14873,7 @@
 10	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	_	_
 11	ikke	ikke	PART	adv	Polarity=Neg	12	advmod	_	_
 12	sitte	sitte	VERB	verb	VerbForm=Inf	0	root	_	_
-13	uvirksom	uvirksom	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	xcomp	_	_
+13	uvirksom	uvirksom	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	xcomp	_	_
 14	og	og	CCONJ	konj	_	15	cc	_	_
 15	dingle	dingle	VERB	verb	VerbForm=Inf	12	conj	_	_
 16	med	med	ADP	prep	_	17	case	_	_
@@ -14906,7 +14906,7 @@
 4	møtet	møte	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	nmod	_	_
 5	skriver	skrive	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	DA	DA	PROPN	subst	_	5	nsubj	_	_
-7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+7	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	saksfremstilling	saksfremstilling	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obj	_	_
 9	til	til	ADP	prep	_	10	case	_	_
 10	Justisdepartementet	Justisdepartementet	PROPN	subst	_	5	obl	_	SpaceAfter=No
@@ -14928,7 +14928,7 @@
 # sent_id = 018893
 # text = Blir Bertelsen feiltolket?
 1	Blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux:pass	_	_
-2	Bertelsen	Bertelsen	PROPN	subst	_	3	nsubj	_	_
+2	Bertelsen	Bertelsen	PROPN	subst	_	3	nsubj:pass	_	_
 3	feiltolket	feiltolke	VERB	verb	VerbForm=Part	0	root	_	SpaceAfter=No
 4	?	$?	PUNCT	clb	_	3	punct	_	_
 
@@ -14944,12 +14944,12 @@
 8	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 9	at	at	SCONJ	sbu	_	13	mark	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-11	uformell	uformell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	uformell	uformell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	stil	stil	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nsubj	_	_
 13	fører	føre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	ccomp	_	_
 14	til	til	ADP	prep	_	19	case	_	_
 15	at	at	SCONJ	sbu	_	19	mark	_	_
-16	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	19	nsubj	_	_
+16	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	19	nsubj:pass	_	_
 17	gjerne	gjerne	ADV	adv	_	19	advmod	_	_
 18	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux:pass	_	_
 19	misforstått	misforstå	VERB	verb	VerbForm=Part	13	advcl	_	SpaceAfter=No
@@ -14959,15 +14959,15 @@
 # text = - I våre saker har han vært konstruktiv i forberedelsene sine og tatt kontakt på forhånd for å diskutere med oss.
 1	-	$-	PUNCT	<strek>	_	8	punct	_	_
 2	I	i	ADP	prep	_	4	case	_	_
-3	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	4	det	_	_
+3	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 4	saker	sak	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	8	obl	_	_
 5	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 6	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
 7	vært	være	AUX	verb	VerbForm=Part	8	cop	_	_
-8	konstruktiv	konstruktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+8	konstruktiv	konstruktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 9	i	i	ADP	prep	_	10	case	_	_
 10	forberedelsene	forberedelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	8	obl	_	_
-11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	det	_	_
+11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	nmod:poss	_	_
 12	og	og	CCONJ	konj	_	13	cc	_	_
 13	tatt	ta	VERB	verb	VerbForm=Part	8	conj	_	_
 14	kontakt	kontakt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	obj	_	_
@@ -14992,7 +14992,7 @@
 8	usikkerhet	usikkerhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	nmod	_	_
 9	og	og	CCONJ	konj	_	11	cc	_	_
 10	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	_	_
-11	mottakelig	mottakelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	conj	_	_
+11	mottakelig	mottakelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	conj	_	_
 12	for	for	ADP	prep	_	13	case	_	_
 13	råd	råd	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	11	obl	_	_
 14	under	under	ADP	prep	_	15	case	_	_
@@ -15018,7 +15018,7 @@
 # text = Han er daglig leder i firmaet 1-2-3 Advokaten, som til sammen har hatt fem-seks saker med Bertelsen som dommer.
 1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
-3	daglig	daglig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	daglig	daglig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	leder	leder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 5	i	i	ADP	prep	_	6	case	_	_
 6	firmaet	firma	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	4	nmod	_	_
@@ -15048,7 +15048,7 @@
 6	klagesakene	klagesak	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	3	obl	_	_
 7	som	som	SCONJ	sbu	_	9	mark	_	_
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	_	_
-9	knyttet	knytte	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	6	amod	_	_
+9	knyttet	knytte	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	6	amod	_	_
 10	til	til	ADP	prep	_	11	case	_	_
 11	Bertelsen	Bertelsen	PROPN	subst	_	9	obl	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -15060,7 +15060,7 @@
 3	opplever	oppleve	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	23	ccomp	_	_
 4	ham	han	PRON	pron	Animacy=Hum|Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	obj	_	_
 5	som	som	ADP	prep	_	6	case	_	_
-6	velmenende	velmenende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	xcomp	_	SpaceAfter=No
+6	velmenende	velmenende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	xcomp	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	17	punct	_	_
 8	selv	selv	ADV	adv	_	9	advmod	_	_
 9	om	om	SCONJ	sbu	_	17	mark	_	_
@@ -15071,7 +15071,7 @@
 14	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux	_	_
 15	være	være	AUX	verb	VerbForm=Inf	17	cop	_	_
 16	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	17	advmod	_	_
-17	klønete	klønete	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	advcl	_	_
+17	klønete	klønete	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	advcl	_	_
 18	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
 19	gang	gang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	obl	_	_
 20	i	i	ADP	prep	_	21	case	_	_
@@ -15091,7 +15091,7 @@
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 6	mer	mye	ADJ	adj	Degree=Cmp	3	ccomp	_	_
 7	enn	enn	ADP	prep	_	8	case	_	_
-8	klønete	klønete	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	advmod	_	SpaceAfter=No
+8	klønete	klønete	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	advmod	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 018902
@@ -15103,18 +15103,18 @@
 5	at	at	SCONJ	sbu	_	7	mark	_	_
 6	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
 7	trengte	trenge	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	ccomp	_	_
-8	juridisk	juridisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	juridisk	juridisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	bistand	bistand	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	SpaceAfter=No
 10	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 018903
 # text = Advokat Georg Kvande, en bekjent gjennom flere år, ble kontaktet.
-1	Advokat	advokat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nsubj	_	_
+1	Advokat	advokat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nsubj:pass	_	_
 2	Georg	Georg	PROPN	subst	Gender=Masc	1	flat:name	_	_
 3	Kvande	Kvande	PROPN	subst	_	1	flat:name	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	6	punct	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-6	bekjent	bekjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	1	appos	_	_
+6	bekjent	bekjent	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	1	appos	_	_
 7	gjennom	gjennom	ADP	prep	_	9	case	_	_
 8	flere	mange	ADJ	adj	Degree=Cmp	9	amod	_	_
 9	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	6	nmod	_	SpaceAfter=No
@@ -15155,14 +15155,14 @@
 13	at	at	SCONJ	sbu	_	16	mark	_	_
 14	Bertelsen	Bertelsen	PROPN	subst	_	16	nsubj	_	_
 15	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	16	cop	_	_
-16	gal	gal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	ccomp	_	SpaceAfter=No
+16	gal	gal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	ccomp	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	6	punct	_	_
 
 # sent_id = 018906
 # text = Jeg ble overrasket over at sorenskriveren sa dette, men jeg kunne jo heller ikke utelukke at det var tilfelle, ettersom jeg ikke hadde hatt jevnlig kontakt med Bertelsen, sier Kvande.
 1	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
 2	ble	bli	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-3	overrasket	overraske	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	2	xcomp	_	_
+3	overrasket	overraske	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	2	xcomp	_	_
 4	over	over	ADP	prep	_	7	case	_	_
 5	at	at	SCONJ	sbu	_	7	mark	_	_
 6	sorenskriveren	sorenskriver	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
@@ -15199,7 +15199,7 @@
 # text = Han fikk oversendt det skriftlige materialet og begynte å gå gjennom papirene.
 1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	fikk	få	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-3	oversendt	oversende	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	2	xcomp	_	_
+3	oversendt	oversende	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	2	xcomp	_	_
 4	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	6	det	_	_
 5	skriftlige	skriftlig	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	6	amod	_	_
 6	materialet	materiale	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	obj	_	_
@@ -15260,7 +15260,7 @@
 4	ingenting	ingenting	PRON	pron	Number=Sing	3	obj	_	_
 5	som	som	SCONJ	sbu	_	10	mark	_	_
 6	etter	etter	ADP	prep	_	8	case	_	_
-7	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+7	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	vurdering	vurdering	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obl	_	_
 9	kunne	kunne	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	aux	_	_
 10	gi	gi	VERB	verb	VerbForm=Inf	4	acl:relcl	_	_
@@ -15285,7 +15285,7 @@
 8	at	at	SCONJ	sbu	_	11	mark	_	_
 9	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
 10	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	11	cop	_	_
-11	gal	gal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	advcl	_	SpaceAfter=No
+11	gal	gal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	advcl	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	4	punct	_	_
 13	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 14	Kvande	Kvande	PROPN	subst	_	13	nsubj	_	SpaceAfter=No
@@ -15302,11 +15302,11 @@
 
 # sent_id = 018913
 # text = Anmeldelsen ble henlagt etter kort tid.
-1	Anmeldelsen	anmeldelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
+1	Anmeldelsen	anmeldelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	henlagt	henlegge	VERB	verb	VerbForm=Part	0	root	_	_
 4	etter	etter	ADP	prep	_	6	case	_	_
-5	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -15356,7 +15356,7 @@
 1	Konklusjonen	konklusjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	meget	meget	ADV	adv	_	4	advmod	_	_
-4	krass	krass	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+4	krass	krass	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 5	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 018918
@@ -15364,7 +15364,7 @@
 1	Bertelsen	Bertelsen	PROPN	subst	_	2	nsubj	_	_
 2	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	ccomp	_	_
 3	«	$"	PUNCT	<anf>	_	5	punct	_	SpaceAfter=No
-4	avvikende	avvikende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	avvikende	avvikende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	virkelighetsoppfatning	virkelighetsoppfatning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	obj	_	SpaceAfter=No
 6	»	$"	PUNCT	<anf>	_	5	punct	_	_
 7	og	og	CCONJ	konj	_	10	cc	_	_
@@ -15402,7 +15402,7 @@
 8	at	at	SCONJ	sbu	_	11	mark	_	_
 9	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	_	_
 10	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	_	_
-11	sinnssyk	sinnssyk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	SpaceAfter=No
+11	sinnssyk	sinnssyk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	5	punct	_	_
 13	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 14	Bertelsen	Bertelsen	PROPN	subst	_	13	nsubj	_	_
@@ -15413,7 +15413,7 @@
 # sent_id = 018921
 # text = Advokaten hans mener DA går langt over streken.
 1	Advokaten	advokat	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
-2	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	1	det	_	_
+2	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	1	nmod:poss	_	_
 3	mener	mene	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	DA	DA	PROPN	subst	_	5	nsubj	_	_
 5	går	gå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
@@ -15436,7 +15436,7 @@
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
 11	dommer	dommer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nsubj	_	_
 12	fremviser	fremvise	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	ccomp	_	_
-13	avvikende	avvikende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	avvikende	avvikende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	virkelighetsoppfatning	virkelighetsoppfatning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	12	obj	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -15506,7 +15506,7 @@
 # sent_id = 018926
 # text = Under sterk tvil sier de også nei til å suspendere ham.
 1	Under	under	ADP	prep	_	3	case	_	_
-2	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	tvil	tvil	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 4	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 5	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	_	_
@@ -15529,14 +15529,14 @@
 7	,	$,	PUNCT	<komma>	_	13	punct	_	_
 8	selv	selv	ADV	adv	_	9	advmod	_	_
 9	om	om	SCONJ	sbu	_	13	mark	_	_
-10	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	12	det	_	_
+10	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 11	egen	egen	DET	det	Definite=Ind|Gender=Masc|Number=Sing|PronType=Prs	12	det	_	_
 12	arbeidsgiver	arbeidsgiver	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nsubj	_	_
 13	mener	mene	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	advcl	_	_
 14	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
 15	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	ccomp	_	_
 16	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
-17	psykisk	psykisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	psykisk	psykisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	lidelse	lidelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obj	_	_
 19	som	som	SCONJ	sbu	_	22	mark	_	_
 20	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	22	cop	_	_
@@ -15569,7 +15569,7 @@
 19	å	å	PART	inf-merke	_	20	mark	_	_
 20	lide	lide	VERB	verb	VerbForm=Inf	17	advcl	_	_
 21	av	av	ADP	prep	_	23	case	_	_
-22	avvikende	avvikende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	amod	_	_
+22	avvikende	avvikende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	amod	_	_
 23	virkelighetsoppfatning	virkelighetsoppfatning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	20	obl	_	_
 24	og	og	CCONJ	konj	_	26	cc	_	_
 25	sviktende	svikte	ADJ	adj	VerbForm=Part	26	amod	_	_
@@ -15635,7 +15635,7 @@
 
 # sent_id = 018933
 # text = Alt jeg sier og gjør, blir tolket i verste mening, sier Bertelsen.
-1	Alt	alt	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
+1	Alt	alt	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	nsubj:pass	_	_
 2	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 3	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	1	acl:relcl	_	_
 4	og	og	CCONJ	konj	_	5	cc	_	_
@@ -15663,14 +15663,14 @@
 1	Ifølge	ifølge	ADP	prep	_	2	case	_	_
 2	Bertelsen	Bertelsen	PROPN	subst	_	8	obl	_	_
 3	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
-4	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	5	det	_	_
+4	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	overordnede	overordnet	ADJ	adj	Degree=Pos|Number=Plur	8	nsubj	_	_
 6	også	også	ADV	adv	_	8	advmod	_	_
 7	vært	være	AUX	verb	VerbForm=Part	8	cop	_	_
 8	lemfeldige	lemfeldig	ADJ	adj	Degree=Pos|Number=Plur	0	root	_	_
 9	med	med	ADP	prep	_	10	case	_	_
 10	helseopplysningene	helseopplysning	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	8	obl	_	_
-11	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	det	_	SpaceAfter=No
+11	hans	hans	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	nmod:poss	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	8	punct	_	_
 
 # sent_id = 018936
@@ -15685,7 +15685,7 @@
 8	Universitetssykehus	Universitetssykehus	PROPN	subst	_	7	flat:name	_	_
 9	med	med	ADP	prep	_	12	case	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-11	akutt	akutt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	akutt	akutt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	betennelse	betennelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 13	i	i	ADP	prep	_	14	case	_	_
 14	albuen	albue	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
@@ -15704,7 +15704,7 @@
 9	i	i	ADP	prep	_	10	case	_	_
 10	kontakt	kontakt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 11	med	med	ADP	prep	_	13	case	_	_
-12	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	13	det	_	_
+12	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 13	avdelingsleder	avdelingsleder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nmod	_	_
 14	i	i	ADP	prep	_	15	case	_	_
 15	Bergen	Bergen	PROPN	subst	_	13	nmod	_	_
@@ -15785,7 +15785,7 @@
 3	med	med	ADP	prep	_	6	case	_	_
 4	å	å	PART	inf-merke	_	6	mark	_	_
 5	være	være	AUX	verb	VerbForm=Inf	6	cop	_	_
-6	syk	syk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	advcl	_	_
+6	syk	syk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	advcl	_	_
 7	neste	neste	DET	det	Definite=Def|PronType=Dem	8	det	_	_
 8	uke	uke	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	obl	_	_
 9	også	også	ADV	adv	_	6	advmod	_	SpaceAfter=No
@@ -15828,7 +15828,7 @@
 5	under	under	ADP	prep	_	6	case	_	_
 6	samtalen	samtale	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	_
 7	sterkt	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	8	advmod	_	_
-8	irritert	irritere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	_
+8	irritert	irritere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	_
 9	på	på	ADP	prep	_	10	case	_	_
 10	meg	jeg	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=1|PronType=Prs	8	obl	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	8	punct	_	_
@@ -15839,7 +15839,7 @@
 2	heter	hete	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	expl	_	_
 4	at	at	SCONJ	sbu	_	9	mark	_	_
-5	vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+5	vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 6	offisielle	offisiell	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	7	amod	_	_
 7	forklaring	forklaring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	nsubj	_	_
 8	bør	burde	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
@@ -15851,7 +15851,7 @@
 1	Tor	Tor	PROPN	subst	Gender=Masc	4	nsubj	_	_
 2	Bertelsen	Bertelsen	PROPN	subst	_	1	flat:name	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	syk	syk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	syk	syk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	og	og	CCONJ	konj	_	8	cc	_	_
 6	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	expl	_	_
 7	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
@@ -15894,12 +15894,12 @@
 9	slik	slik	DET	det	Gender=Masc|Number=Sing|PronType=Dem	10	det	_	_
 10	e-post	e-post	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
 11	med	med	ADP	prep	_	14	case	_	_
-12	uriktig	uriktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
-13	medisinsk	medisinsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+12	uriktig	uriktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
+13	medisinsk	medisinsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	informasjon	informasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nmod	_	_
 15	om	om	ADP	prep	_	17	case	_	_
 16	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-17	ansatt	ansatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	SpaceAfter=No
+17	ansatt	ansatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 018949
@@ -16002,7 +16002,7 @@
 6	dette	dette	DET	det	Gender=Neut|Number=Sing|PronType=Dem	7	det	_	_
 7	tidspunktet	tidspunkt	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	9	obl	_	_
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	_	_
-9	inhabil	inhabil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	ccomp	_	_
+9	inhabil	inhabil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	ccomp	_	_
 10	i	i	ADP	prep	_	12	case	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
 12	sak	sak	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
@@ -16012,12 +16012,12 @@
 # text = Hole er uenig i at Bertelsen er inhabil, og skriver senere et notat om hendelsen.
 1	Hole	Hole	PROPN	subst	_	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	uenig	uenig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	uenig	uenig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	i	i	ADP	prep	_	8	case	_	_
 5	at	at	SCONJ	sbu	_	8	mark	_	_
 6	Bertelsen	Bertelsen	PROPN	subst	_	8	nsubj	_	_
 7	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
-8	inhabil	inhabil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	advcl	_	SpaceAfter=No
+8	inhabil	inhabil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	advcl	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	11	punct	_	_
 10	og	og	CCONJ	konj	_	11	cc	_	_
 11	skriver	skrive	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	_	_
@@ -16044,7 +16044,7 @@
 12	hånden	hånd	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 13	mot	mot	ADP	prep	_	14	case	_	_
 14	brystet	bryst	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	12	xcomp	_	_
-15	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	14	det	_	SpaceAfter=No
+15	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	14	nmod:poss	_	SpaceAfter=No
 16	»	$"	PUNCT	<anf>	_	7	punct	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -16077,7 +16077,7 @@
 # text = I en skriftlig redegjørelse avviser Bertelsen at han berørte Hole.
 1	I	i	ADP	prep	_	4	case	_	_
 2	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-3	skriftlig	skriftlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	skriftlig	skriftlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	redegjørelse	redegjørelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 5	avviser	avvise	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	Bertelsen	Bertelsen	PROPN	subst	_	5	nsubj	_	_
@@ -16117,7 +16117,7 @@
 11	ikke	ikke	PART	adv	Polarity=Neg	12	advmod	_	_
 12	tvilsomt	tvilsom	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	20	ccomp	_	_
 13	at	at	SCONJ	sbu	_	17	mark	_	_
-14	Hole	Hole	PROPN	subst	_	17	nsubj	_	_
+14	Hole	Hole	PROPN	subst	_	17	nsubj:pass	_	_
 15	faktisk	faktisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	17	advmod	_	_
 16	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux:pass	_	_
 17	dyttet	dytte	VERB	verb	VerbForm=Part	12	csubj	_	SpaceAfter=No
@@ -16167,7 +16167,7 @@
 14	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	13	obj	_	_
 15	på	på	ADP	prep	_	16	case	_	_
 16	skoene	sko	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	13	obl	_	_
-17	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	16	det	_	SpaceAfter=No
+17	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	16	nmod:poss	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 018965
@@ -16179,7 +16179,7 @@
 5	finger	finger	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 6	mot	mot	ADP	prep	_	7	case	_	_
 7	nesen	nese	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	obl	_	_
-8	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	SpaceAfter=No
+8	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 018966
@@ -16202,7 +16202,7 @@
 16	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	_	_
 17	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	19	cop	_	_
 18	mentalt	mental	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	19	advmod	_	_
-19	syk	syk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	ccomp	_	SpaceAfter=No
+19	syk	syk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	ccomp	_	SpaceAfter=No
 20	,	$,	PUNCT	<komma>	_	11	punct	_	_
 21	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 22	Bertelsen	Bertelsen	PROPN	subst	_	21	nsubj	_	SpaceAfter=No
@@ -16225,7 +16225,7 @@
 5	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
 6	Bertelsen	Bertelsen	PROPN	subst	_	8	nsubj	_	_
 7	vært	være	AUX	verb	VerbForm=Part	8	cop	_	_
-8	utsatt	utsatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+8	utsatt	utsatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 9	for	for	ADP	prep	_	10	case	_	_
 10	kritikk	kritikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	8	punct	_	_
@@ -16237,12 +16237,12 @@
 3	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
 5	så	så	ADV	adv	_	6	advmod	_	_
-6	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	dommer	dommer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	23	obl	_	_
 8	at	at	SCONJ	sbu	_	10	mark	_	_
 9	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	expl	_	_
 10	var	være	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	advcl	_	_
-11	berettiget	berettige	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	12	amod	_	_
+11	berettiget	berettige	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	12	amod	_	_
 12	grunn	grunn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	nsubj	_	_
 13	for	for	ADP	prep	_	15	case	_	_
 14	å	å	PART	inf-merke	_	15	mark	_	_
@@ -16279,7 +16279,7 @@
 14	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	17	nsubj	_	_
 15	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	17	cop	_	_
 16	så	så	ADV	adv	_	17	advmod	_	_
-17	håpløs	håpløs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	advcl	_	_
+17	håpløs	håpløs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	advcl	_	_
 18	som	som	SCONJ	sbu	_	20	mark	_	_
 19	arbeidsgiveren	arbeidsgiver	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	20	nsubj	_	_
 20	mener	mene	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	advcl	_	_
@@ -16354,7 +16354,7 @@
 1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	viser	vise	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	ccomp	_	_
 3	at	at	SCONJ	sbu	_	7	mark	_	_
-4	rykter	rykte	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	7	nsubj	_	_
+4	rykter	rykte	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	7	nsubj:pass	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
 6	blitt	bli	AUX	verb	VerbForm=Part	7	aux:pass	_	_
 7	fremstilt	fremstille	VERB	verb	VerbForm=Part	2	xcomp	_	_
@@ -16444,7 +16444,7 @@
 # sent_id = 018979
 # text = Arbeidsgiveren hans, Domstoladministrasjonen, slår fast at «Tor Holger Bertelsen under samlivskonflikten barrikaderte seg på et saksbehandlerkontor i tinghuset i Bergen, sammen med saksbehandler og sitt eget barn».
 1	Arbeidsgiveren	arbeidsgiver	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
-2	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	1	det	_	SpaceAfter=No
+2	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	1	nmod:poss	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	4	punct	_	_
 4	Domstoladministrasjonen	Domstoladministrasjonen	PROPN	subst	_	1	appos	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	4	punct	_	_
@@ -16471,7 +16471,7 @@
 26	med	med	ADP	prep	_	27	case	_	_
 27	saksbehandler	saksbehandler	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obl	_	_
 28	og	og	CCONJ	konj	_	31	cc	_	_
-29	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	31	det	_	_
+29	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	31	nmod:poss	_	_
 30	eget	egen	DET	det	Definite=Ind|Gender=Neut|Number=Sing|PronType=Prs	31	det	_	_
 31	barn	barn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	27	conj	_	SpaceAfter=No
 32	»	$"	PUNCT	<anf>	_	15	punct	_	SpaceAfter=No
@@ -16500,7 +16500,7 @@
 4	på	på	ADP	prep	_	5	case	_	_
 5	kontoret	kontor	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	obl	_	_
 6	med	med	ADP	prep	_	8	case	_	_
-7	åpen	åpen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	åpen	åpen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	dør	dør	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -16514,7 +16514,7 @@
 6	,	$,	PUNCT	<komma>	_	10	punct	_	_
 7	mens	mens	SCONJ	sbu	_	10	mark	_	_
 8	barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	10	nsubj	_	_
-9	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+9	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 10	tegnet	tegne	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	advcl	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -16555,7 +16555,7 @@
 3	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 4	understrekes	understreke	VERB	verb	VerbForm=Inf|Voice=Pass	31	ccomp	_	_
 5	at	at	SCONJ	sbu	_	16	mark	_	_
-6	gjenforeningen	gjenforening	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	16	nsubj	_	_
+6	gjenforeningen	gjenforening	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	16	nsubj:pass	_	_
 7	(	$(	PUNCT	<parentes-beg>	_	9	punct	_	SpaceAfter=No
 8	av	av	ADP	prep	_	9	case	_	_
 9	mor	mor	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	nmod	_	_
@@ -16574,14 +16574,14 @@
 22	at	at	SCONJ	sbu	_	25	mark	_	_
 23	tjenestemennene	tjenestemann	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	25	nsubj	_	_
 24	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	25	cop	_	_
-25	uniformert	uniformere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	18	dislocated	_	_
+25	uniformert	uniformere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	18	dislocated	_	_
 26	(	$(	PUNCT	<parentes-beg>	_	27	punct	_	SpaceAfter=No
 27	...	$...	PUNCT	clb	_	4	punct	_	SpaceAfter=No
 28	)	$)	PUNCT	<parentes-slutt>	_	27	punct	_	SpaceAfter=No
 29	»	$"	PUNCT	<anf>	_	4	punct	_	SpaceAfter=No
 30	,	$,	PUNCT	<komma>	_	31	punct	_	_
 31	skriver	skrive	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-32	daværende	daværende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	33	amod	_	_
+32	daværende	daværende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	33	amod	_	_
 33	politimester	politimester	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	31	nsubj	_	_
 34	Wegner	Wegner	PROPN	subst	_	33	flat:name	_	_
 35	i	i	ADP	prep	_	37	case	_	_
@@ -16647,7 +16647,7 @@
 4	hele	hel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	5	amod	_	_
 5	tiden	tid	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
 6	barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	obj	_	_
-7	fast	fast	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	advmod	_	_
+7	fast	fast	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	advmod	_	_
 8	som	som	ADP	prep	_	11	case	_	_
 9	om	om	SCONJ	sbu	_	11	mark	_	_
 10	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
@@ -16694,7 +16694,7 @@
 7	som	som	SCONJ	sbu	_	10	mark	_	_
 8	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	cop	_	_
 9	sentralt	sentral	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	10	advmod	_	_
-10	plassert	plassere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	6	amod	_	_
+10	plassert	plassere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	6	amod	_	_
 11	på	på	ADP	prep	_	12	case	_	_
 12	Tinghuset	Tinghuset	PROPN	subst	_	10	obl	_	_
 13	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
@@ -16729,7 +16729,7 @@
 8	fra	fra	ADP	prep	_	4	case	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	2	punct	_	_
 10	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-11	vedkommende	vedkommende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	nsubj	_	SpaceAfter=No
+11	vedkommende	vedkommende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	nsubj	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	10	punct	_	_
 
 # sent_id = 018994
@@ -16758,7 +16758,7 @@
 11	i	i	ADP	prep	_	12	case	_	_
 12	forbindelse	forbindelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obl	_	_
 13	med	med	ADP	prep	_	15	case	_	_
-14	vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	15	det	_	_
+14	vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 15	behandling	behandling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	12	nmod	_	_
 16	av	av	ADP	prep	_	17	case	_	_
 17	saken	sak	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	SpaceAfter=No
@@ -16818,7 +16818,7 @@
 3	stiller	stille	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	31	ccomp	_	_
 4	meg	jeg	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=1|PronType=Prs	3	obj	_	_
 5	svært	svær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
-6	kritisk	kritisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	xcomp	_	_
+6	kritisk	kritisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	xcomp	_	_
 7	til	til	ADP	prep	_	11	case	_	_
 8	at	at	SCONJ	sbu	_	11	mark	_	_
 9	DA	DA	PROPN	subst	_	11	nsubj	_	_
@@ -16860,10 +16860,10 @@
 2	Tor	Tor	PROPN	subst	Gender=Masc	1	flat:name	_	_
 3	Bertelsen	Bertelsen	PROPN	subst	_	1	flat:name	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
-5	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+5	glad	glad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 6	i	i	ADP	prep	_	7	case	_	_
 7	jobben	jobb	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
-8	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	SpaceAfter=No
+8	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 019000
@@ -16878,7 +16878,7 @@
 8	,	$,	PUNCT	<komma>	_	10	punct	_	_
 9	og	og	CCONJ	konj	_	10	cc	_	_
 10	håper	håpe	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	_	_
-11	saken	sak	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	_
+11	saken	sak	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	nsubj:pass	_	_
 12	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux:pass	_	_
 13	avgjort	avgjøre	VERB	verb	VerbForm=Part	10	xcomp	_	_
 14	snart	snar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	13	advmod	_	_
@@ -16890,7 +16890,7 @@
 20	tilbake	tilbake	ADP	prep	_	22	case	_	_
 21	til	til	ADP	prep	_	22	case	_	_
 22	jobben	jobb	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	19	obl	_	_
-23	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	22	det	_	_
+23	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	22	nmod:poss	_	_
 24	så	så	ADV	adv	_	25	advmod	_	_
 25	snart	snar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	19	advmod	_	_
 26	som	som	ADP	prep	_	27	case	_	_
@@ -16953,7 +16953,7 @@
 10	hatt	ha	VERB	verb	VerbForm=Part	7	acl:relcl	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
 12	så	så	ADV	adv	_	13	advmod	_	_
-13	vanskelig	vanskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	vanskelig	vanskelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	arbeidssituasjon	arbeidssituasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obj	_	_
 15	i	i	ADP	prep	_	17	case	_	_
 16	16	16	NUM	det	Number=Plur|NumType=Card	17	nummod	_	_
@@ -16985,7 +16985,7 @@
 4	når	når	SCONJ	sbu	_	14	mark	_	_
 5	Bertelsens	Bertelsen	PROPN	subst	Case=Gen	7	nmod	_	_
 6	videre	vid	ADJ	adj	Degree=Cmp	7	amod	_	_
-7	skjebne	skjebne	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nsubj	_	_
+7	skjebne	skjebne	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nsubj:pass	_	_
 8	som	som	ADP	prep	_	9	case	_	_
 9	dommer	dommer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nmod	_	_
 10	i	i	ADP	prep	_	11	case	_	_
@@ -17046,7 +17046,7 @@
 # text = Samtlige på Tor Holger Bertelsens arbeidsplass er inhabile.
 1	Samtlige	samtlige	PRON	pron	Number=Plur|Person=3|PronType=Prs,Tot	8	nsubj	_	_
 2	på	på	ADP	prep	_	6	case	_	_
-3	Tor	Tor	PROPN	subst	Gender=Masc	6	nmod	_	_
+3	Tor	Tor	PROPN	subst	Gender=Masc	6	nmod:poss	_	_
 4	Holger	Holger	PROPN	subst	_	3	flat:name	_	_
 5	Bertelsens	Bertelsen	PROPN	subst	Case=Gen	3	flat:name	_	_
 6	arbeidsplass	arbeidsplass	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	nmod	_	_
@@ -17085,7 +17085,7 @@
 
 # sent_id = 019015
 # text = Babyer ble hentet og levert på hemmelige turer.
-1	Babyer	baby	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	nsubj	_	_
+1	Babyer	baby	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	hentet	hente	VERB	verb	VerbForm=Part	0	root	_	_
 4	og	og	CCONJ	konj	_	5	cc	_	_
@@ -17118,7 +17118,7 @@
 
 # sent_id = 019018
 # text = Nyfødte ble sendt med drosje fra jordmor Johanne Marie Nygaard i Nordheimsund til blant annet Christian Michelsens barnehjem på Os.
-1	Nyfødte	nyfødt	ADJ	adj	Degree=Pos|Number=Plur	3	nsubj	_	_
+1	Nyfødte	nyfødt	ADJ	adj	Degree=Pos|Number=Plur	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	sendt	sende	VERB	verb	VerbForm=Part	0	root	_	_
 4	med	med	ADP	prep	_	5	case	_	_
@@ -17149,12 +17149,12 @@
 4	Hjørdis	Hjørdis	PROPN	subst	Gender=Fem	3	obj	_	_
 5	som	som	ADP	prep	_	13	case	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-7	moden	moden	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	SpaceAfter=No
+7	moden	moden	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	10	punct	_	_
 9	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	10	advmod	_	_
-10	ferm	ferm	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	conj	_	_
+10	ferm	ferm	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	conj	_	_
 11	og	og	CCONJ	konj	_	12	cc	_	_
-12	moderlig	moderlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	conj	_	_
+12	moderlig	moderlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	conj	_	_
 13	type	type	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	xcomp	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -17162,19 +17162,19 @@
 # text = Hun var rolig, saklig og ganske frittalende.
 1	Hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	cop	_	_
-3	rolig	rolig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+3	rolig	rolig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	5	punct	_	_
-5	saklig	saklig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	conj	_	_
+5	saklig	saklig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	conj	_	_
 6	og	og	CCONJ	konj	_	8	cc	_	_
 7	ganske	ganske	ADV	adv	_	8	advmod	_	_
-8	frittalende	frittalende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	conj	_	SpaceAfter=No
+8	frittalende	frittalende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	conj	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 019021
 # text = Hun virket beroligende i det hun behandlet krisen som en dagligdags affære.
 1	Hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	virket	virke	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-3	beroligende	beroligende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	xcomp	_	_
+3	beroligende	beroligende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	xcomp	_	_
 4	i	i	ADP	prep	_	5	case	_	_
 5	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	obl	_	_
 6	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
@@ -17182,7 +17182,7 @@
 8	krisen	krise	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	obj	_	_
 9	som	som	ADP	prep	_	12	case	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-11	dagligdags	dagligdags	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	dagligdags	dagligdags	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	affære	affære	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	xcomp	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -17214,13 +17214,13 @@
 4	,	$,	PUNCT	<komma>	_	7	punct	_	_
 5	Grete	Grete	PROPN	subst	Gender=Fem	7	nsubj	_	_
 6	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	_	_
-7	gravid	gravid	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	conj	_	_
+7	gravid	gravid	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	conj	_	_
 8	og	og	CCONJ	konj	_	10	cc	_	_
 9	ville	ville	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	aux	_	_
 10	adoptere	adoptere	VERB	verb	VerbForm=Inf	7	conj	_	_
 11	vekk	vekk	ADV	prep	_	10	advmod	_	_
 12	barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	10	obj	_	_
-13	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	12	det	_	SpaceAfter=No
+13	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	12	nmod:poss	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 019025
@@ -17258,7 +17258,7 @@
 13	Johnsen	Johnsen	PROPN	subst	_	11	flat:name	_	_
 14	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	16	cop	_	_
 15	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
-16	sentral	sentral	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+16	sentral	sentral	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 17	i	i	ADP	prep	_	19	case	_	_
 18	to	to	NUM	det	Number=Plur|NumType=Card	19	nummod	_	_
 19	apparat	apparat	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	16	obl	_	_
@@ -17292,7 +17292,7 @@
 # sent_id = 019028
 # text = Gjennom sine mange tillitsverv og stillinger engasjerte hun seg i adopsjon både praktisk og organisatorisk fra 1935 til slutten av 60-tallet.
 1	Gjennom	gjennom	ADP	prep	_	4	case	_	_
-2	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	4	det	_	_
+2	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 3	mange	mange	ADJ	adj	Degree=Pos|Number=Plur	4	amod	_	_
 4	tillitsverv	tillitsverv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	7	obl	_	_
 5	og	og	CCONJ	konj	_	6	cc	_	_
@@ -17339,7 +17339,7 @@
 13	og	og	CCONJ	konj	_	17	cc	_	_
 14	frem	frem	ADP	prep	_	17	case	_	_
 15	til	til	ADP	prep	_	17	case	_	_
-16	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	det	_	_
+16	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
 17	død	død	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	conj	_	_
 18	i	i	ADP	prep	_	19	case	_	_
 19	1963	1963	NUM	det	Number=Plur|NumType=Card	17	nmod	_	SpaceAfter=No
@@ -17374,7 +17374,7 @@
 2	Johnsen	Johnsen	PROPN	subst	_	1	flat:name	_	_
 3	hadde	ha	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	gjennom	gjennom	ADP	prep	_	6	case	_	_
-5	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+5	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 6	stilling	stilling	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 7	hos	hos	ADP	prep	_	8	case	_	_
 8	Fylkesmannen	Fylkesmannen	PROPN	subst	_	6	nmod	_	_
@@ -17421,7 +17421,7 @@
 16	,	$,	PUNCT	<komma>	_	3	punct	_	_
 17	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 18	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	expl	_	_
-19	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	amod	_	_
+19	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	amod	_	_
 20	grunn	grunn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	nsubj	_	_
 21	til	til	ADP	prep	_	23	case	_	_
 22	å	å	PART	inf-merke	_	23	mark	_	_
@@ -17443,7 +17443,7 @@
 10	,	$,	PUNCT	<komma>	_	19	punct	_	_
 11	men	men	CCONJ	konj	_	19	cc	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-13	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	22	nmod	_	_
 15	av	av	ADP	prep	_	16	case	_	_
 16	adopsjonsformidlingen	adopsjonsformidling	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
@@ -17523,7 +17523,7 @@
 10	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
 12	svært	svær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	13	advmod	_	_
-13	erfaren	erfaren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	erfaren	erfaren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	adopsjonsformidler	adopsjonsformidler	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	14	punct	_	_
 
@@ -17562,7 +17562,7 @@
 9	fra	fra	ADP	prep	_	10	case	_	_
 10	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	8	obl	_	_
 11	barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	8	obj	_	_
-12	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	SpaceAfter=No
+12	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 019041
@@ -17654,7 +17654,7 @@
 10	grunn	grunn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obl	_	_
 11	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	_	_
 12	gi	gi	VERB	verb	VerbForm=Inf	3	acl:relcl	_	_
-13	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	14	det	_	_
+13	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	14	nmod:poss	_	_
 14	barn	barn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	12	obj	_	_
 15	bort	bort	ADP	prep	_	17	case	_	_
 16	til	til	ADP	prep	_	17	case	_	_
@@ -17691,7 +17691,7 @@
 4	født	føde	VERB	verb	VerbForm=Part	9	advcl	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	4	punct	_	_
 6	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	aux:pass	_	_
-7	barna	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	9	nsubj	_	_
+7	barna	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	9	nsubj:pass	_	_
 8	umiddelbart	umiddelbar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
 9	tatt	ta	VERB	verb	VerbForm=Part	0	root	_	_
 10	fra	fra	ADP	prep	_	11	case	_	_
@@ -17700,7 +17700,7 @@
 
 # sent_id = 019047
 # text = Søster Hjørdis ble intervjuet i Bergens Arbeiderblad i 1964:
-1	Søster	søster	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	nsubj	_	_
+1	Søster	søster	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	nsubj:pass	_	_
 2	Hjørdis	Hjørdis	PROPN	subst	Gender=Fem	1	flat:name	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	_	_
 4	intervjuet	intervjue	VERB	verb	VerbForm=Part	0	root	_	_
@@ -17714,7 +17714,7 @@
 # sent_id = 019048
 # text = - Barnet blir lagt inn til observasjon i 6 uker, hvorav moren har en betenkningstid på 4 uker.
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
-2	Barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	4	nsubj	_	_
+2	Barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	4	nsubj:pass	_	_
 3	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux:pass	_	_
 4	lagt	legge	VERB	verb	VerbForm=Part	0	root	_	_
 5	inn	inn	ADV	prep	_	4	advmod	_	_
@@ -17742,7 +17742,7 @@
 4	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	0	root	_	_
 5	som	som	SCONJ	sbu	_	6	mark	_	_
 6	vet	vite	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	_	_
-7	hvis	hvis	PRON	pron	Animacy=Hum|Poss=Yes|PronType=Int	8	det	_	_
+7	hvis	hvis	PRON	pron	Animacy=Hum|Poss=Yes|PronType=Int	8	nmod:poss	_	_
 8	barn	barn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	6	ccomp	_	_
 9	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
 10	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	SpaceAfter=No
@@ -17772,7 +17772,7 @@
 3	i	i	ADP	prep	_	4	case	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	2	obl	_	_
 5	av	av	ADP	prep	_	8	case	_	_
-6	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	det	_	_
+6	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 7	mange	mange	ADJ	adj	Degree=Pos|Number=Plur	8	amod	_	_
 8	rapporter	rapport	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	4	nmod	_	_
 9	fra	fra	ADP	prep	_	10	case	_	_
@@ -17783,13 +17783,13 @@
 # text = «Da barnet skulle adopteres bort, ble jeg bedt om å ta meg av saken og jeg hentet barnet i dag og la det inn på Spebarnshjemmet under dekknavnet « Reidun » .
 1	«	$"	PUNCT	<anf>	_	10	punct	_	SpaceAfter=No
 2	Da	da	SCONJ	sbu	_	5	mark	_	_
-3	barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	5	nsubj	_	_
+3	barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	5	nsubj:pass	_	_
 4	skulle	skulle	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux	_	_
 5	adopteres	adoptere	VERB	verb	VerbForm=Inf|Voice=Pass	10	advcl	_	_
 6	bort	bort	ADV	prep	_	5	advmod	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	5	punct	_	_
 8	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	aux:pass	_	_
-9	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	_	_
+9	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj:pass	_	_
 10	bedt	be	VERB	verb	VerbForm=Part	0	root	_	_
 11	om	om	ADP	prep	_	13	case	_	_
 12	å	å	PART	inf-merke	_	13	mark	_	_
@@ -17832,7 +17832,7 @@
 6	adoptere	adoptere	VERB	verb	VerbForm=Inf	3	acl:relcl	_	_
 7	vekk	vekk	ADV	prep	_	6	advmod	_	_
 8	barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	obj	_	_
-9	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	det	_	_
+9	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 10	fikk	få	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 11	dekkadresse	dekkadresse	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	obj	_	_
 12	hos	hos	ADP	prep	_	13	case	_	_
@@ -17904,7 +17904,7 @@
 25	ekteskapet	ekteskap	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	23	obl	_	_
 26	registrert	registrere	VERB	verb	VerbForm=Part	14	advcl	_	_
 27	i	i	ADP	prep	_	29	case	_	_
-28	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	29	det	_	_
+28	hans	hans	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	29	nmod:poss	_	_
 29	prestegjeld	prestegjeld	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	26	obl	_	SpaceAfter=No
 30	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -17983,7 +17983,7 @@
 14	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	17	nsubj	_	_
 15	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	17	cop	_	_
 16	meget	meget	ADV	adv	_	17	advmod	_	_
-17	fornuftig	fornuftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	conj	_	SpaceAfter=No
+17	fornuftig	fornuftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	conj	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 019061
@@ -17998,7 +17998,7 @@
 8	for	for	ADP	prep	_	9	case	_	_
 9	barnet	barn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	nmod	_	_
 10	at	at	SCONJ	sbu	_	13	mark	_	_
-11	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
+11	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj:pass	_	_
 12	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	aux:pass	_	_
 13	adoptert	adoptere	VERB	verb	VerbForm=Part	7	csubj	_	_
 14	bort	bort	ADV	prep	_	13	advmod	_	_
@@ -18007,7 +18007,7 @@
 17	ikke	ikke	PART	adv	Polarity=Neg	18	advmod	_	_
 18	følte	føle	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	advcl	_	_
 19	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	18	obj	_	_
-20	moden	moden	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	xcomp	_	_
+20	moden	moden	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	xcomp	_	_
 21	nok	nok	ADV	adv	_	20	advmod	_	_
 22	til	til	ADP	prep	_	24	case	_	_
 23	å	å	PART	inf-merke	_	24	mark	_	_
@@ -18028,7 +18028,7 @@
 7	at	at	SCONJ	sbu	_	10	mark	_	_
 8	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	10	nsubj	_	_
 9	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	cop	_	_
-10	gravid	gravid	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	ccomp	_	SpaceAfter=No
+10	gravid	gravid	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	ccomp	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	16	punct	_	_
 12	da	da	SCONJ	sbu	_	16	mark	_	_
 13	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
@@ -18195,7 +18195,7 @@
 18	å	å	PART	inf-merke	_	19	mark	_	_
 19	gi	gi	VERB	verb	VerbForm=Inf	17	xcomp	_	_
 20	bort	bort	ADV	prep	_	19	advmod	_	_
-21	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	23	det	_	_
+21	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	23	nmod:poss	_	_
 22	nyfødte	nyfødt	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	23	amod	_	_
 23	barn	barn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	19	obj	_	SpaceAfter=No
 24	,	$,	PUNCT	<komma>	_	11	punct	_	_
@@ -18218,11 +18218,11 @@
 41	til	til	ADP	prep	_	43	case	_	_
 42	å	å	PART	inf-merke	_	43	mark	_	_
 43	få	få	VERB	verb	VerbForm=Inf	39	advcl	_	_
-44	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	45	det	_	_
+44	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	45	nmod:poss	_	_
 45	barn	barn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	43	obj	_	_
 46	tilbake	tilbake	ADV	prep	_	43	advmod	_	_
 47	til	til	ADP	prep	_	49	case	_	_
-48	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	49	amod	_	_
+48	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	49	amod	_	_
 49	fortvilelse	fortvilelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	39	obl	_	_
 50	for	for	ADP	prep	_	51	case	_	_
 51	dem	de	PRON	pron	Case=Acc|Number=Plur|Person=3|PronType=Prs	49	nmod	_	_
@@ -18339,7 +18339,7 @@
 13	mødre	mor	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	15	nsubj	_	_
 14	skulle	skulle	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	15	aux	_	_
 15	beholde	beholde	VERB	verb	VerbForm=Inf	8	advcl	_	_
-16	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	17	det	_	_
+16	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
 17	barn	barn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	15	obj	_	_
 18	selv	selv	ADV	adv	_	15	advmod	_	SpaceAfter=No
 19	,	$,	PUNCT	<komma>	_	8	punct	_	_
@@ -18370,7 +18370,7 @@
 3	Andresen	Andresen	PROPN	subst	_	1	flat:name	_	_
 4	konkluderer	konkludere	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 5	i	i	ADP	prep	_	7	case	_	_
-6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+6	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 7	bok	bok	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 8	«	$"	PUNCT	<anf>	_	9	punct	_	SpaceAfter=No
 9	Hender	Hender	PROPN	subst	_	7	appos	_	_
@@ -18383,7 +18383,7 @@
 16	krigen	krig	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
 17	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	19	cop	_	_
 18	svært	svær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	19	advmod	_	_
-19	positiv	positiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	advcl	_	_
+19	positiv	positiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	advcl	_	_
 20	til	til	ADP	prep	_	21	case	_	_
 21	adopsjon	adopsjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	obl	_	SpaceAfter=No
 22	,	$,	PUNCT	<komma>	_	31	punct	_	_
@@ -18492,7 +18492,7 @@
 # text = Det andre apparatet i Bergen ble etablert rundt Nasjonalhjelpens kontor i Bergen og Chr. Michelsens barnehjem i Os.
 1	Det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
 2	andre	andre	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing|NumType=Ord	3	amod	_	_
-3	apparatet	apparat	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	nsubj	_	_
+3	apparatet	apparat	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	nsubj:pass	_	_
 4	i	i	ADP	prep	_	5	case	_	_
 5	Bergen	Bergen	PROPN	subst	_	3	nmod	_	_
 6	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
@@ -18517,7 +18517,7 @@
 2	Inger	Inger	PROPN	subst	Gender=Fem	1	flat:name	_	_
 3	Haldorsen	Haldorsen	PROPN	subst	_	1	flat:name	_	_
 4	og	og	CCONJ	konj	_	6	cc	_	_
-5	sykepleierutdannede	sykepleierutdanne	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	6	amod	_	_
+5	sykepleierutdannede	sykepleierutdanne	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	6	amod	_	_
 6	Solveig	Solveig	PROPN	subst	Gender=Fem	1	conj	_	_
 7	Garnæs	Garnæs	PROPN	subst	_	6	flat:name	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	11	punct	_	_
@@ -18554,7 +18554,7 @@
 
 # sent_id = 019086
 # text = Garnæs ble valgt inn i styret for Chr. Michelsens barnehjem i Os i 1945.
-1	Garnæs	Garnæs	PROPN	subst	_	3	nsubj	_	_
+1	Garnæs	Garnæs	PROPN	subst	_	3	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	valgt	velge	VERB	verb	VerbForm=Part	0	root	_	_
 4	inn	inn	ADP	prep	_	6	case	_	_
@@ -18573,10 +18573,10 @@
 
 # sent_id = 019087
 # text = Inger Haldorsen ble kort tid etter ansatt som barnehjemmets lege på Garnæs sin anbefaling.
-1	Inger	Inger	PROPN	subst	Gender=Fem	7	nsubj	_	_
+1	Inger	Inger	PROPN	subst	Gender=Fem	7	nsubj:pass	_	_
 2	Haldorsen	Haldorsen	PROPN	subst	_	1	flat:name	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
-4	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	obl	_	_
 6	etter	etter	ADV	prep	_	7	advmod	_	_
 7	ansatt	ansette	VERB	verb	VerbForm=Part	0	root	_	_
@@ -18585,7 +18585,7 @@
 10	lege	lege	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	xcomp	_	_
 11	på	på	ADP	prep	_	14	case	_	_
 12	Garnæs	Garnæs	PROPN	subst	_	13	obl	_	_
-13	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	14	det	_	_
+13	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	14	nmod:poss	_	_
 14	anbefaling	anbefaling	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	7	punct	_	_
 
@@ -18648,7 +18648,7 @@
 3	,	$,	PUNCT	<komma>	_	5	punct	_	_
 4	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
 5	året	år	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	appos	_	_
-6	Garnæs	Garnæs	PROPN	subst	_	8	nsubj	_	_
+6	Garnæs	Garnæs	PROPN	subst	_	8	nsubj:pass	_	_
 7	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	aux:pass	_	_
 8	ansatt	ansette	VERB	verb	VerbForm=Part	5	acl:relcl	_	_
 9	som	som	ADP	prep	_	10	case	_	_
@@ -18675,7 +18675,7 @@
 10	10	10	NUM	det	Number=Plur|NumType=Card	13	nummod	_	_
 11	og	og	CCONJ	konj	_	12	cc	_	_
 12	20	20	NUM	det	Number=Plur|NumType=Card	10	conj	_	_
-13	spedbarn	spedbarn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	19	nsubj	_	_
+13	spedbarn	spedbarn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	19	nsubj:pass	_	_
 14	fra	fra	ADP	prep	_	15	case	_	_
 15	Chr	Chr	PROPN	subst	_	13	nmod	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	15	punct	_	_
@@ -18700,7 +18700,7 @@
 8	på	på	ADP	prep	_	9	case	_	_
 9	barnehjemmet	barnehjem	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	obl	_	_
 10	før	før	SCONJ	sbu	_	13	mark	_	_
-11	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj	_	_
+11	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj:pass	_	_
 12	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	aux:pass	_	_
 13	levert	levere	VERB	verb	VerbForm=Part	2	advcl	_	_
 14	adoptivforeldrene	adoptivforelder	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	13	obj	_	SpaceAfter=No
@@ -18823,7 +18823,7 @@
 3	avtale	avtale	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 4	med	med	ADP	prep	_	7	case	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	fast	fast	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	fast	fast	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	drosjeeier	drosjeeier	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nmod	_	_
 8	i	i	ADP	prep	_	9	case	_	_
 9	Os	Os	PROPN	subst	_	7	nmod	_	_
@@ -18837,7 +18837,7 @@
 # sent_id = 019100
 # text = Disse spedbarna ble plassert på barnehjem i Bergen.
 1	Disse	disse	DET	det	Number=Plur|PronType=Dem	2	det	_	_
-2	spedbarna	spedbarn	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	4	nsubj	_	_
+2	spedbarna	spedbarn	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	4	nsubj:pass	_	_
 3	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	_	_
 4	plassert	plassere	VERB	verb	VerbForm=Part	0	root	_	_
 5	på	på	ADP	prep	_	6	case	_	_
@@ -18851,7 +18851,7 @@
 1	Haldorsen	Haldorsen	PROPN	subst	_	2	nsubj	_	_
 2	drev	drive	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	privat	privat	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	privat	privat	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	gynekologpraksis	gynekologpraksis	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 6	i	i	ADP	prep	_	7	case	_	_
 7	Richard	Richard	PROPN	subst	Gender=Masc	5	nmod	_	_
@@ -18864,7 +18864,7 @@
 1	Hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	_	_
 3	også	også	ADV	adv	_	5	advmod	_	_
-4	faglig	faglig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	faglig	faglig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	leder	leder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 6	ved	ved	ADP	prep	_	7	case	_	_
 7	Mødrehygienekontoret	Mødrehygienekontoret	PROPN	subst	_	5	nmod	_	SpaceAfter=No
@@ -18912,7 +18912,7 @@
 3	også	også	ADV	adv	_	5	advmod	_	_
 4	ha	ha	AUX	verb	VerbForm=Inf	5	aux	_	_
 5	tatt	ta	VERB	verb	VerbForm=Part	0	root	_	_
-6	direkte	direkte	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	direkte	direkte	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	kontakt	kontakt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obj	_	_
 8	med	med	ADP	prep	_	10	case	_	_
 9	Nasjonalhjelpens	Nasjonalhjelpen	PROPN	subst	Case=Gen	10	nmod	_	_
@@ -19032,7 +19032,7 @@
 2	kunne	kunne	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux	_	_
 3	opptre	opptre	VERB	verb	VerbForm=Inf	0	root	_	_
 4	med	med	ADP	prep	_	6	case	_	_
-5	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	diskresjon	diskresjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -19109,7 +19109,7 @@
 3	byen	by	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	_
 4	kjenner	kjenne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 5	ikke	ikke	PART	adv	Polarity=Neg	4	advmod	_	_
-6	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	7	det	_	_
+6	mine	min	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 7	omgivelser	omgivelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	4	nsubj	_	_
 8	til	til	ADP	prep	_	11	case	_	_
 9	hvor	hvor	ADV	adv	_	11	advmod	_	_
@@ -19147,7 +19147,7 @@
 16	henne	hun	PRON	pron	Animacy=Hum|Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	15	obj	_	_
 17	vel	vel	ADV	adv	_	20	advmod	_	_
 18	i	i	ADP	prep	_	20	case	_	_
-19	Deres	Deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	20	det	_	_
+19	Deres	Deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	20	nmod:poss	_	_
 20	hjem	hjem	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	15	obl	_	SpaceAfter=No
 21	.	$.	PUNCT	clb	_	5	punct	_	SpaceAfter=No
 22	»	$"	PUNCT	<anf>	_	5	punct	_	_
@@ -19175,7 +19175,7 @@
 9	i	i	ADP	prep	_	7	reparandum	_	_
 10	innblikk	innblikk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	7	obj	_	_
 11	i	i	ADP	prep	_	13	case	_	_
-12	hennes	hennes	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	det	_	_
+12	hennes	hennes	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 13	hemmeligheter	hemmelighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	10	nmod	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	7	punct	_	_
 
@@ -19190,7 +19190,7 @@
 7	av	av	ADP	prep	_	11	case	_	_
 8	Solveig	Solveig	PROPN	subst	Gender=Fem	10	obl	_	_
 9	Garnæs	Garnæs	PROPN	subst	_	8	flat:name	_	_
-10	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	det	_	_
+10	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	venninner	venninne	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	6	nmod	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	4	punct	_	_
 13	husker	huske	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -19207,7 +19207,7 @@
 5	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
 6	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	cop	_	_
 7	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	8	advmod	_	_
-8	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	ccomp	_	_
+8	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	ccomp	_	_
 9	av	av	ADP	prep	_	11	case	_	_
 10	å	å	PART	inf-merke	_	11	mark	_	_
 11	finne	finne	VERB	verb	VerbForm=Inf	8	advcl	_	_
@@ -19222,7 +19222,7 @@
 1	Søster	søster	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	nsubj	_	_
 2	Solveig	Solveig	PROPN	subst	Gender=Fem	1	flat:name	_	_
 3	fortalte	fortelle	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-4	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+4	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	mor	mor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 6	om	om	ADP	prep	_	8	case	_	_
 7	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
@@ -19231,7 +19231,7 @@
 10	kom	komme	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	acl:relcl	_	_
 11	fra	fra	ADP	prep	_	14	case	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-13	musikalsk	musikalsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	musikalsk	musikalsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	familie	familie	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obl	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -19303,7 +19303,7 @@
 # sent_id = 019127
 # text = En håndskrevet påskrift i et brev til Kari Trosvik sine adoptivforeldre fra 1955 forteller om dette:
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	håndskrevet	håndskrevet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	håndskrevet	håndskrevet	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	påskrift	påskrift	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nsubj	_	_
 4	i	i	ADP	prep	_	6	case	_	_
 5	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	6	det	_	_
@@ -19311,7 +19311,7 @@
 7	til	til	ADP	prep	_	11	case	_	_
 8	Kari	Kari	PROPN	subst	Gender=Fem	10	obl	_	_
 9	Trosvik	Trosvik	PROPN	subst	_	8	flat:name	_	_
-10	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	det	_	_
+10	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	adoptivforeldre	adoptivforelder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	6	nmod	_	_
 12	fra	fra	ADP	prep	_	13	case	_	_
 13	1955	1955	NUM	det	Number=Plur|NumType=Card	6	nmod	_	_
@@ -19333,12 +19333,12 @@
 1	Tusen	tusen	NUM	det	Number=Plur|NumType=Card	2	nummod	_	_
 2	takk	takk	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	0	root	_	_
 3	for	for	ADP	prep	_	4	case	_	_
-4	sist	sist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	advmod	_	SpaceAfter=No
+4	sist	sist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	advmod	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	10	punct	_	_
 6	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	expl	_	_
 7	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	cop	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-9	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	glede	glede	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	conj	_	_
 11	for	for	ADP	prep	_	12	case	_	_
 12	mig	jeg	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=1|PronType=Prs	10	obl	_	_
@@ -19415,7 +19415,7 @@
 8	barnehjem	barnehjem	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	5	flat:name	_	_
 9	foregikk	foregå	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 10	uten	uten	ADP	prep	_	12	case	_	_
-11	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	oppmerksomhet	oppmerksomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	obl	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	9	punct	_	_
 
@@ -19437,7 +19437,7 @@
 14	,	$,	PUNCT	<komma>	_	2	punct	_	_
 15	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	18	aux:pass	_	_
 16	ikke	ikke	PART	adv	Polarity=Neg	18	advmod	_	_
-17	adopsjonsformidlingen	adopsjonsformidling	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	18	nsubj	_	_
+17	adopsjonsformidlingen	adopsjonsformidling	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	18	nsubj:pass	_	_
 18	nevnt	nevne	VERB	verb	VerbForm=Part	0	root	_	_
 19	med	med	ADP	prep	_	21	case	_	_
 20	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	21	det	_	_
@@ -19478,7 +19478,7 @@
 14	hjemmet	hjem	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	12	nmod	_	SpaceAfter=No
 15	,	$,	PUNCT	<komma>	_	6	punct	_	_
 16	omtales	omtale	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
-17	adopsjonsvirksomheten	adopsjonsvirksomhet	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	16	nsubj	_	_
+17	adopsjonsvirksomheten	adopsjonsvirksomhet	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	16	nsubj:pass	_	_
 18	i	i	ADP	prep	_	21	case	_	_
 19	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	21	det	_	_
 20	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	21	amod	_	_
@@ -19509,7 +19509,7 @@
 
 # sent_id = 019137
 # text = Chr. Michelsens barnehjem ble fortsatt brukt til observasjon av adopsjonsbarn til tidlig på 80-tallet, men andre instanser sto for formidlingen.
-1	Chr	Chr	PROPN	subst	_	7	nsubj	_	SpaceAfter=No
+1	Chr	Chr	PROPN	subst	_	7	nsubj:pass	_	SpaceAfter=No
 2	.	$.	PUNCT	clb	_	1	punct	_	_
 3	Michelsens	Michelsens	PROPN	subst	_	1	flat:name	_	_
 4	barnehjem	barnehjem	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	1	flat:name	_	_
@@ -19575,11 +19575,11 @@
 # text = Ble ikke det gjort, ville barnehjemmet bli nedlagt, forteller Johnsen.
 1	Ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	_	_
 2	ikke	ikke	PART	adv	Polarity=Neg	4	advmod	_	_
-3	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
+3	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj:pass	_	_
 4	gjort	gjøre	VERB	verb	VerbForm=Part	9	advcl	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	4	punct	_	_
 6	ville	ville	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	aux	_	_
-7	barnehjemmet	barnehjem	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	9	nsubj	_	_
+7	barnehjemmet	barnehjem	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	9	nsubj:pass	_	_
 8	bli	bli	AUX	verb	VerbForm=Inf	9	aux:pass	_	_
 9	nedlagt	nedlegge	VERB	verb	VerbForm=Part	11	ccomp	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	9	punct	_	_
@@ -19604,7 +19604,7 @@
 # text = Spedbarnsavdelingen var dyr å drive og dagpengene fra mødrene som skulle adoptere vekk barna uteble.
 1	Spedbarnsavdelingen	spedbarnsavdeling	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	cop	_	_
-3	dyr	dyr	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+3	dyr	dyr	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 4	å	å	PART	inf-merke	_	5	mark	_	_
 5	drive	drive	VERB	verb	VerbForm=Inf	3	advcl	_	_
 6	og	og	CCONJ	konj	_	15	cc	_	_
@@ -19654,7 +19654,7 @@
 15	bygge	bygge	VERB	verb	VerbForm=Inf	4	conj	_	_
 16	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
 17	helt	hel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	18	advmod	_	_
-18	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+18	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	spedbarnsavdeling	spedbarnsavdeling	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obj	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -19714,7 +19714,7 @@
 8	valgte	velge	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	ccomp	_	_
 9	å	å	PART	inf-merke	_	10	mark	_	_
 10	beholde	beholde	VERB	verb	VerbForm=Inf	8	xcomp	_	_
-11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	det	_	_
+11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 12	barn	barn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	10	obj	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -19843,7 +19843,7 @@
 15	flere	mange	ADJ	adj	Degree=Cmp	16	amod	_	_
 16	adopsjonssaker	adopsjonssak	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	13	nmod	_	_
 17	og	og	CCONJ	konj	_	20	cc	_	_
-18	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	20	det	_	_
+18	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	20	nmod:poss	_	_
 19	mange	mange	ADJ	adj	Degree=Pos|Number=Plur	20	amod	_	_
 20	roller	rolle	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	13	conj	_	SpaceAfter=No
 21	.	$.	PUNCT	clb	_	9	punct	_	_
@@ -19864,7 +19864,7 @@
 
 # sent_id = 019158
 # text = Sosialkontorene ble i disse årene bemannet med fagutdannede barnevernsarbeidere.
-1	Sosialkontorene	sosialkontor	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	6	nsubj	_	_
+1	Sosialkontorene	sosialkontor	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	6	nsubj:pass	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 3	i	i	ADP	prep	_	5	case	_	_
 4	disse	disse	DET	det	Number=Plur|PronType=Dem	5	det	_	_
@@ -19877,7 +19877,7 @@
 
 # sent_id = 019159
 # text = Ny fagkunnskap, nye holdninger og nye løsninger kom i konflikt med Johnsens oppfatninger.
-1	Ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	fagkunnskap	fagkunnskap	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nsubj	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	5	punct	_	_
 4	nye	ny	ADJ	adj	Degree=Pos|Number=Plur	5	amod	_	_
@@ -19925,7 +19925,7 @@
 3	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
 4	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	person	person	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	24	csubj	_	_
 8	som	som	SCONJ	sbu	_	10	mark	_	_
 9	kunne	kunne	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	10	aux	_	_
@@ -19946,7 +19946,7 @@
 24	indisium	indisium	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	0	root	_	_
 25	på	på	ADP	prep	_	36	case	_	_
 26	at	at	SCONJ	sbu	_	36	mark	_	_
-27	hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	28	det	_	_
+27	hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	28	nmod:poss	_	_
 28	arbeid	arbeid	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	36	nsubj	_	_
 29	i	i	ADP	prep	_	30	case	_	_
 30	forhold	forhold	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	28	nmod	_	_
@@ -20032,7 +20032,7 @@
 14	Hordaland	Hordaland	PROPN	subst	_	12	nmod	_	_
 15	etter	etter	ADP	prep	_	19	case	_	_
 16	at	at	SCONJ	sbu	_	19	mark	_	_
-17	barnevernsloven	barnevernslov	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	19	nsubj	_	_
+17	barnevernsloven	barnevernslov	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	19	nsubj:pass	_	_
 18	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	19	aux:pass	_	_
 19	vedtatt	vedta	VERB	verb	VerbForm=Part	6	advcl	_	_
 20	i	i	ADP	prep	_	21	case	_	_
@@ -20051,7 +20051,7 @@
 8	,	$,	PUNCT	<komma>	_	11	punct	_	_
 9	70	70	NUM	det	Number=Plur|NumType=Card	10	nummod	_	_
 10	år	år	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	11	obl	_	_
-11	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	xcomp	_	SpaceAfter=No
+11	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	xcomp	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 019166
@@ -20079,7 +20079,7 @@
 4	som	som	ADP	prep	_	5	case	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	2	xcomp	_	_
 6	av	av	ADP	prep	_	8	case	_	_
-7	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	det	_	_
+7	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	livsoppgaver	livsoppgave	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	5	nmod	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -20101,7 +20101,7 @@
 # sent_id = 019170
 # text = «Sist gangen jeg besøkte henne, viste hun meg albumet av alle de barna hun hadde hatt med å gjøre.
 1	«	$"	PUNCT	<anf>	_	8	punct	_	SpaceAfter=No
-2	Sist	sist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	Sist	sist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	gangen	gang	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	obl	_	_
 4	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
 5	besøkte	besøke	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	acl:relcl	_	_
@@ -20150,7 +20150,7 @@
 14	sitte	sitte	VERB	verb	VerbForm=Inf	6	conj	_	_
 15	med	med	ADP	prep	_	18	case	_	_
 16	hele	hel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	18	amod	_	_
-17	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	18	det	_	_
+17	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	18	nmod:poss	_	_
 18	livsverk	livsverk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	14	obl	_	_
 19	i	i	ADP	prep	_	20	case	_	_
 20	hendene	hånd	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	18	xcomp	_	SpaceAfter=No
@@ -20198,7 +20198,7 @@
 8	men	men	CCONJ	konj	_	12	cc	_	_
 9	med	med	ADP	prep	_	12	case	_	_
 10	én	én	NUM	det	Gender=Masc|Number=Sing|NumType=Card	12	nummod	_	_
-11	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	forskjell	forskjell	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	conj	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -20215,7 +20215,7 @@
 9	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
 10	arkivnummer	arkivnummer	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	7	nmod	_	_
 11	i	i	ADP	prep	_	15	case	_	_
-12	Bergen	Bergen	PROPN	subst	_	15	nmod	_	_
+12	Bergen	Bergen	PROPN	subst	_	15	nmod:poss	_	_
 13	Helseråds	Helseråd	PROPN	subst	Case=Gen	12	flat:name	_	_
 14	gamle	gammel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	15	amod	_	_
 15	adopsjonsarkiv	adopsjonsarkiv	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	10	nmod	_	SpaceAfter=No
@@ -20290,7 +20290,7 @@
 3	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 4	kjøpt	kjøpe	VERB	verb	VerbForm=Part	0	root	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-6	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	obj	_	SpaceAfter=No
+6	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	obj	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 019181
@@ -20311,7 +20311,7 @@
 14	som	som	SCONJ	sbu	_	16	mark	_	_
 15	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	_	_
 16	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	acl:relcl	_	_
-17	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	glede	glede	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	16	obj	_	_
 19	av	av	ADP	prep	_	18	nmod	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -20320,7 +20320,7 @@
 # text = - Hvis du mot formodning skulle bli ranet, hadde du håpet at de stjal innholdet i veska og ikke veska?
 1	-	$-	PUNCT	<strek>	_	12	punct	_	_
 2	Hvis	hvis	SCONJ	sbu	_	8	mark	_	_
-3	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	8	nsubj	_	_
+3	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	8	nsubj:pass	_	_
 4	mot	mot	ADP	prep	_	5	case	_	_
 5	formodning	formodning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	8	obl	_	_
 6	skulle	skulle	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	aux	_	_
@@ -20481,7 +20481,7 @@
 4	ikke	ikke	PART	adv	Polarity=Neg	7	advmod	_	_
 5	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	_	_
 6	så	så	ADV	adv	_	7	advmod	_	_
-7	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	ccomp	_	_
+7	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	ccomp	_	_
 8	på	på	ADP	prep	_	10	case	_	_
 9	sånne	sånn	DET	det	Number=Plur|PronType=Dem	10	det	_	_
 10	fjellting	fjellting	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	7	obl	_	SpaceAfter=No
@@ -20512,18 +20512,18 @@
 # sent_id = 019198
 # text = Fardals hang til ørepynt av en viss størrelse ble nøkternt bemerket i hennes eget 40-årslag.
 1	Fardals	Fardal	PROPN	subst	Case=Gen	2	nmod	_	_
-2	hang	hang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nsubj	_	_
+2	hang	hang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nsubj:pass	_	_
 3	til	til	ADP	prep	_	4	case	_	_
 4	ørepynt	ørepynt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	nmod	_	_
 5	av	av	ADP	prep	_	8	case	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	viss	viss	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	viss	viss	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	størrelse	størrelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nmod	_	_
 9	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	11	aux:pass	_	_
 10	nøkternt	nøktern	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	11	advmod	_	_
 11	bemerket	bemerke	VERB	verb	VerbForm=Part	0	root	_	_
 12	i	i	ADP	prep	_	15	case	_	_
-13	hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	15	det	_	_
+13	hennes	hennes	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 14	eget	egen	DET	det	Definite=Ind|Gender=Neut|Number=Sing|PronType=Prs	15	det	_	_
 15	40-årslag	40-årslag	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	11	obl	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	11	punct	_	_
@@ -20742,12 +20742,12 @@
 # sent_id = 019212
 # text = Hvis hun blir spurt om hvor gammel hun er, hender det at hun legger på et år, og så sier hun:
 1	Hvis	hvis	SCONJ	sbu	_	4	mark	_	_
-2	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
+2	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	4	nsubj:pass	_	_
 3	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux:pass	_	_
 4	spurt	spørre	VERB	verb	VerbForm=Part	11	advcl	_	_
 5	om	om	ADP	prep	_	7	case	_	_
 6	hvor	hvor	ADV	adv	_	7	advmod	_	_
-7	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	advcl	_	_
+7	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	advcl	_	_
 8	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
 9	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	4	punct	_	_
@@ -20845,7 +20845,7 @@
 2	tenner	tenne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	rød	rød	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	rød	rød	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	Prince	Prince	PROPN	subst	_	2	obj	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -20918,7 +20918,7 @@
 5	tenkt	tenke	VERB	verb	VerbForm=Part	0	root	_	_
 6	på	på	ADP	prep	_	7	case	_	_
 7	oldefaren	oldefar	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
-8	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	det	_	_
+8	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 9	som	som	SCONJ	sbu	_	10	mark	_	_
 10	røyket	røyke	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	7	acl:relcl	_	_
 11	til	til	SCONJ	sbu	_	14	mark	_	_
@@ -21050,7 +21050,7 @@
 2	nå	nå	ADV	adv	_	6	advmod	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	2	punct	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	historie	historie	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -21095,7 +21095,7 @@
 4	på	på	ADP	prep	_	5	case	_	_
 5	totusentallet	totusentall	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	0	root	_	_
 6	og	og	CCONJ	konj	_	11	cc	_	_
-7	Signy	Signy	PROPN	subst	_	11	nsubj	_	_
+7	Signy	Signy	PROPN	subst	_	11	nsubj:pass	_	_
 8	Fardal	Fardal	PROPN	subst	_	7	flat:name	_	_
 9	hadde	ha	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	11	aux	_	_
 10	blitt	bli	AUX	verb	VerbForm=Part	11	aux:pass	_	_
@@ -21114,9 +21114,9 @@
 5	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
 6	historien	historie	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
 7	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	cop	_	_
-8	død	død	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	ccomp	_	_
+8	død	død	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	ccomp	_	_
 9	og	og	CCONJ	konj	_	10	cc	_	_
-10	begravet	begrave	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	8	conj	_	SpaceAfter=No
+10	begravet	begrave	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	8	conj	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 019236
@@ -21127,8 +21127,8 @@
 4	Fardal	Fardal	PROPN	subst	_	1	nmod	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	4	punct	_	_
 6	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	cop	_	_
-7	nåværende	nåværende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
-8	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+7	nåværende	nåværende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
+8	politisk	politisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	redaktør	redaktør	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 10	i	i	ADP	prep	_	11	case	_	_
 11	Dagbladet	Dagbladet	PROPN	subst	Gender=Neut	9	nmod	_	SpaceAfter=No
@@ -21227,7 +21227,7 @@
 2	du	du	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
 3	vet	vite	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	6	punct	_	_
-5	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	vin	vin	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 7	og	og	CCONJ	konj	_	8	cc	_	_
 8	hagefest	hagefest	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	conj	_	SpaceAfter=No
@@ -21413,7 +21413,7 @@
 6	som	som	SCONJ	sbu	_	9	mark	_	_
 7	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	_	_
 8	mer	mye	ADJ	adj	Degree=Cmp	9	advmod	_	_
-9	behersket	behersket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+9	behersket	behersket	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 10	enn	enn	ADP	prep	_	11	case	_	_
 11	meg	jeg	PRON	pron	Animacy=Hum|Case=Acc|Number=Sing|Person=1|PronType=Prs	8	obl	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	14	punct	_	_
@@ -21445,7 +21445,7 @@
 5	slett	slett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	3	conj	_	_
 6	for	for	ADV	adv	_	7	advmod	_	_
 7	lite	lite	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	8	advmod	_	_
-8	polert	polere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	SpaceAfter=No
+8	polert	polere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	8	punct	_	_
 
 # sent_id = 019262
@@ -21577,7 +21577,7 @@
 6	holder	holde	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	_	_
 7	fram	fram	ADV	prep	_	6	advmod	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-9	rosa	rosa	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	rosa	rosa	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	kjole	kjole	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -21630,7 +21630,7 @@
 12	,	$,	PUNCT	<komma>	_	15	punct	_	_
 13	bare	bare	ADV	adv	_	15	advmod	_	_
 14	være	være	AUX	verb	VerbForm=Inf	15	cop	_	_
-15	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	conj	_	_
+15	opptatt	opptatt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	conj	_	_
 16	av	av	ADP	prep	_	19	case	_	_
 17	hva	hva	PRON	pron	PronType=Int	19	nsubj	_	_
 18	som	som	SCONJ	sbu	_	19	mark	_	_
@@ -21658,7 +21658,7 @@
 15	allment	allmenn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	16	advmod	_	_
 16	akseptert	akseptere	VERB	verb	VerbForm=Part	12	acl:relcl	_	_
 17	som	som	ADP	prep	_	18	case	_	_
-18	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	xcomp	_	SpaceAfter=No
+18	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	xcomp	_	SpaceAfter=No
 19	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 019279
@@ -21687,7 +21687,7 @@
 11	at	at	SCONJ	sbu	_	14	mark	_	_
 12	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	_	_
 13	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	_	_
-14	endimensjonal	endimensjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	ccomp	_	SpaceAfter=No
+14	endimensjonal	endimensjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	ccomp	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	8	punct	_	_
 
 # sent_id = 019281
@@ -21827,7 +21827,7 @@
 # newpar
 # sent_id = 019292
 # text = Ekte vare:
-1	Ekte	ekte	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Ekte	ekte	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	vare	vare	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
 3	:	$:	PUNCT	clb	_	2	punct	_	_
 
@@ -21887,7 +21887,7 @@
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 3	akkurat	akkurat	ADV	adv	_	4	advmod	_	_
 4	passe	passe	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
-5	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+5	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 6	for	for	ADP	prep	_	7	case	_	_
 7	pappa	pappa	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 8	og	og	CCONJ	konj	_	9	cc	_	_
@@ -21909,7 +21909,7 @@
 11	«	$"	PUNCT	<anf>	_	12	punct	_	SpaceAfter=No
 12	Tingeling	Tingeling	PROPN	subst	_	15	nsubj	_	SpaceAfter=No
 13	»	$"	PUNCT	<anf>	_	12	punct	_	_
-14	hyppig	hyppig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	hyppig	hyppig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	gjest	gjest	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	conj	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -22002,7 +22002,7 @@
 # sent_id = 019310
 # text = En svær komfyr sto øverst på ønskelista.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	svær	svær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	svær	svær	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	komfyr	komfyr	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj	_	_
 4	sto	stå	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 5	øverst	øvre	ADJ	adj	Definite=Ind|Degree=Sup	4	advmod	_	_
@@ -22017,7 +22017,7 @@
 3	laget	lage	VERB	verb	VerbForm=Part	0	root	_	_
 4	av	av	ADP	prep	_	7	case	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	dansk	dansk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	dansk	dansk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	snekker	snekker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	12	punct	_	_
 9	som	som	SCONJ	sbu	_	12	mark	_	_
@@ -22078,7 +22078,7 @@
 
 # sent_id = 019317
 # text = God alene, bedre med konjakk eller foie gras, mener Øyvind.
-1	God	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	ccomp	_	_
+1	God	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	ccomp	_	_
 2	alene	alene	ADV	adv	_	1	advmod	_	SpaceAfter=No
 3	,	$,	PUNCT	<komma>	_	4	punct	_	_
 4	bedre	god	ADJ	adj	Degree=Cmp	1	conj	_	_
@@ -22124,7 +22124,7 @@
 # sent_id = 019321
 # text = En god varme tar imot gjester hjemme hos Øyvind Lofthus (42).
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	varme	varme	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj	_	_
 4	tar	ta	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 5	imot	imot	ADV	prep	_	4	advmod	_	_
@@ -22180,7 +22180,7 @@
 10	benken	benk	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	obl	_	_
 11	står	stå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	conj	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-13	ferdig	ferdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	ferdig	ferdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	krydderkake	krydderkake	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nsubj	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -22205,7 +22205,7 @@
 17	)	$)	PUNCT	<parentes-slutt>	_	16	punct	_	_
 18	med	med	ADP	prep	_	19	case	_	_
 19	munnen	munn	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
-20	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	xcomp	_	_
+20	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	xcomp	_	_
 21	av	av	ADP	prep	_	22	case	_	_
 22	pepperkakedeig	pepperkakedeig	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	20	obl	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -22283,19 +22283,19 @@
 2	man	man	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|PronType=Prs	3	nsubj	_	_
 3	baker	baker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obl	_	_
 4	og	og	CCONJ	konj	_	5	cc	_	_
-5	matglad	matglad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	conj	_	SpaceAfter=No
+5	matglad	matglad	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	conj	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	3	punct	_	_
 7	trenger	trenge	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	man	man	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|PronType=Prs	7	nsubj	_	_
 9	for	for	ADP	prep	_	10	case	_	_
 10	eksempel	eksempel	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	7	obl	_	_
 11	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-12	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	spisestue	spisestue	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	_
 14	og	og	CCONJ	konj	_	18	cc	_	_
 15	bare	bare	ADV	adv	_	18	advmod	_	_
 16	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
-17	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	stue	stue	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	conj	_	SpaceAfter=No
 19	.	$.	PUNCT	clb	_	7	punct	_	_
 
@@ -22315,7 +22315,7 @@
 2	fra	fra	ADP	prep	_	3	case	_	_
 3	50-tallet	50-tall	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	1	nmod	_	_
 4	står	stå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-5	stablet	stable	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	4	xcomp	_	_
+5	stablet	stable	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	4	xcomp	_	_
 6	i	i	ADP	prep	_	8	case	_	_
 7	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
 8	hjørne	hjørne	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	5	obl	_	_
@@ -22412,7 +22412,7 @@
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 5	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
 6	blitt	bli	VERB	verb	VerbForm=Part	0	root	_	_
-7	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	kunde	kunde	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	xcomp	_	_
 9	hos	hos	ADP	prep	_	11	case	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
@@ -22464,7 +22464,7 @@
 3	liker	like	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	industristilen	industristil	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obj	_	_
 5	og	og	CCONJ	konj	_	7	cc	_	_
-6	klassisk	klassisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	klassisk	klassisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	design	design	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	conj	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	11	punct	_	_
 9	for	for	ADP	prep	_	10	case	_	_
@@ -22523,7 +22523,7 @@
 2	fra	fra	ADP	prep	_	3	case	_	_
 3	Lofthus	Lofthus	PROPN	subst	_	1	nmod	_	_
 4	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	_	_
-5	sikker	sikker	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+5	sikker	sikker	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 6	på	på	ADP	prep	_	8	case	_	_
 7	to	to	NUM	det	Number=Plur|NumType=Card	8	nummod	_	_
 8	ting	ting	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	obl	_	SpaceAfter=No
@@ -22662,7 +22662,7 @@
 12	med	med	ADP	prep	_	13	case	_	_
 13	gjær	gjær	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
 14	,	$,	PUNCT	<komma>	_	16	punct	_	_
-15	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	hevetid	hevetid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	conj	_	_
 17	og	og	CCONJ	konj	_	18	cc	_	_
 18	steking	steking	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	9	conj	_	_
@@ -22723,7 +22723,7 @@
 11	til	til	ADP	prep	_	16	case	_	_
 12	blant	blant	ADP	prep	_	13	case	_	_
 13	andre	annen	DET	det	Number=Plur|PronType=Dem	16	nmod	_	_
-14	Paul	Paul	PROPN	subst	Gender=Masc	16	nmod	_	_
+14	Paul	Paul	PROPN	subst	Gender=Masc	16	nmod:poss	_	_
 15	Bocuses	Bocuse	PROPN	subst	Case=Gen	14	flat:name	_	_
 16	restaurant	restaurant	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obl	_	_
 17	i	i	ADP	prep	_	18	case	_	_
@@ -22758,8 +22758,8 @@
 8	bilde	bilde	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	4	obj	_	_
 9	av	av	ADP	prep	_	13	case	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-11	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
-12	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+11	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
+12	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	ovn	ovn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -22825,7 +22825,7 @@
 # text = Siden ble de kjent for å lage Norges beste bagett og for de lange køene på gata - de minnet om bilder fra Sovjet-tida.
 1	Siden	siden	ADV	adv	_	4	advmod	_	_
 2	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	_	_
-3	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	_	_
+3	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj:pass	_	_
 4	kjent	kjenne	VERB	verb	VerbForm=Part	0	root	_	_
 5	for	for	ADP	prep	_	7	case	_	_
 6	å	å	PART	inf-merke	_	7	mark	_	_
@@ -22996,7 +22996,7 @@
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 4	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	_	_
 5	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
-6	lei	lei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+6	lei	lei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	6	punct	_	_
 
 # sent_id = 019375
@@ -23047,9 +23047,9 @@
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
 5	hun	hun	PRON	pron	Animacy=Hum|Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
 6	alltid	alltid	ADV	adv	_	7	advmod	_	_
-7	nygredd	nygredd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+7	nygredd	nygredd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 8	og	og	CCONJ	konj	_	9	cc	_	_
-9	fin	fin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	conj	_	SpaceAfter=No
+9	fin	fin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	conj	_	SpaceAfter=No
 10	.	$.	PUNCT	clb	_	7	punct	_	_
 
 # sent_id = 019379
@@ -23079,7 +23079,7 @@
 8	får	få	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 9	snakke	snakke	VERB	verb	VerbForm=Inf	2	conj	_	_
 10	om	om	ADP	prep	_	12	case	_	_
-11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	det	_	_
+11	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 12	favorittemaer	favorittema	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	9	obl	_	SpaceAfter=No
 13	,	$,	PUNCT	<komma>	_	14	punct	_	_
 14	baking	baking	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	12	conj	_	_
@@ -23272,7 +23272,7 @@
 3	heller	heller	ADV	adv	_	6	advmod	_	_
 4	ikke	ikke	PART	adv	Polarity=Neg	6	advmod	_	_
 5	«	$"	PUNCT	<anf>	_	6	punct	_	SpaceAfter=No
-6	speltfrelst	speltfrelst	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+6	speltfrelst	speltfrelst	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 7	»	$"	PUNCT	<anf>	_	6	punct	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	12	punct	_	_
 9	selv	selv	ADV	adv	_	10	advmod	_	_
@@ -23315,10 +23315,10 @@
 # text = Det er mye helse i god smak også.
 1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	expl	_	_
 2	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	helse	helse	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	nsubj	_	_
 5	i	i	ADP	prep	_	7	case	_	_
-6	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	smak	smak	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	_
 8	også	også	ADV	adv	_	2	advmod	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	2	punct	_	_
@@ -23386,7 +23386,7 @@
 4	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
 5	forteller	fortelle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 6	om	om	ADP	prep	_	8	case	_	_
-7	ungdommelig	ungdommelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	ungdommelig	ungdommelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	sårbarhet	sårbarhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	obl	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	11	punct	_	_
 10	om	om	ADP	prep	_	11	case	_	_
@@ -23400,7 +23400,7 @@
 18	fertilitet	fertilitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	nmod	_	_
 19	i	i	ADP	prep	_	22	case	_	_
 20	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-21	kald	kald	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	amod	_	_
+21	kald	kald	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	amod	_	_
 22	verden	verden	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	nmod	_	SpaceAfter=No
 23	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -23442,7 +23442,7 @@
 1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	hatt	ha	VERB	verb	VerbForm=Part	0	root	_	_
-4	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+4	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	pris	pris	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -23469,7 +23469,7 @@
 # text = Gjær er levende.
 1	Gjær	gjær	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	levende	levende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+3	levende	levende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 4	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 019409
@@ -23695,7 +23695,7 @@
 2	Nå	nå	ADV	adv	_	5	advmod	_	_
 3	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	_	_
 4	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
-5	heldig	heldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	ccomp	_	SpaceAfter=No
+5	heldig	heldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	ccomp	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	5	punct	_	_
 7	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	Øyvind	Øyvind	PROPN	subst	Gender=Masc	7	nsubj	_	SpaceAfter=No
@@ -23852,7 +23852,7 @@
 
 # sent_id = 019437
 # text = Ole Einar Bjørndalens andreplass kan tyde på at 34-åringens form er på vei.
-1	Ole	Ole	PROPN	subst	Gender=Masc	4	nmod	_	_
+1	Ole	Ole	PROPN	subst	Gender=Masc	4	nmod:poss	_	_
 2	Einar	Einar	PROPN	subst	Gender=Masc	1	flat:name	_	_
 3	Bjørndalens	Bjørndalen	PROPN	subst	Case=Gen	1	flat:name	_	_
 4	andreplass	andreplass	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nsubj	_	_
@@ -23927,7 +23927,7 @@
 14	to	to	NUM	det	Number=Plur|NumType=Card	12	obj	_	_
 15	og	og	CCONJ	konj	_	18	cc	_	_
 16	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
-17	halv	halv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	halv	halv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	uke	uke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	conj	_	_
 19	med	med	ADP	prep	_	20	case	_	_
 20	trening	trening	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	18	nmod	_	_
@@ -23946,7 +23946,7 @@
 6	at	at	SCONJ	sbu	_	8	mark	_	_
 7	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	_	_
 8	gikk	gå	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	4	advcl	_	_
-9	oppreist	oppreist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	xcomp	_	SpaceAfter=No
+9	oppreist	oppreist	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	xcomp	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	15	punct	_	_
 11	men	men	CCONJ	konj	_	15	cc	_	_
 12	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	_	_
@@ -24063,7 +24063,7 @@
 10	og	og	CCONJ	konj	_	13	cc	_	_
 11	sisterunden	sisterunde	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	_
 12	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	cop	_	_
-13	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	conj	_	SpaceAfter=No
+13	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	conj	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	8	punct	_	_
 
 # sent_id = 019449
@@ -24093,7 +24093,7 @@
 23	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	24	nsubj	_	_
 24	ble	bli	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	_	_
 25	for	for	ADV	adv	_	26	advmod	_	_
-26	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	24	xcomp	_	SpaceAfter=No
+26	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	24	xcomp	_	SpaceAfter=No
 27	,	$,	PUNCT	<komma>	_	24	punct	_	_
 28	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 29	skiskytteren	skiskytter	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	28	nsubj	_	_
@@ -24171,7 +24171,7 @@
 3	Koivuranta	Koivuranta	PROPN	subst	_	2	flat:name	_	_
 4	tok	ta	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	suveren	suveren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	suveren	suveren	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	seier	seier	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 8	i	i	ADP	prep	_	9	case	_	_
 9	verdenscuprennet	verdenscuprenn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	4	obl	_	_
@@ -24408,7 +24408,7 @@
 12	Tora	Tora	PROPN	subst	_	15	nsubj	_	_
 13	Berger	Berger	PROPN	subst	_	12	flat:name	_	_
 14	like	like	ADV	adv	_	15	advmod	_	_
-15	treffsikker	treffsikker	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	conj	_	SpaceAfter=No
+15	treffsikker	treffsikker	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	conj	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 019470
@@ -24421,7 +24421,7 @@
 6	og	og	CCONJ	konj	_	9	cc	_	_
 7	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	9	cop	_	_
 8	dermed	dermed	ADV	adv	_	9	advmod	_	_
-9	sjanseløs	sjanseløs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	conj	_	_
+9	sjanseløs	sjanseløs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	conj	_	_
 10	mot	mot	ADP	prep	_	12	case	_	_
 11	tyske	tysk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	12	amod	_	_
 12	Martina	Martina	PROPN	subst	_	9	obl	_	_
@@ -24604,7 +24604,7 @@
 # text = Det mangler litt trygghet, og hoppene blir litt for kontrollert, sa 23-åringen.
 1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	expl	_	_
 2	mangler	mangle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	ccomp	_	_
-3	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	trygghet	trygghet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	nsubj	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	8	punct	_	_
 6	og	og	CCONJ	konj	_	8	cc	_	_
@@ -24662,7 +24662,7 @@
 1	-	$-	PUNCT	<strek>	_	4	punct	_	_
 2	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	kjempefornøyd	kjempefornøyd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+4	kjempefornøyd	kjempefornøyd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 5	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 019487
@@ -24699,7 +24699,7 @@
 13	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	14	cop	_	_
 14	tangering	tangering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	nmod	_	_
 15	av	av	ADP	prep	_	18	case	_	_
-16	Gregor	Gregor	PROPN	subst	_	18	nmod	_	_
+16	Gregor	Gregor	PROPN	subst	_	18	nmod:poss	_	_
 17	Schlierenzauers	Schlierenzauer	PROPN	subst	Case=Gen	16	flat:name	_	_
 18	bakkerekord	bakkerekord	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nmod	_	_
 19	fra	fra	ADP	prep	_	21	case	_	_
@@ -24852,12 +24852,12 @@
 # newpar
 # sent_id = 019499
 # text = Sportssjef Clas Brede Bråthen er full av ros overfor Johan Remen Evensen etter helgens to verdenscuprenn i Granåsen.
-1	Sportssjef	sportssjef	NOUN	subst	Definite=Ind|Gender=Fem,Masc|Number=Sing	6	nsubj	_	_
+1	Sportssjef	sportssjef	NOUN	subst	Definite=Ind|Gender=Com|Number=Sing	6	nsubj	_	_
 2	Clas	Clas	PROPN	subst	_	1	flat:name	_	_
 3	Brede	Brede	PROPN	subst	Gender=Masc	1	flat:name	_	_
 4	Bråthen	Bråthen	PROPN	subst	_	1	flat:name	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
-6	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+6	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 7	av	av	ADP	prep	_	8	case	_	_
 8	ros	ros	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obl	_	_
 9	overfor	overfor	ADP	prep	_	10	case	_	_
@@ -24936,7 +24936,7 @@
 7	hoppkometen	hoppkomet	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	_
 8	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	_	_
 9	være	være	AUX	verb	VerbForm=Inf	10	cop	_	_
-10	aktuell	aktuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	advcl	_	_
+10	aktuell	aktuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	advcl	_	_
 11	for	for	ADP	prep	_	14	case	_	_
 12	den	den	DET	det	Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
 13	tysk-østerrikske	tysk-østerriksk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	14	amod	_	_
@@ -24979,7 +24979,7 @@
 4	pressen	presse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 5	om	om	ADP	prep	_	10	case	_	_
 6	hvor	hvor	ADV	adv	_	7	advmod	_	_
-7	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	xcomp	_	_
+7	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	xcomp	_	_
 8	Evensen	Evensen	PROPN	subst	_	10	nsubj	_	_
 9	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	_	_
 10	bli	bli	VERB	verb	VerbForm=Inf	2	acl:relcl	_	SpaceAfter=No
@@ -25003,10 +25003,10 @@
 1	Selv	selv	ADV	adv	_	2	advmod	_	_
 2	virket	virke	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 3	romsdalingen	romsdaling	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
-4	overveldet	overvelde	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	2	xcomp	_	_
+4	overveldet	overvelde	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	2	xcomp	_	_
 5	og	og	CCONJ	konj	_	7	cc	_	_
 6	nærmest	nær	ADJ	adj	Definite=Ind|Degree=Sup	7	advmod	_	_
-7	brydd	brydd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	conj	_	_
+7	brydd	brydd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	conj	_	_
 8	av	av	ADP	prep	_	10	case	_	_
 9	helgens	helg	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
 10	suksess	suksess	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obl	_	_
@@ -25027,7 +25027,7 @@
 # text = Jeg er kjempefornøyd.
 1	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	kjempefornøyd	kjempefornøyd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+3	kjempefornøyd	kjempefornøyd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 4	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 019510
@@ -25125,10 +25125,10 @@
 2	Jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	ikke	ikke	PART	adv	Polarity=Neg	5	advmod	_	_
-5	overrasket	overraske	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	SpaceAfter=No
+5	overrasket	overraske	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	8	punct	_	_
 7	men	men	CCONJ	konj	_	8	cc	_	_
-8	imponert	imponere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	5	conj	_	SpaceAfter=No
+8	imponert	imponere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	5	conj	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 019517
@@ -25184,7 +25184,7 @@
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 3	Evensen	Evensen	PROPN	subst	_	5	nsubj	_	_
 4	veldig	veldig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
-5	fornøyd	fornøyd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+5	fornøyd	fornøyd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 6	med	med	ADP	prep	_	10	case	_	_
 7	å	å	PART	inf-merke	_	10	mark	_	_
 8	få	få	AUX	verb	VerbForm=Inf	10	aux	_	_
@@ -25264,7 +25264,7 @@
 10	på	på	ADP	prep	_	11	case	_	_
 11	Holmenkollen-tårnet	Holmenkollen-tårn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	8	nmod	_	_
 12	da	da	SCONJ	sbu	_	15	mark	_	_
-13	nettauksjonen	nettauksjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	nsubj	_	_
+13	nettauksjonen	nettauksjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	nsubj:pass	_	_
 14	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	15	aux:pass	_	_
 15	avsluttet	avslutte	VERB	verb	VerbForm=Part	3	advcl	_	_
 16	søndag	søndag	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	obl	_	SpaceAfter=No
@@ -25323,7 +25323,7 @@
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
 13	skandale	skandale	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	conj	_	_
 14	om	om	SCONJ	sbu	_	18	mark	_	_
-15	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	18	nsubj	_	_
+15	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	18	nsubj:pass	_	_
 16	hadde	ha	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	18	aux	_	_
 17	blitt	bli	AUX	verb	VerbForm=Part	18	aux:pass	_	_
 18	solgt	selge	VERB	verb	VerbForm=Part	13	advcl	_	_
@@ -25353,7 +25353,7 @@
 
 # sent_id = 019528
 # text = Toppen av det historiske Holmenkollen-tårnet, den såkalte diamanten, ble søndag solgt på nettauksjon for 270.000 kroner.
-1	Toppen	topp	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	_
+1	Toppen	topp	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	nsubj:pass	_	_
 2	av	av	ADP	prep	_	5	case	_	_
 3	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
 4	historiske	historisk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	5	amod	_	_
@@ -25375,7 +25375,7 @@
 
 # sent_id = 019529
 # text = Auksjonen på det internasjonale auksjonsnettstedet eBay ble avsluttet klokken 16.30 søndag ettermiddag.
-1	Auksjonen	auksjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
+1	Auksjonen	auksjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj:pass	_	_
 2	på	på	ADP	prep	_	5	case	_	_
 3	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
 4	internasjonale	internasjonal	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	5	amod	_	_
@@ -25421,7 +25421,7 @@
 # sent_id = 019531
 # text = «Diamanten» ble skilt fra resten av ovarennet i forbindelse med at den gamle hoppbakken ble revet.
 1	«	$"	PUNCT	<anf>	_	2	punct	_	SpaceAfter=No
-2	Diamanten	Diamanten	PROPN	subst	_	5	nsubj	_	SpaceAfter=No
+2	Diamanten	Diamanten	PROPN	subst	_	5	nsubj:pass	_	SpaceAfter=No
 3	»	$"	PUNCT	<anf>	_	2	punct	_	_
 4	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	skilt	skille	VERB	verb	VerbForm=Part	0	root	_	_
@@ -25435,7 +25435,7 @@
 13	at	at	SCONJ	sbu	_	18	mark	_	_
 14	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
 15	gamle	gammel	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	16	amod	_	_
-16	hoppbakken	hoppbakke	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	18	nsubj	_	_
+16	hoppbakken	hoppbakke	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	18	nsubj:pass	_	_
 17	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	18	aux:pass	_	_
 18	revet	rive	VERB	verb	VerbForm=Part	11	acl	_	SpaceAfter=No
 19	.	$.	PUNCT	clb	_	5	punct	_	_
@@ -25443,11 +25443,11 @@
 # sent_id = 019532
 # text = En ny og mer moderne bakke skal nå reises isteden.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+2	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 3	og	og	CCONJ	konj	_	5	cc	_	_
 4	mer	mye	ADJ	adj	Degree=Cmp	5	advmod	_	_
-5	moderne	moderne	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	conj	_	_
-6	bakke	bakke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nsubj	_	_
+5	moderne	moderne	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	conj	_	_
+6	bakke	bakke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nsubj:pass	_	_
 7	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 8	nå	nå	ADV	adv	_	9	advmod	_	_
 9	reises	reise	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
@@ -25493,7 +25493,7 @@
 16	som	som	SCONJ	sbu	_	17	mark	_	_
 17	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	acl:relcl	_	_
 18	i	i	ADP	prep	_	20	case	_	_
-19	grei	grei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	amod	_	_
+19	grei	grei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	amod	_	_
 20	stand	stand	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	obl	_	_
 21	og	og	CCONJ	konj	_	24	cc	_	_
 22	som	som	SCONJ	sbu	_	24	mark	_	_
@@ -25508,12 +25508,12 @@
 # sent_id = 019535
 # text = - Rik mulighet til å imponere dine venner, kolleger eller forretningsforbindelser.
 1	-	$-	PUNCT	<strek>	_	3	punct	_	_
-2	Rik	rik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	Rik	rik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	mulighet	mulighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	0	root	_	_
 4	til	til	ADP	prep	_	6	case	_	_
 5	å	å	PART	inf-merke	_	6	mark	_	_
 6	imponere	imponere	VERB	verb	VerbForm=Inf	3	acl	_	_
-7	dine	din	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	det	_	_
+7	dine	din	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	8	nmod:poss	_	_
 8	venner	venn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	6	obj	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	10	punct	_	_
 10	kolleger	kollega	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	conj	_	_
@@ -25527,7 +25527,7 @@
 2	Diamanten	Diamanten	PROPN	subst	_	5	nsubj	_	SpaceAfter=No
 3	»	$"	PUNCT	<anf>	_	2	punct	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
-5	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	ccomp	_	_
+5	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	ccomp	_	_
 6	for	for	ADP	prep	_	9	case	_	_
 7	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
 8	nytt	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	amod	_	_
@@ -25556,7 +25556,7 @@
 1	Et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	2	det	_	_
 2	tidel	tidel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 3	unna	unna	ADP	prep	_	5	case	_	_
-4	trippel	trippel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	trippel	trippel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	Aksel	Aksel	PROPN	subst	Gender=Masc	0	root	_	_
 
 # newpar
@@ -25617,7 +25617,7 @@
 13	konturene	kontur	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	11	obj	_	_
 14	av	av	ADP	prep	_	17	case	_	_
 15	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-16	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+16	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 17	triumf	triumf	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nmod	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -25656,7 +25656,7 @@
 31	hundredelene	hundredel	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	26	obj	_	_
 32	med	med	ADP	prep	_	35	case	_	_
 33	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	35	det	_	_
-34	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	35	amod	_	_
+34	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	35	amod	_	_
 35	andreomgang	andreomgang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	26	obl	_	SpaceAfter=No
 36	.	$.	PUNCT	clb	_	8	punct	_	_
 
@@ -25785,7 +25785,7 @@
 # text = Dermed er Lund Svindals fasit etter tre renn i Beaver Creek to seire og en tredjeplass.
 1	Dermed	dermed	ADV	adv	_	13	advmod	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	13	cop	_	_
-3	Lund	Lund	PROPN	subst	_	5	nmod	_	_
+3	Lund	Lund	PROPN	subst	_	5	nmod:poss	_	_
 4	Svindals	Svindal	PROPN	subst	Case=Gen	3	flat:name	_	_
 5	fasit	fasit	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nsubj	_	_
 6	etter	etter	ADP	prep	_	8	case	_	_
@@ -25817,11 +25817,11 @@
 # text = Den norske standarden ble satt med Kjetil Jansruds fantastiske andreomgang.
 1	Den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
 2	norske	norsk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	3	amod	_	_
-3	standarden	standard	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
+3	standarden	standard	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj:pass	_	_
 4	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	satt	sette	VERB	verb	VerbForm=Part	0	root	_	_
 6	med	med	ADP	prep	_	10	case	_	_
-7	Kjetil	Kjetil	PROPN	subst	Gender=Masc	10	nmod	_	_
+7	Kjetil	Kjetil	PROPN	subst	Gender=Masc	10	nmod:poss	_	_
 8	Jansruds	Jansrud	PROPN	subst	Case=Gen	7	flat:name	_	_
 9	fantastiske	fantastisk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	10	amod	_	_
 10	andreomgang	andreomgang	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	SpaceAfter=No
@@ -25841,7 +25841,7 @@
 10	kjørte	kjøre	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	_	_
 11	ned	ned	ADV	prep	_	10	advmod	_	_
 12	til	til	ADP	prep	_	14	case	_	_
-13	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	ledelse	ledelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obl	_	_
 15	i	i	ADP	prep	_	16	case	_	_
 16	andre	andre	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing|NumType=Ord	10	advmod	_	SpaceAfter=No
@@ -25881,7 +25881,7 @@
 9	og	og	CCONJ	konj	_	10	cc	_	_
 10	ble	bli	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	_	_
 11	nesten	nesten	ADV	adv	_	10	advmod	_	_
-12	nervøs	nervøs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	xcomp	_	_
+12	nervøs	nervøs	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	xcomp	_	_
 13	av	av	ADP	prep	_	14	case	_	_
 14	standarden	standard	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
 15	unggutten	unggutt	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	16	nsubj	_	_
@@ -25900,7 +25900,7 @@
 8	så	se	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	_	_
 9	på	på	ADP	prep	_	10	case	_	_
 10	linja	linje	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	8	obl	_	_
-11	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	10	det	_	_
+11	hans	hans	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	10	nmod:poss	_	_
 12	og	og	CCONJ	konj	_	14	cc	_	_
 13	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
 14	kjørte	kjøre	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	conj	_	_
@@ -25925,7 +25925,7 @@
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
 4	jævla	jævla	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
-5	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	storslalåm-kjører	storslalåm-kjører	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	ccomp	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	6	punct	_	_
 8	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -26039,7 +26039,7 @@
 11	jeg	jeg	PRON	pron	Animacy=Hum|Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	_	_
 12	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	_	_
 13	ikke	ikke	PART	adv	Polarity=Neg	14	advmod	_	_
-14	overrasket	overraske	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	5	conj	_	SpaceAfter=No
+14	overrasket	overraske	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	5	conj	_	SpaceAfter=No
 15	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 019564
@@ -26110,7 +26110,7 @@
 2	bør	burde	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 3	ingen	ingen	PRON	pron	Number=Plur|Person=3|PronType=Prs	5	nsubj	_	_
 4	være	være	AUX	verb	VerbForm=Inf	5	cop	_	_
-5	overrasket	overraske	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	_
+5	overrasket	overraske	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	_
 6	om	om	SCONJ	sbu	_	9	mark	_	_
 7	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	expl	_	_
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	_	_
@@ -26163,7 +26163,7 @@
 7	-	$-	PUNCT	<strek>	_	8	punct	_	SpaceAfter=No
 8	1	1	NUM	det	Number=Plur|NumType=Card	6	conj	_	_
 9	til	til	ADP	prep	_	15	case	_	_
-10	Espen	Espen	PROPN	subst	Gender=Masc	15	nmod	_	_
+10	Espen	Espen	PROPN	subst	Gender=Masc	15	nmod:poss	_	_
 11	«	$"	PUNCT	<anf>	_	12	punct	_	SpaceAfter=No
 12	Shampo	Shampo	PROPN	subst	_	10	flat:name	_	SpaceAfter=No
 13	»	$"	PUNCT	<anf>	_	12	punct	_	_
@@ -26262,7 +26262,7 @@
 4	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 5	fortsatt	fortsatt	ADV	adv	_	4	advmod	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	knallsterk	knallsterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	knallsterk	knallsterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	hjemmestatistikk	hjemmestatistikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	12	punct	_	_
 10	og	og	CCONJ	konj	_	12	cc	_	_
@@ -26373,7 +26373,7 @@
 6	gjøre	gjøre	VERB	verb	VerbForm=Inf	2	advcl	_	_
 7	nok	nok	ADV	adv	_	10	advmod	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-9	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	kamp	kamp	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
 11	i	i	ADP	prep	_	12	case	_	_
 12	innebandy-VM	innebandy-VM	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	10	nmod	_	_
@@ -26576,7 +26576,7 @@
 3	sett	se	VERB	verb	VerbForm=Part	0	root	_	_
 4	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	3	obj	_	_
 5	mektig	mektig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
-6	lei	lei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	xcomp	_	_
+6	lei	lei	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	xcomp	_	_
 7	på	på	ADP	prep	_	9	case	_	_
 8	Frp	Frp	PROPN	subst	Abbr=Yes	9	nmod	_	_
 9	angrep	angrep	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	6	obl	_	_
@@ -26704,7 +26704,7 @@
 17	Ap	Ap	PROPN	subst	Abbr=Yes	19	nsubj	_	_
 18	måttet	måtte	AUX	verb	VerbForm=Part	19	aux	_	_
 19	tåle	tåle	VERB	verb	VerbForm=Inf	2	conj	_	_
-20	krass	krass	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	amod	_	_
+20	krass	krass	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	amod	_	_
 21	kritikk	kritikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	obj	_	_
 22	for	for	ADP	prep	_	33	case	_	_
 23	at	at	SCONJ	sbu	_	33	mark	_	_
@@ -26750,7 +26750,7 @@
 26	at	at	SCONJ	sbu	_	34	mark	_	_
 27	målet	mål	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	34	nsubj	_	_
 28	om	om	ADP	prep	_	30	case	_	_
-29	fulle	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	30	amod	_	_
+29	fulle	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	30	amod	_	_
 30	sykehjemsdekning	sykehjemsdekning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	27	nmod	_	_
 31	ennå	ennå	ADV	adv	_	34	advmod	_	_
 32	ikke	ikke	PART	adv	Polarity=Neg	34	advmod	_	_
@@ -26776,7 +26776,7 @@
 14	Solberg	Solberg	PROPN	subst	_	13	flat:name	_	_
 15	gjorde	gjøre	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	12	acl:relcl	_	_
 16	i	i	ADP	prep	_	18	case	_	_
-17	si	sin	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	18	det	_	_
+17	si	sin	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	18	nmod:poss	_	_
 18	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	15	obl	_	_
 19	som	som	ADP	prep	_	20	case	_	_
 20	kommunalminister	kommunalminister	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	xcomp	_	SpaceAfter=No
@@ -26935,7 +26935,7 @@
 # sent_id = 019609
 # text = - Full sykehjemsdekning er det neste store velferdsløftet.
 1	-	$-	PUNCT	<strek>	_	3	punct	_	_
-2	Full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	Full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	sykehjemsdekning	sykehjemsdekning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	0	root	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
 5	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
@@ -27051,7 +27051,7 @@
 7	kommuner	kommune	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	9	nsubj	_	_
 8	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 9	ta	ta	VERB	verb	VerbForm=Inf	2	xcomp	_	_
-10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	obj	_	_
 12	av	av	ADP	prep	_	13	case	_	_
 13	ansvaret	ansvar	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	11	nmod	_	_
@@ -27140,7 +27140,7 @@
 12	av	av	ADP	prep	_	13	case	_	_
 13	F-35-flyene	F-35-fly	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	11	nmod	_	_
 14	skaper	skape	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-15	berettiget	berettige	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	16	amod	_	_
+15	berettiget	berettige	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	16	amod	_	_
 16	uro	uro	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	14	obj	_	SpaceAfter=No
 17	,	$,	PUNCT	<komma>	_	22	punct	_	_
 18	og	og	CCONJ	konj	_	22	cc	_	_
@@ -27173,7 +27173,7 @@
 8	smertegrense	smertegrense	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
 9	for	for	ADP	prep	_	15	case	_	_
 10	hvor	hvor	ADV	adv	_	11	advmod	_	_
-11	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	prisøkning	prisøkning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	15	obj	_	_
 13	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	15	nsubj	_	_
 14	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	_	_
@@ -27192,7 +27192,7 @@
 # text = «Enhver demokratisk nasjon vil på et eller annet tidspunkt måtte sette ned foten dersom økonomiske rammer sprenges, men vi er ikke i nærheten av å være der nå».
 1	«	$"	PUNCT	<anf>	_	12	punct	_	SpaceAfter=No
 2	Enhver	enhver	DET	det	Gender=Masc|Number=Sing|PronType=Tot	4	det	_	_
-3	demokratisk	demokratisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	demokratisk	demokratisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	nasjon	nasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nsubj	_	_
 5	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	_	_
 6	på	på	ADP	prep	_	10	case	_	_
@@ -27206,7 +27206,7 @@
 14	foten	fot	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	12	obj	_	_
 15	dersom	dersom	SCONJ	sbu	_	18	mark	_	_
 16	økonomiske	økonomisk	ADJ	adj	Degree=Pos|Number=Plur	17	amod	_	_
-17	rammer	ramme	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	18	nsubj	_	_
+17	rammer	ramme	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	18	nsubj:pass	_	_
 18	sprenges	sprenge	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	12	advcl	_	SpaceAfter=No
 19	,	$,	PUNCT	<komma>	_	22	punct	_	_
 20	men	men	CCONJ	konj	_	22	cc	_	_
@@ -27324,7 +27324,7 @@
 8	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	_	_
 9	langt	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	10	advmod	_	_
 10	mer	mye	ADJ	adj	Degree=Cmp	11	advmod	_	_
-11	nyansert	nyansere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	SpaceAfter=No
+11	nyansert	nyansere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	18	punct	_	_
 13	og	og	CCONJ	konj	_	18	cc	_	_
 14	stadig	stadig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	15	advmod	_	_
@@ -27429,12 +27429,12 @@
 6	,	$,	PUNCT	<komma>	_	11	punct	_	_
 7	og	og	CCONJ	konj	_	11	cc	_	_
 8	rundt	rundt	ADP	prep	_	9	case	_	_
-9	600	600	NUM	det	Number=Plur|NumType=Card	11	nsubj	_	_
+9	600	600	NUM	det	Number=Plur|NumType=Card	11	nsubj:pass	_	_
 10	skulle	skulle	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	11	aux	_	_
 11	kjøpes	kjøpe	VERB	verb	VerbForm=Inf|Voice=Pass	3	conj	_	_
 12	inn	inn	ADV	prep	_	11	advmod	_	_
 13	av	av	ADP	prep	_	15	case	_	_
-14	deres	deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	15	det	_	_
+14	deres	deres	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 15	allierte	alliert	ADJ	adj	Degree=Pos|Number=Plur	11	advmod	_	_
 16	-	$-	PUNCT	<strek>	_	18	punct	_	_
 17	blant	blant	ADP	prep	_	18	case	_	_
@@ -27560,7 +27560,7 @@
 
 # sent_id = 019639
 # text = Lav deltakelse
-1	Lav	lav	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Lav	lav	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	deltakelse	deltakelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 
 # newpar
@@ -27603,7 +27603,7 @@
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	_	_
 3	valgdeltakelsen	valgdeltakelse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
 4	relativt	relativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	5	advmod	_	_
-5	lav	lav	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+5	lav	lav	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	12	punct	_	_
 7	bare	bare	ADV	adv	_	8	advmod	_	_
 8	61,7	61,7	NUM	det	Number=Plur|NumType=Card	9	nummod	_	_
@@ -27619,7 +27619,7 @@
 2	mellom	mellom	ADP	prep	_	3	case	_	_
 3	kommunene	kommune	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	1	nmod	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
-5	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+5	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 019644
@@ -27676,7 +27676,7 @@
 12	at	at	SCONJ	sbu	_	15	mark	_	_
 13	han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
 14	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
-15	urolig	urolig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	ccomp	_	_
+15	urolig	urolig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	ccomp	_	_
 16	for	for	ADP	prep	_	19	case	_	_
 17	kommunens	kommune	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	19	nmod	_	_
 18	lave	lav	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	19	amod	_	_
@@ -27697,7 +27697,7 @@
 10	i	i	ADP	prep	_	11	case	_	_
 11	forsøksordningen	forsøksordning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 12	med	med	ADP	prep	_	14	case	_	_
-13	elektronisk	elektronisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	elektronisk	elektronisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	stemming	stemming	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	nmod	_	_
 15	og	og	CCONJ	konj	_	16	cc	_	_
 16	stemmerett	stemmerett	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	conj	_	_
@@ -27795,7 +27795,7 @@
 26	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	28	expl	_	_
 27	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	28	aux	_	_
 28	vært	være	VERB	verb	VerbForm=Part	14	conj	_	_
-29	lokal	lokal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	30	amod	_	_
+29	lokal	lokal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	30	amod	_	_
 30	oppmerksomhet	oppmerksomhet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	28	nsubj	_	_
 31	om	om	ADP	prep	_	34	case	_	_
 32	den	den	DET	det	Gender=Masc|Number=Sing|PronType=Art	34	det	_	_
@@ -27850,7 +27850,7 @@
 8	partier	parti	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nmod	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	5	punct	_	_
 10	dess	dess	ADV	adv	_	11	advmod	_	_
-11	flere	mange	ADJ	adj	Degree=Cmp	17	nsubj	_	_
+11	flere	mange	ADJ	adj	Degree=Cmp	17	nsubj:pass	_	_
 12	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	_	_
 13	en	en	PRON	pron	Animacy=Hum|Number=Sing|PronType=Art,Prs	14	nsubj	_	_
 14	anta	anta	VERB	verb	VerbForm=Inf	0	root	_	_
@@ -27878,7 +27878,7 @@
 13	folk	folk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	14	nsubj	_	_
 14	føler	føle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	acl:relcl	_	_
 15	at	at	SCONJ	sbu	_	18	mark	_	_
-16	deres	deres	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	det	_	_
+16	deres	deres	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	17	nmod:poss	_	_
 17	stemme	stemme	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	nsubj	_	_
 18	betyr	bety	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	ccomp	_	_
 19	noe	noe	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Ind,Prs	18	obj	_	_
@@ -27915,7 +27915,7 @@
 11	lokalvalg	lokalvalg	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	17	obl	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	11	punct	_	_
 13	at	at	SCONJ	sbu	_	17	mark	_	_
-14	kommuner	kommune	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	17	nsubj	_	_
+14	kommuner	kommune	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	17	nsubj:pass	_	_
 15	og	og	CCONJ	konj	_	16	cc	_	_
 16	lokalpolitikere	lokalpolitiker	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	14	conj	_	_
 17	fratas	frata	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
@@ -27935,7 +27935,7 @@
 7	og	og	CCONJ	konj	_	8	cc	_	_
 8	forordninger	forordning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	6	conj	_	_
 9	som	som	SCONJ	sbu	_	11	mark	_	_
-10	kommunene	kommune	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	11	nsubj	_	_
+10	kommunene	kommune	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	11	nsubj:pass	_	_
 11	forutsettes	forutsette	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	8	acl:relcl	_	_
 12	å	å	PART	inf-merke	_	13	mark	_	_
 13	sette	sette	VERB	verb	VerbForm=Inf	11	xcomp	_	_
@@ -27967,7 +27967,7 @@
 9	ikke	ikke	PART	adv	Polarity=Neg	15	advmod	_	_
 10	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
 11	lokale	lokal	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	12	amod	_	_
-12	folkestyret	folkestyre	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	15	nsubj	_	_
+12	folkestyret	folkestyre	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	15	nsubj:pass	_	_
 13	nå	nå	ADV	adv	_	15	advmod	_	_
 14	bør	burde	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	_	_
 15	styrkes	styrke	VERB	verb	VerbForm=Inf|Voice=Pass	7	acl:relcl	_	_
@@ -27995,7 +27995,7 @@
 # sent_id = 019659
 # text = En desperat Gaddafi vil forhandle med opprørene.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	desperat	desperat	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	desperat	desperat	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	Gaddafi	Gaddafi	PROPN	subst	_	5	nsubj	_	_
 4	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 5	forhandle	forhandle	VERB	verb	VerbForm=Inf	0	root	_	_
@@ -28050,7 +28050,7 @@
 4	Vikør	Vikør	PROPN	subst	_	1	flat:name	_	_
 5	frykter	frykte	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	at	at	SCONJ	sbu	_	14	mark	_	_
-7	sivile	sivil	ADJ	adj	Degree=Pos|Number=Plur	14	nsubj	_	_
+7	sivile	sivil	ADJ	adj	Degree=Pos|Number=Plur	14	nsubj:pass	_	_
 8	i	i	ADP	prep	_	11	case	_	_
 9	Gaddafis	Gaddafi	PROPN	subst	Case=Gen	11	nmod	_	_
 10	resterende	restere	ADJ	adj	VerbForm=Part	11	amod	_	_
@@ -28133,7 +28133,7 @@
 5	al-Gaddafi	al-Gaddafi	PROPN	subst	_	4	flat:name	_	_
 6	ymtet	ymte	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 7	gjennom	gjennom	ADP	prep	_	9	case	_	_
-8	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	det	_	_
+8	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 9	talsmann	talsmann	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obl	_	_
 10	Moussa	Moussa	PROPN	subst	_	9	appos	_	_
 11	Ibrahim	Ibrahim	PROPN	subst	_	10	flat:name	_	SpaceAfter=No
@@ -28235,7 +28235,7 @@
 2	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	_	_
 3	vært	være	AUX	verb	VerbForm=Part	6	cop	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	gjennomgående	gjennomgående	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	gjennomgående	gjennomgående	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	faktor	faktor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 7	i	i	ADP	prep	_	8	case	_	_
 8	Libya-krigen	Libya-krig	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
@@ -28303,7 +28303,7 @@
 3	uka	uke	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	4	obl	_	_
 4	oppfordret	oppfordre	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 5	Gaddafi	Gaddafi	PROPN	subst	_	4	nsubj	_	_
-6	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	7	det	_	_
+6	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	7	nmod:poss	_	_
 7	lojalister	lojalist	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	4	obj	_	_
 8	til	til	ADP	prep	_	10	case	_	_
 9	å	å	PART	inf-merke	_	10	mark	_	_
@@ -28447,8 +28447,8 @@
 1	Her	her	ADV	prep	_	5	advmod	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 3	støtten	støtte	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
-4	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	_
-5	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	_
+5	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 6	og	og	CCONJ	konj	_	12	cc	_	_
 7	mange	mange	ADJ	adj	Degree=Pos|Number=Plur	12	nsubj	_	_
 8	av	av	ADP	prep	_	9	case	_	_
@@ -28510,7 +28510,7 @@
 2	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	oppfordret	oppfordre	VERB	verb	VerbForm=Part	0	root	_	_
 4	styrkene	styrke	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	3	obj	_	_
-5	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	4	det	_	_
+5	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 6	til	til	ADP	prep	_	8	case	_	_
 7	å	å	PART	inf-merke	_	8	mark	_	_
 8	unngå	unngå	VERB	verb	VerbForm=Inf	3	advcl	_	_
@@ -28598,7 +28598,7 @@
 4	kontroll	kontroll	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 5	over	over	ADP	prep	_	6	case	_	_
 6	styrkene	styrke	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	3	obl	_	_
-7	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	6	det	_	_
+7	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 8	i	i	ADP	prep	_	9	case	_	_
 9	møte	møte	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	obl	_	_
 10	med	med	ADP	prep	_	11	case	_	_
@@ -28614,7 +28614,7 @@
 # sent_id = 019695
 # text = - Vårt mål er ikke mer blod, det er frihet.
 1	-	$-	PUNCT	<strek>	_	7	punct	_	_
-2	Vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	3	det	_	_
+2	Vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	3	nmod:poss	_	_
 3	mål	mål	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	7	nsubj	_	_
 4	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
 5	ikke	ikke	PART	adv	Polarity=Neg	7	advmod	_	_
@@ -28757,7 +28757,7 @@
 10	ikke	ikke	PART	adv	Polarity=Neg	11	advmod	_	_
 11	havne	havne	VERB	verb	VerbForm=Inf	4	advcl	_	_
 12	på	på	ADP	prep	_	14	case	_	_
-13	feil	feil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	feil	feil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	fot	fot	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obl	_	_
 15	med	med	ADP	prep	_	16	case	_	_
 16	befolkningen	befolkning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	11	obl	_	_
@@ -28771,7 +28771,7 @@
 2	hevder	hevde	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	de	de	PRON	pron	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	_	_
 4	gjør	gjøre	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	_	_
-5	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	det	_	_
+5	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	6	nmod:poss	_	_
 6	beste	god	ADJ	adj	Definite=Def|Degree=Sup	4	obj	_	_
 7	for	for	ADP	prep	_	9	case	_	_
 8	å	å	PART	inf-merke	_	9	mark	_	_
@@ -28812,7 +28812,7 @@
 4	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 5	innebære	innebære	VERB	verb	VerbForm=Inf	0	root	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	intern	intern	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	intern	intern	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	regelgivning	regelgivning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obj	_	_
 9	innenfor	innenfor	ADP	prep	_	11	case	_	_
 10	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
@@ -28843,7 +28843,7 @@
 # sent_id = 019708
 # text = Dersom noe av virksomheten på Jan Mayen skulle bli drevet av en institusjon utskilt fra staten i form av et selvstendig rettssubjekt noe som i og for seg kan tenkes når det gjelder værtjenesten vil en statlig instruks ikke være bindende for dem.
 1	Dersom	dersom	SCONJ	sbu	_	10	mark	_	_
-2	noe	noe	DET	det	Gender=Masc|Number=Sing|PronType=Ind	10	nsubj	_	_
+2	noe	noe	DET	det	Gender=Masc|Number=Sing|PronType=Ind	10	nsubj:pass	_	_
 3	av	av	ADP	prep	_	4	case	_	_
 4	virksomheten	virksomhet	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 5	på	på	ADP	prep	_	6	case	_	_
@@ -28878,7 +28878,7 @@
 34	værtjenesten	værtjeneste	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	33	obj	_	_
 35	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	41	aux	_	_
 36	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	38	det	_	_
-37	statlig	statlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	38	amod	_	_
+37	statlig	statlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	38	amod	_	_
 38	instruks	instruks	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	41	nsubj	_	_
 39	ikke	ikke	PART	adv	Polarity=Neg	41	advmod	_	_
 40	være	være	AUX	verb	VerbForm=Inf	41	cop	_	_
@@ -28944,7 +28944,7 @@
 4	til	til	ADP	prep	_	11	case	_	_
 5	at	at	SCONJ	sbu	_	11	mark	_	_
 6	miljøverdienes	miljøverdi	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	7	nmod	_	_
-7	stilling	stilling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	nsubj	_	_
+7	stilling	stilling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	nsubj:pass	_	_
 8	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux:pass	_	_
 9	vesentlig	vesentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	10	advmod	_	_
 10	bedre	god	ADJ	adj	Degree=Cmp	11	advmod	_	_
@@ -28956,7 +28956,7 @@
 16	enn	enn	ADP	prep	_	20	case	_	_
 17	gjennom	gjennom	ADP	prep	_	20	case	_	_
 18	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
-19	intern	intern	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	amod	_	_
+19	intern	intern	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	amod	_	_
 20	instruks	instruks	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	obl	_	SpaceAfter=No
 21	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -28976,7 +28976,7 @@
 12	effektivt	effektiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	15	advmod	_	_
 13	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
 14	føre	føre	ADP	prep	_	15	case	_	_
-15	vàr	var	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+15	vàr	var	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 16	dersom	dersom	SCONJ	sbu	_	19	mark	_	_
 17	utviklingen	utvikling	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	19	nsubj	_	_
 18	skulle	skulle	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	19	aux	_	_
@@ -29021,18 +29021,18 @@
 # sent_id = 019713
 # text = At organisert turisme knapt er tenkelig, behøver ikke å hindre at Jan Mayen kan bli oppsøkt av eventyrere.
 1	At	at	SCONJ	sbu	_	6	mark	_	_
-2	organisert	organisere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	3	amod	_	_
+2	organisert	organisere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	3	amod	_	_
 3	turisme	turisme	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nsubj	_	_
 4	knapt	knapp	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	6	advmod	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
-6	tenkelig	tenkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	csubj	_	SpaceAfter=No
+6	tenkelig	tenkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	csubj	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	6	punct	_	_
 8	behøver	behøve	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 9	ikke	ikke	PART	adv	Polarity=Neg	8	advmod	_	_
 10	å	å	PART	inf-merke	_	11	mark	_	_
 11	hindre	hindre	VERB	verb	VerbForm=Inf	8	xcomp	_	_
 12	at	at	SCONJ	sbu	_	17	mark	_	_
-13	Jan	Jan	PROPN	subst	Gender=Masc	17	nsubj	_	_
+13	Jan	Jan	PROPN	subst	Gender=Masc	17	nsubj:pass	_	_
 14	Mayen	Mayen	PROPN	subst	_	13	flat:name	_	_
 15	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux	_	_
 16	bli	bli	AUX	verb	VerbForm=Inf	17	aux:pass	_	_
@@ -29053,7 +29053,7 @@
 8	grunn	grunn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obl	_	_
 9	av	at	SCONJ	sbu	_	25	mark	_	_
 10	de	de	DET	det	Number=Plur|PronType=Art	11	det	_	_
-11	forhold	forhold	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	25	nsubj	_	_
+11	forhold	forhold	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	25	nsubj:pass	_	_
 12	hvor	hvor	ADV	adv	_	15	advmod	_	_
 13	miljøpåvirkningen	miljøpåvirkning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	nsubj	_	_
 14	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	_	_
@@ -29069,7 +29069,7 @@
 24	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	25	aux	_	_
 25	holdes	holde	VERB	verb	VerbForm=Inf|Voice=Pass	5	xcomp	_	_
 26	utenfor	utenfor	ADP	prep	_	28	case	_	_
-27	fremtidig	fremtidig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	28	amod	_	_
+27	fremtidig	fremtidig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	28	amod	_	_
 28	miljølovgivning	miljølovgivning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	25	obl	_	_
 29	for	for	ADP	prep	_	30	case	_	_
 30	Jan	Jan	PROPN	subst	Gender=Masc	28	nmod	_	_
@@ -29107,9 +29107,9 @@
 11	,	$,	PUNCT	<komma>	_	17	punct	_	_
 12	både	både	CCONJ	konj	_	14	cc	_	_
 13	av	av	ADP	prep	_	17	case	_	_
-14	innholdsmessig	innholdsmessig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	17	amod	_	_
+14	innholdsmessig	innholdsmessig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	17	amod	_	_
 15	og	og	CCONJ	konj	_	16	cc	_	_
-16	formell	formell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	conj	_	_
+16	formell	formell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	conj	_	_
 17	art	art	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	nmod	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -29193,7 +29193,7 @@
 # text = Et eget regelverk for Jan Mayen kan av den grunn gjøres enklere.
 1	Et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
 2	eget	egen	DET	det	Definite=Ind|Gender=Neut|Number=Sing|PronType=Prs	3	det	_	_
-3	regelverk	regelverk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	11	nsubj	_	_
+3	regelverk	regelverk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	11	nsubj:pass	_	_
 4	for	for	ADP	prep	_	5	case	_	_
 5	Jan	Jan	PROPN	subst	Gender=Masc	3	nmod	_	_
 6	Mayen	Mayen	PROPN	subst	_	5	flat:name	_	_
@@ -29300,7 +29300,7 @@
 20	som	som	SCONJ	sbu	_	23	mark	_	_
 21	ikke	ikke	PART	adv	Polarity=Neg	23	advmod	_	_
 22	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	23	cop	_	_
-23	ønsket	ønske	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	19	amod	_	SpaceAfter=No
+23	ønsket	ønske	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	19	amod	_	SpaceAfter=No
 24	.	$.	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 019724
@@ -29332,7 +29332,7 @@
 4	nå	nå	ADV	adv	_	3	advmod	_	_
 5	for	for	ADP	prep	_	9	case	_	_
 6	at	at	SCONJ	sbu	_	9	mark	_	_
-7	grensen	grense	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	_
+7	grensen	grense	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	9	nsubj:pass	_	_
 8	bør	burde	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	_	_
 9	settes	sette	VERB	verb	VerbForm=Inf|Voice=Pass	3	advcl	_	_
 10	til	til	ADP	prep	_	11	case	_	_
@@ -29432,7 +29432,7 @@
 # text = Et nytt miljøregelverk for Jan Mayen kan utformes på forskjellige måter:
 1	Et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
 2	nytt	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	3	amod	_	_
-3	miljøregelverk	miljøregelverk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	8	nsubj	_	_
+3	miljøregelverk	miljøregelverk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	8	nsubj:pass	_	_
 4	for	for	ADP	prep	_	5	case	_	_
 5	Jan	Jan	PROPN	subst	Gender=Masc	3	nmod	_	_
 6	Mayen	Mayen	PROPN	subst	_	5	flat:name	_	_
@@ -29451,7 +29451,7 @@
 4	eksisterende	eksistere	ADJ	adj	VerbForm=Part	5	amod	_	_
 5	forskrifter	forskrift	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	2	nmod	_	_
 6	ved	ved	ADP	prep	_	8	case	_	_
-7	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	miljølov	miljølov	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nmod	_	_
 9	for	for	ADP	prep	_	10	case	_	_
 10	Svalbard	Svalbard	PROPN	subst	_	8	nmod	_	_
@@ -29473,7 +29473,7 @@
 26	Mayen	Mayen	PROPN	subst	_	25	flat:name	_	_
 27	ved	ved	ADP	prep	_	30	case	_	_
 28	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	30	det	_	_
-29	samlet	samle	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	30	amod	_	_
+29	samlet	samle	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	30	amod	_	_
 30	miljøforskrift	miljøforskrift	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	22	obl	_	_
 31	i	i	ADP	prep	_	32	case	_	_
 32	medhold	medhold	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	30	nmod	_	_
@@ -29498,7 +29498,7 @@
 12	mer	mye	ADJ	adj	Degree=Cmp	15	advmod	_	_
 13	eller	eller	CCONJ	konj	_	14	cc	_	_
 14	mindre	liten	ADJ	adj	Degree=Cmp	12	conj	_	_
-15	omfattende	omfattende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+15	omfattende	omfattende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	15	punct	_	_
 
 # sent_id = 019732
@@ -29515,7 +29515,7 @@
 10	i	i	ADP	prep	_	11	case	_	_
 11	regelverket	regelverk	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	9	nmod	_	_
 12	blir	bli	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	ccomp	_	_
-13	forskjellig	forskjellig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	xcomp	_	_
+13	forskjellig	forskjellig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	xcomp	_	_
 14	fra	fra	ADP	prep	_	15	case	_	_
 15	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	13	obl	_	_
 16	som	som	SCONJ	sbu	_	18	mark	_	_
@@ -29530,7 +29530,7 @@
 25	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	24	obj	_	_
 26	på	på	ADP	prep	_	29	case	_	_
 27	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	29	det	_	_
-28	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	29	amod	_	_
+28	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	29	amod	_	_
 29	miljølov	miljølov	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	24	obl	_	SpaceAfter=No
 30	.	$.	PUNCT	clb	_	7	punct	_	_
 
@@ -29552,7 +29552,7 @@
 14	arbeidet	arbeid	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	13	obj	_	_
 15	med	med	ADP	prep	_	18	case	_	_
 16	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
-17	helhetlig	helhetlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	helhetlig	helhetlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	miljøforvaltning	miljøforvaltning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nmod	_	_
 19	også	også	ADV	adv	_	20	advmod	_	_
 20	her	her	ADV	prep	_	13	advmod	_	SpaceAfter=No
@@ -29646,7 +29646,7 @@
 28	,	$,	PUNCT	<komma>	_	32	punct	_	_
 29	eventuelt	eventuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	32	advmod	_	_
 30	i	i	ADP	prep	_	32	case	_	_
-31	modifisert	modifisere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	32	amod	_	_
+31	modifisert	modifisere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	32	amod	_	_
 32	form	form	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	27	obl	_	SpaceAfter=No
 33	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -29665,10 +29665,10 @@
 11	når	når	SCONJ	sbu	_	13	mark	_	_
 12	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	expl	_	_
 13	gjelder	gjelde	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	acl:relcl	_	_
-14	folkerettslig	folkerettslig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	folkerettslig	folkerettslig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	status	status	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	obj	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	18	punct	_	_
-17	administrativ	administrativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	administrativ	administrativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	ordning	ordning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	15	conj	_	SpaceAfter=No
 19	,	$,	PUNCT	<komma>	_	20	punct	_	_
 20	aktivitet	aktivitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	conj	_	_
@@ -29723,7 +29723,7 @@
 6	unaturlig	unaturlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	4	advmod	_	_
 7	med	med	ADP	prep	_	10	case	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-9	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	miljølov	miljølov	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj	_	_
 11	for	for	ADP	prep	_	12	case	_	_
 12	Svalbard	Svalbard	PROPN	subst	_	10	nmod	_	_
@@ -29769,7 +29769,7 @@
 7	stedet	sted	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	8	obl	_	_
 8	foreslå	foreslå	VERB	verb	VerbForm=Inf	0	root	_	_
 9	at	at	SCONJ	sbu	_	18	mark	_	_
-10	miljøreglene	miljøregel	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	18	nsubj	_	_
+10	miljøreglene	miljøregel	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	18	nsubj:pass	_	_
 11	for	for	ADP	prep	_	12	case	_	_
 12	Jan	Jan	PROPN	subst	Gender=Masc	10	nmod	_	_
 13	Mayen	Mayen	PROPN	subst	_	12	flat:name	_	_
@@ -29780,7 +29780,7 @@
 18	samles	samle	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	8	ccomp	_	_
 19	i	i	ADP	prep	_	22	case	_	_
 20	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-21	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	22	amod	_	_
+21	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	22	amod	_	_
 22	miljøforskrift	miljøforskrift	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	18	obl	_	_
 23	og	og	CCONJ	konj	_	27	cc	_	_
 24	at	at	SCONJ	sbu	_	27	mark	_	_
@@ -29788,7 +29788,7 @@
 26	Mayen-loven	Mayen-lov	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	27	nsubj	_	_
 27	får	få	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	conj	_	_
 28	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	30	det	_	_
-29	uttrykkelig	uttrykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	30	amod	_	_
+29	uttrykkelig	uttrykkelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	30	amod	_	_
 30	hjemmel	hjemmel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	27	obj	_	_
 31	for	for	ADP	prep	_	33	case	_	_
 32	å	å	PART	inf-merke	_	33	mark	_	_
@@ -29814,9 +29814,9 @@
 2	mener	mene	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	at	at	SCONJ	sbu	_	16	mark	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-5	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	SpaceAfter=No
+5	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	5	punct	_	_
-7	samlet	samle	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	8	amod	_	_
+7	samlet	samle	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	8	amod	_	_
 8	miljøforskrift	miljøforskrift	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	nsubj	_	_
 9	for	for	ADP	prep	_	10	case	_	_
 10	Jan	Jan	PROPN	subst	Gender=Masc	8	nmod	_	_
@@ -29869,7 +29869,7 @@
 19	,	$,	PUNCT	<komma>	_	24	punct	_	_
 20	dersom	dersom	SCONJ	sbu	_	24	mark	_	_
 21	disse	disse	DET	det	Number=Plur|PronType=Dem	22	det	_	_
-22	reglene	regel	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	24	nsubj	_	_
+22	reglene	regel	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	24	nsubj:pass	_	_
 23	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	24	aux	_	_
 24	opprettholdes	opprettholde	VERB	verb	VerbForm=Inf|Voice=Pass	9	advcl	_	SpaceAfter=No
 25	.	$.	PUNCT	clb	_	5	punct	_	_
@@ -29880,7 +29880,7 @@
 2	utvalget	utvalg	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	nsubj	_	_
 3	foreslår	foreslå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	advcl	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	særskilt	særskilt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	særskilt	særskilt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	miljølov	miljølov	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 7	for	for	ADP	prep	_	8	case	_	_
 8	Svalbard	Svalbard	PROPN	subst	_	6	nmod	_	_
@@ -29952,7 +29952,7 @@
 4	klart	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	0	root	_	_
 5	at	at	SCONJ	sbu	_	12	mark	_	_
 6	lovutkastets	lovutkast	NOUN	subst	Case=Gen|Definite=Def|Gender=Neut|Number=Sing	7	nmod	_	_
-7	kapittel	kapittel	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	12	nsubj	_	_
+7	kapittel	kapittel	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	12	nsubj:pass	_	_
 8	om	om	ADP	prep	_	9	case	_	_
 9	arealplanlegging	arealplanlegging	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	nmod	_	_
 10	ikke	ikke	PART	adv	Polarity=Neg	12	advmod	_	_
@@ -29987,7 +29987,7 @@
 4	at	at	SCONJ	sbu	_	6	mark	_	_
 5	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	expl	_	_
 6	er	være	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	_	_
-7	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	liten	liten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	grunn	grunn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	nsubj	_	_
 9	til	til	ADP	prep	_	11	case	_	_
 10	å	å	PART	inf-merke	_	11	mark	_	_
@@ -30052,7 +30052,7 @@
 # text = Men slike verneområder kan opprettes med hjemmel direkte i den nye bestemmelsen som utvalget foreslår i Jan Mayen-loven § 2 tredje ledd, uten at det trenges noen særskilt regulering i miljøforskriften.
 1	Men	men	CCONJ	konj	_	5	cc	_	_
 2	slike	slik	DET	det	Number=Plur|PronType=Dem	3	det	_	_
-3	verneområder	verneområde	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nsubj	_	_
+3	verneområder	verneområde	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nsubj:pass	_	_
 4	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 5	opprettes	opprette	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 6	med	med	ADP	prep	_	7	case	_	_
@@ -30078,7 +30078,7 @@
 26	det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	27	expl	_	_
 27	trenges	trenges	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	advcl	_	_
 28	noen	noen	DET	det	Gender=Fem|Number=Sing|PronType=Ind	30	det	_	_
-29	særskilt	særskilt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	30	amod	_	_
+29	særskilt	særskilt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	30	amod	_	_
 30	regulering	regulering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	27	obj	_	_
 31	i	i	ADP	prep	_	32	case	_	_
 32	miljøforskriften	miljøforskrift	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	30	nmod	_	SpaceAfter=No
@@ -30113,7 +30113,7 @@
 # text = Hvordan få økt konkurranse på Vigra.
 1	Hvordan	hvordan	ADV	adv	_	2	advmod	_	_
 2	få	få	VERB	verb	VerbForm=Inf	0	root	_	_
-3	økt	øke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	4	amod	_	_
+3	økt	øke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	4	amod	_	_
 4	konkurranse	konkurranse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 5	på	på	ADP	prep	_	6	case	_	_
 6	Vigra	Vigra	PROPN	subst	_	2	obl	_	SpaceAfter=No
@@ -30128,13 +30128,13 @@
 5	bekreftelse	bekreftelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 6	på	på	ADP	prep	_	14	case	_	_
 7	at	at	SCONJ	sbu	_	14	mark	_	_
-8	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	det	_	_
+8	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 9	teori	teori	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	nsubj	_	_
 10	angående	angående	ADP	prep	_	12	case	_	_
 11	dette	dette	DET	det	Gender=Neut|Number=Sing|PronType=Dem	12	det	_	_
 12	tema	tema	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	9	nmod	_	_
 13	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	_	_
-14	riktig	riktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	SpaceAfter=No
+14	riktig	riktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	SpaceAfter=No
 15	,	$,	PUNCT	<komma>	_	21	punct	_	_
 16	nemlig	nemlig	ADV	adv	_	17	advmod	_	_
 17	at	at	SCONJ	sbu	_	21	mark	_	_
@@ -30146,7 +30146,7 @@
 23	for	for	ADP	prep	_	24	case	_	_
 24	konkurransen	konkurranse	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	22	nmod	_	_
 25	i	i	ADP	prep	_	27	case	_	_
-26	negativ	negativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	27	amod	_	_
+26	negativ	negativ	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	27	amod	_	_
 27	retning	retning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	22	nmod	_	SpaceAfter=No
 28	.	$.	PUNCT	clb	_	4	punct	_	_
 
@@ -30200,7 +30200,7 @@
 46	å	å	PART	inf-merke	_	47	mark	_	_
 47	be	be	VERB	verb	VerbForm=Inf	35	acl	_	_
 48	for	for	ADP	prep	_	51	case	_	_
-49	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	51	det	_	_
+49	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	51	nmod:poss	_	_
 50	syke	syk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	51	amod	_	_
 51	mor	mor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	47	obl	_	SpaceAfter=No
 52	.	$.	PUNCT	clb	_	4	punct	_	_
@@ -30220,10 +30220,10 @@
 11	inn	inn	ADP	prep	_	17	case	_	_
 12	på	på	ADP	prep	_	17	case	_	_
 13	hvordan	hvordan	ADV	adv	_	17	advmod	_	_
-14	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	15	det	_	_
+14	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 15	teori	teori	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	nsubj	_	_
 16	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	cop	_	_
-17	riktig	riktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	advcl	_	SpaceAfter=No
+17	riktig	riktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	advcl	_	SpaceAfter=No
 18	.	$.	PUNCT	clb	_	3	punct	_	_
 
 # sent_id = 019759
@@ -30248,7 +30248,7 @@
 18	be	be	VERB	verb	VerbForm=Inf	14	conj	_	_
 19	om	om	ADP	prep	_	26	case	_	_
 20	at	at	SCONJ	sbu	_	26	mark	_	_
-21	bonusordningen	bonusordning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	26	nsubj	_	_
+21	bonusordningen	bonusordning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	26	nsubj:pass	_	_
 22	på	på	ADP	prep	_	23	case	_	_
 23	flyreiser	flyreise	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	21	nmod	_	_
 24	innenlands	innenlands	ADP	prep	_	23	nmod	_	_
@@ -30259,7 +30259,7 @@
 29	fordi	fordi	SCONJ	sbu	_	32	mark	_	_
 30	denne	denne	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	32	nsubj	_	_
 31	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	32	cop	_	_
-32	konkurransevridende	konkurransevridende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	26	advcl	_	_
+32	konkurransevridende	konkurransevridende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	26	advcl	_	_
 33	til	til	ADP	prep	_	37	case	_	_
 34	SAS	SAS	PROPN	subst	_	37	nmod	_	SpaceAfter=No
 35	/	$/	SYM	symb	_	36	cc	_	SpaceAfter=No
@@ -30338,7 +30338,7 @@
 28	Norwegian	Norwegian	PROPN	subst	_	20	conj	_	_
 29	som	som	SCONJ	sbu	_	31	mark	_	_
 30	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	31	cop	_	_
-31	avhengig	avhengig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	28	amod	_	_
+31	avhengig	avhengig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	28	amod	_	_
 32	av	av	ADP	prep	_	34	case	_	_
 33	større	stor	ADJ	adj	Degree=Cmp	34	amod	_	_
 34	volum	volum	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	31	obl	_	SpaceAfter=No
@@ -30357,11 +30357,11 @@
 4	nå	nå	ADV	adv	_	5	advmod	_	_
 5	fått	få	VERB	verb	VerbForm=Part	0	root	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	gledelig	gledelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	gledelig	gledelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	bekreftelse	bekreftelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	obj	_	_
 9	på	på	ADP	prep	_	19	case	_	_
 10	at	at	SCONJ	sbu	_	19	mark	_	_
-11	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	12	det	_	_
+11	min	min	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	12	nmod:poss	_	_
 12	teori	teori	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	19	nsubj	_	_
 13	angående	angående	ADP	prep	_	14	case	_	_
 14	fjerning	fjerning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	12	nmod	_	_
@@ -30369,13 +30369,13 @@
 16	disse	disse	DET	det	Number=Plur|PronType=Dem	17	det	_	_
 17	bonuspoengene	bonuspoeng	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	14	nmod	_	_
 18	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	cop	_	_
-19	riktig	riktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	SpaceAfter=No
+19	riktig	riktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	5	punct	_	_
 
 # sent_id = 019763
 # text = For kort tid siden, så søkte Norwegian/sterling om å få fjernet bonuspoengene innen resten av Skandinavia.
 1	For	for	ADP	prep	_	3	case	_	_
-2	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	obl	_	_
 4	siden	siden	ADV	adv	_	3	advmod	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	3	punct	_	_
@@ -30387,7 +30387,7 @@
 11	om	om	ADP	prep	_	13	case	_	_
 12	å	å	PART	inf-merke	_	13	mark	_	_
 13	få	få	VERB	verb	VerbForm=Inf	7	advcl	_	_
-14	fjernet	fjerne	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	13	xcomp	_	_
+14	fjernet	fjerne	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	13	xcomp	_	_
 15	bonuspoengene	bonuspoeng	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	13	obj	_	_
 16	innen	innen	ADP	prep	_	17	case	_	_
 17	resten	rest	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	obl	_	_
@@ -30418,7 +30418,7 @@
 5	her	her	ADV	prep	_	4	advmod	_	_
 6	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	8	cop	_	_
 7	meget	meget	ADV	adv	_	8	advmod	_	_
-8	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+8	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 9	,	$,	PUNCT	<komma>	_	12	punct	_	_
 10	og	og	CCONJ	konj	_	12	cc	_	_
 11	langt	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	12	advmod	_	_
@@ -30444,7 +30444,7 @@
 12	lagt	legge	VERB	verb	VerbForm=Part	5	acl:relcl	_	_
 13	frem	frem	ADV	prep	_	12	advmod	_	_
 14	for	for	ADP	prep	_	16	case	_	_
-15	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+15	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 16	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	12	obl	_	_
 17	siden	siden	ADV	adv	_	16	advmod	_	SpaceAfter=No
 18	,	$,	PUNCT	<komma>	_	24	punct	_	_
@@ -30510,7 +30510,7 @@
 13	fikk	få	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	26	advcl	_	_
 14	overskudd	overskudd	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	13	obj	_	_
 15	på	på	ADP	prep	_	18	case	_	_
-16	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	18	det	_	_
+16	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	18	nmod:poss	_	_
 17	interkontinentale	interkontinental	ADJ	adj	Degree=Pos|Number=Plur	18	amod	_	_
 18	ruter	rute	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	13	obl	_	_
 19	innen	innen	ADP	prep	_	20	case	_	_
@@ -30518,7 +30518,7 @@
 21	,	$,	PUNCT	<komma>	_	13	punct	_	_
 22	så	så	ADV	adv	_	26	advmod	_	_
 23	ville	ville	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	26	aux	_	_
-24	disse	disse	PRON	pron	Number=Plur|Person=3|PronType=Prs	26	nsubj	_	_
+24	disse	disse	PRON	pron	Number=Plur|Person=3|PronType=Prs	26	nsubj:pass	_	_
 25	bli	bli	AUX	verb	VerbForm=Inf	26	aux:pass	_	_
 26	avviklet	avvikle	VERB	verb	VerbForm=Part	6	xcomp	_	SpaceAfter=No
 27	.	$.	PUNCT	clb	_	6	punct	_	_
@@ -30538,7 +30538,7 @@
 11	de	de	DET	det	Number=Plur|PronType=Art	12	det	_	_
 12	store	stor	ADJ	adj	Degree=Pos|Number=Plur	9	amod	_	_
 13	i	i	ADP	prep	_	15	case	_	_
-14	internasjonal	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	internasjonal	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	luftfart	luftfart	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nmod	_	_
 16	opprette	opprette	VERB	verb	VerbForm=Inf	0	root	_	_
 17	direkte	direkte	ADJ	adj	Degree=Pos|Number=Plur	18	amod	_	_
@@ -30619,7 +30619,7 @@
 17	,	$,	PUNCT	<komma>	_	21	punct	_	_
 18	og	og	CCONJ	konj	_	21	cc	_	_
 19	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
-20	rimelig	rimelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	21	amod	_	_
+20	rimelig	rimelig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	21	amod	_	_
 21	grad	grad	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	conj	_	_
 22	av	av	ADP	prep	_	23	case	_	_
 23	service	service	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
@@ -30632,7 +30632,7 @@
 30	at	at	SCONJ	sbu	_	33	mark	_	_
 31	noen	noen	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Ind,Prs	33	nsubj	_	_
 32	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	33	cop	_	_
-33	villig	villig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	advcl	_	_
+33	villig	villig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	advcl	_	_
 34	til	til	ADP	prep	_	36	case	_	_
 35	å	å	PART	inf-merke	_	36	mark	_	_
 36	betale	betale	VERB	verb	VerbForm=Inf	33	advcl	_	_
@@ -30673,14 +30673,14 @@
 11	i	i	ADP	prep	_	12	case	_	_
 12	Luftfartstilsynet	Luftfartstilsynet	PROPN	subst	_	10	nmod	_	_
 13	for	for	ADP	prep	_	15	case	_	_
-14	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	kort	kort	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	tid	tid	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	6	nmod	_	_
 16	siden	siden	ADV	adv	_	15	advmod	_	SpaceAfter=No
 17	,	$,	PUNCT	<komma>	_	21	punct	_	_
 18	hvor	hvor	ADV	adv	_	21	advmod	_	_
 19	skepsisen	skepsis	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	21	nsubj	_	_
 20	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	21	cop	_	_
-21	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+21	stor	stor	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 22	til	til	ADP	prep	_	23	case	_	_
 23	oppblomstringen	oppblomstring	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	21	obl	_	_
 24	av	av	ADP	prep	_	26	case	_	_
@@ -30716,7 +30716,7 @@
 1	Konklusjonen	konklusjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	derfor	derfor	ADV	adv	_	4	advmod	_	_
-4	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+4	klar	klar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 5	:	$:	PUNCT	clb	_	4	punct	_	_
 
 # sent_id = 019777
@@ -30731,7 +30731,7 @@
 8	flere	mange	ADJ	adj	Degree=Cmp	9	amod	_	_
 9	aktører	aktør	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	10	nsubj	_	_
 10	blir	bli	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	1	dislocated	_	_
-11	interessert	interessere	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	10	xcomp	_	_
+11	interessert	interessere	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	10	xcomp	_	_
 12	i	i	ADP	prep	_	15	case	_	_
 13	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	15	det	_	_
 14	norske	norsk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	15	amod	_	_
@@ -30775,7 +30775,7 @@
 3	arbeidsplasser	arbeidsplass	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	2	obj	_	_
 4	-	$-	PUNCT	<strek>	_	7	punct	_	_
 5	og	og	CCONJ	konj	_	7	cc	_	_
-6	fornybar	fornybar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	fornybar	fornybar	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	energi	energi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	conj	_	SpaceAfter=No
 8	!	$!	PUNCT	clb	_	2	punct	_	_
 
@@ -30845,7 +30845,7 @@
 1	Han	han	PRON	pron	Animacy=Hum|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	deltar	delta	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	etter	etter	ADP	prep	_	5	case	_	_
-4	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	det	_	_
+4	mitt	min	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	5	nmod:poss	_	_
 5	syn	syn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	2	obl	_	_
 6	i	i	ADP	prep	_	7	case	_	_
 7	hylekoret	hylekor	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	2	obl	_	_
@@ -30914,7 +30914,7 @@
 10	ut	ut	ADP	prep	_	12	case	_	_
 11	av	av	ADP	prep	_	12	case	_	_
 12	bosset	boss	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	obl	_	_
-13	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	12	det	_	SpaceAfter=No
+13	vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	12	nmod:poss	_	SpaceAfter=No
 14	.	$.	PUNCT	clb	_	2	punct	_	_
 
 # sent_id = 019787
@@ -30933,10 +30933,10 @@
 12	fortauene	fortau	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	10	obj	_	_
 13	i	i	ADP	prep	_	14	case	_	_
 14	byene	by	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	12	nmod	_	_
-15	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	14	det	_	_
+15	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	14	nmod:poss	_	_
 16	med	med	ADP	prep	_	19	case	_	_
-17	høyverdig	høyverdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
-18	elektrisk	elektrisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	_
+17	høyverdig	høyverdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
+18	elektrisk	elektrisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	_
 19	kraft	kraft	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	obl	_	SpaceAfter=No
 20	.	$.	PUNCT	clb	_	6	punct	_	_
 
@@ -30955,7 +30955,7 @@
 11	vann	vann	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	8	obj	_	_
 12	i	i	ADP	prep	_	13	case	_	_
 13	fjordene	fjord	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	8	obl	_	_
-14	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	det	_	_
+14	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	13	nmod:poss	_	_
 15	og	og	CCONJ	konj	_	18	cc	_	_
 16	dermed	dermed	ADV	adv	_	18	advmod	_	_
 17	kunne	kunne	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	18	aux	_	_
@@ -31001,7 +31001,7 @@
 6	;	$;	PUNCT	clb	_	8	punct	_	_
 7	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	expl	_	_
 8	monteres	montere	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	3	conj	_	_
-9	varmepumper	varmepumpe	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	8	nsubj	_	_
+9	varmepumper	varmepumpe	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	8	nsubj:pass	_	_
 10	som	som	ADP	prep	_	11	case	_	_
 11	aldri	aldri	ADV	adv	_	8	advmod	_	_
 12	før	før	ADV	prep	_	11	advmod	_	_
@@ -31017,7 +31017,7 @@
 # text = Norge har mye skog.
 1	Norge	Norge	PROPN	subst	_	2	nsubj	_	_
 2	har	ha	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	skog	skog	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	SpaceAfter=No
 5	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -31168,7 +31168,7 @@
 26	og	og	CCONJ	konj	_	30	cc	_	_
 27	faktisk	faktisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	28	advmod	_	_
 28	like	like	ADV	adv	_	29	advmod	_	_
-29	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	30	amod	_	_
+29	mye	mye	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	30	amod	_	_
 30	energi	energi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	21	conj	_	_
 31	som	som	SCONJ	sbu	_	34	mark	_	_
 32	20	20	NUM	det	Number=Plur|NumType=Card	33	nummod	_	_
@@ -31201,7 +31201,7 @@
 5	bioenergi	bioenergi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 6	som	som	ADP	prep	_	9	case	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	industrinæring	industrinæring	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	xcomp	_	_
 10	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	_	_
 11	satsinga	satsing	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	12	nsubj	_	_
@@ -31217,9 +31217,9 @@
 21	slipper	slippe	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	ccomp	_	_
 22	å	å	PART	inf-merke	_	23	mark	_	_
 23	importere	importere	VERB	verb	VerbForm=Inf	21	xcomp	_	_
-24	dyr	dyr	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	27	amod	_	_
+24	dyr	dyr	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	27	amod	_	_
 25	og	og	CCONJ	konj	_	26	cc	_	_
-26	skitten	skitten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	24	conj	_	_
+26	skitten	skitten	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	24	conj	_	_
 27	kullkraft	kullkraft	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	23	obj	_	SpaceAfter=No
 28	.	$.	PUNCT	clb	_	12	punct	_	_
 
@@ -31245,7 +31245,7 @@
 
 # sent_id = 019804
 # text = Gardermoen hovedflyplass blir i dag oppvarmet av flis.
-1	Gardermoen	Gardermoen	PROPN	subst	Gender=Masc	6	nsubj	_	_
+1	Gardermoen	Gardermoen	PROPN	subst	Gender=Masc	6	nsubj:pass	_	_
 2	hovedflyplass	hovedflyplass	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	flat:name	_	_
 3	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux:pass	_	_
 4	i	i	ADP	prep	_	5	case	_	_
@@ -31257,7 +31257,7 @@
 
 # sent_id = 019805
 # text = Eidskog kommunes biovarmesentral gir varme til de fleste offentlige byggene i sentrum, så som alders- og sjukehjemmet, ungdomsskolen, biblioteket/servicebygget m.fl
-1	Eidskog	Eidskog	PROPN	subst	_	3	nmod	_	_
+1	Eidskog	Eidskog	PROPN	subst	_	3	nmod:poss	_	_
 2	kommunes	kommune	NOUN	subst	Case=Gen|Definite=Ind|Gender=Masc|Number=Sing	1	flat:name	_	_
 3	biovarmesentral	biovarmesentral	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	nsubj	_	_
 4	gir	gi	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -31329,7 +31329,7 @@
 11	seks	seks	NUM	det	Number=Plur|NumType=Card	12	nummod	_	_
 12	prosent	prosent	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	7	conj	_	_
 13	av	av	ADP	prep	_	15	case	_	_
-14	samla	samle	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	15	amod	_	_
+14	samla	samle	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	15	amod	_	_
 15	energiproduksjon	energiproduksjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
 16	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -31354,7 +31354,7 @@
 # sent_id = 019809
 # text = En økt satsing på bioenergi i Norge kan gi over 4.000 nye arbeidsplasser innen 2010.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	økt	øke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	3	amod	_	_
+2	økt	øke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	3	amod	_	_
 3	satsing	satsing	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	9	nsubj	_	_
 4	på	på	ADP	prep	_	5	case	_	_
 5	bioenergi	bioenergi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	nmod	_	_
@@ -31384,7 +31384,7 @@
 3	sier	si	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	at	at	SCONJ	sbu	_	11	mark	_	_
 5	«	$"	PUNCT	<anf>	_	11	punct	_	SpaceAfter=No
-6	økt	øke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	7	amod	_	_
+6	økt	øke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	7	amod	_	_
 7	bruk	bruk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	nsubj	_	_
 8	av	av	ADP	prep	_	9	case	_	_
 9	bioenergi	bioenergi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nmod	_	_
@@ -31433,7 +31433,7 @@
 # text = Hele 70 prosent av det norske oppvarmingsbehovet i dag blir dekket med elektrisitet, så hvis mange går over til bioenergi vil det frigjøre store mengder elektrisitet, redusere følsomheten for svingninger i strømprisen og attpåtil være bra for klimapolitikken.
 1	Hele	hel	ADJ	adj	Degree=Pos|Number=Plur	3	amod	_	_
 2	70	70	NUM	det	Number=Plur|NumType=Card	3	nummod	_	_
-3	prosent	prosent	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	11	nsubj	_	_
+3	prosent	prosent	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	11	nsubj:pass	_	_
 4	av	av	ADP	prep	_	7	case	_	_
 5	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
 6	norske	norsk	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	7	amod	_	_
@@ -31468,7 +31468,7 @@
 35	og	og	CCONJ	konj	_	38	cc	_	_
 36	attpåtil	attpåtil	ADV	adv	_	38	advmod	_	_
 37	være	være	AUX	verb	VerbForm=Inf	38	cop	_	_
-38	bra	bra	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	24	conj	_	_
+38	bra	bra	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	24	conj	_	_
 39	for	for	ADP	prep	_	40	case	_	_
 40	klimapolitikken	klimapolitikk	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	38	obl	_	SpaceAfter=No
 41	.	$.	PUNCT	clb	_	11	punct	_	_
@@ -31483,7 +31483,7 @@
 6	får	få	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
 8	satsing	satsing	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
-9	lik	lik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+9	lik	lik	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 10	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	9	obj	_	_
 11	i	i	ADP	prep	_	12	case	_	_
 12	Sverige	Sverige	PROPN	subst	_	10	nmod	_	_
@@ -31540,7 +31540,7 @@
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
 6	selvfølge	selvfølge	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 7	at	at	SCONJ	sbu	_	15	mark	_	_
-8	lokal	lokal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	nsubj	_	_
+8	lokal	lokal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	nsubj	_	_
 9	og	og	CCONJ	konj	_	10	cc	_	_
 10	fylkespolitikerne	fylkespolitiker	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	8	conj	_	_
 11	i	i	ADP	prep	_	12	case	_	_
@@ -31560,7 +31560,7 @@
 25	bygg	bygg	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	22	obj	_	_
 26	så	så	ADV	adv	_	29	advmod	_	_
 27	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	29	aux	_	_
-28	flis	flis	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	29	nsubj	_	_
+28	flis	flis	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	29	nsubj:pass	_	_
 29	vurderes	vurdere	VERB	verb	VerbForm=Inf|Voice=Pass	15	xcomp	_	_
 30	som	som	ADP	prep	_	31	case	_	_
 31	energikilde	energikilde	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	29	xcomp	_	SpaceAfter=No
@@ -31660,7 +31660,7 @@
 
 # sent_id = 019822
 # text = Bruk av virkemidler som kan virke støtende på mange må også tåles i et demokrati.
-1	Bruk	bruk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nsubj	_	_
+1	Bruk	bruk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	nsubj:pass	_	_
 2	av	av	ADP	prep	_	3	case	_	_
 3	virkemidler	virkemiddel	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	1	nmod	_	_
 4	som	som	SCONJ	sbu	_	6	mark	_	_
@@ -31725,7 +31725,7 @@
 11	verne	verne	VERB	verb	VerbForm=Inf	5	conj	_	_
 12	om	om	ADP	prep	_	15	case	_	_
 13	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
-14	verdig	verdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	verdig	verdig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	debattform	debattform	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	2	punct	_	_
 17	bør	burde	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	20	aux	_	_
@@ -31774,7 +31774,7 @@
 10	at	at	SCONJ	sbu	_	15	mark	_	_
 11	dette	dette	DET	det	Gender=Neut|Number=Sing|PronType=Dem	13	det	_	_
 12	vanskelige	vanskelig	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	13	amod	_	_
-13	valget	valg	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	15	nsubj	_	_
+13	valget	valg	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	15	nsubj:pass	_	_
 14	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	_	_
 15	tas	ta	VERB	verb	VerbForm=Inf|Voice=Pass	9	xcomp	_	_
 16	av	av	ADP	prep	_	17	case	_	_
@@ -31790,7 +31790,7 @@
 4	dagens	dag	NOUN	subst	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 5	grense	grense	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obj	_	_
 6	for	for	ADP	prep	_	8	case	_	_
-7	selvbestemt	selvbestemt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	selvbestemt	selvbestemt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	abort	abort	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nmod	_	_
 9	på	på	ADP	prep	_	11	case	_	_
 10	12	12	NUM	det	Number=Plur|NumType=Card	11	nummod	_	_
@@ -31849,7 +31849,7 @@
 1	Ja	ja	INTJ	interj	_	0	root	_	_
 2	til	til	ADP	prep	_	5	case	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	stabil	stabil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	stabil	stabil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	fiskeripolitikk	fiskeripolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	obl	_	_
 
 # newpar
@@ -31871,12 +31871,12 @@
 
 # sent_id = 019831
 # text = Nåværende fiskeriminister Svein Ludvigsen og hans kanskje fremste utfordrer, Senterpartiets Lars Peder Brekk, møtes til holmgang i Sunnmørshallen sammen med fremtredende stortingsrepresentanter fra Møre og Romsdal .
-1	Nåværende	nåværende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Nåværende	nåværende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	fiskeriminister	fiskeriminister	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	nsubj	_	_
 3	Svein	Svein	PROPN	subst	Gender=Masc	2	flat:name	_	_
 4	Ludvigsen	Ludvigsen	PROPN	subst	_	2	flat:name	_	_
 5	og	og	CCONJ	konj	_	9	cc	_	_
-6	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	det	_	_
+6	hans	hans	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 7	kanskje	kanskje	ADV	adv	_	8	advmod	_	_
 8	fremste	fremre	ADJ	adj	Definite=Def|Degree=Sup	9	amod	_	_
 9	utfordrer	utfordrer	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	conj	_	SpaceAfter=No
@@ -31938,7 +31938,7 @@
 4	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	_	_
 5	Stortinget	Stortinget	PROPN	subst	Gender=Neut	7	nsubj	_	_
 6	vært	være	AUX	verb	VerbForm=Part	7	cop	_	_
-7	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+7	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 8	i	i	ADP	prep	_	9	case	_	_
 9	målsettingene	målsetting	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	7	obl	_	_
 10	om	om	ADP	prep	_	12	case	_	_
@@ -31954,7 +31954,7 @@
 2	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 3	selv	selv	ADV	adv	_	4	advmod	_	_
 4	blitt	bli	VERB	verb	VerbForm=Part	0	root	_	_
-5	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	xcomp	_	_
+5	enig	enig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	xcomp	_	_
 6	om	om	ADP	prep	_	7	case	_	_
 7	fordeling	fordeling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	obl	_	_
 8	av	av	ADP	prep	_	9	case	_	_
@@ -31966,7 +31966,7 @@
 14	,	$,	PUNCT	<komma>	_	20	punct	_	_
 15	og	og	CCONJ	konj	_	20	cc	_	_
 16	dette	dette	DET	det	Gender=Neut|Number=Sing|PronType=Dem	17	det	_	_
-17	forliket	forlik	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	20	nsubj	_	_
+17	forliket	forlik	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	20	nsubj:pass	_	_
 18	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	20	cop	_	_
 19	blitt	bli	AUX	verb	VerbForm=Part	20	aux:pass	_	_
 20	respektert	respektere	VERB	verb	VerbForm=Part	4	conj	_	SpaceAfter=No
@@ -32075,7 +32075,7 @@
 
 # sent_id = 019841
 # text = Torskekvoten i Barentshavet blir satt 20 prosent lavere enn den elles ville ha blitt gjort fordi forskerne tar høyde for tjuvfisket i sine anbefalinger.
-1	Torskekvoten	torskekvote	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
+1	Torskekvoten	torskekvote	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj:pass	_	_
 2	i	i	ADP	prep	_	3	case	_	_
 3	Barentshavet	Barentshavet	PROPN	subst	Gender=Neut	1	nmod	_	_
 4	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux:pass	_	_
@@ -32084,7 +32084,7 @@
 7	prosent	prosent	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	8	obl	_	_
 8	lavere	lav	ADJ	adj	Degree=Cmp	5	advmod	_	_
 9	enn	enn	SCONJ	sbu	_	15	mark	_	_
-10	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
+10	den	den	PRON	pron	Gender=Fem,Masc|Number=Sing|Person=3|PronType=Prs	15	nsubj:pass	_	_
 11	elles	elles	ADV	adv	_	15	advmod	_	_
 12	ville	ville	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	15	aux	_	_
 13	ha	ha	AUX	verb	VerbForm=Inf	15	aux	_	_
@@ -32097,7 +32097,7 @@
 20	for	for	ADP	prep	_	21	case	_	_
 21	tjuvfisket	tjuvfiske	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	19	nmod	_	_
 22	i	i	ADP	prep	_	24	case	_	_
-23	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	24	det	_	_
+23	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	24	nmod:poss	_	_
 24	anbefalinger	anbefaling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	18	obl	_	SpaceAfter=No
 25	.	$.	PUNCT	clb	_	5	punct	_	_
 
@@ -32111,7 +32111,7 @@
 6	lavere	lav	ADJ	adj	Degree=Cmp	7	amod	_	_
 7	priser	pris	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	3	obj	_	_
 8	på	på	ADP	prep	_	10	case	_	_
-9	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	det	_	_
+9	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	10	nmod:poss	_	_
 10	produkt	produkt	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	3	obl	_	_
 11	på	på	ADP	prep	_	12	case	_	_
 12	markedet	marked	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	obl	_	_
@@ -32202,7 +32202,7 @@
 4	et	en	DET	det	Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
 5	øre	øre	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	2	obj	_	_
 6	i	i	ADP	prep	_	8	case	_	_
-7	statlig	statlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	statlig	statlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	støtte	støtte	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -32211,7 +32211,7 @@
 1	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	obl	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	_	_
-4	fornøyd	fornøyd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	_
+4	fornøyd	fornøyd	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	_
 5	med	med	ADP	prep	_	1	case	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	12	punct	_	_
 7	men	men	CCONJ	konj	_	12	cc	_	_
@@ -32241,7 +32241,7 @@
 7	åpnet	åpne	VERB	verb	Mood=Ind|Tense=Past|VerbForm=Fin	2	advcl	_	_
 8	for	for	ADP	prep	_	12	case	_	_
 9	at	at	SCONJ	sbu	_	12	mark	_	_
-10	kvoter	kvote	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	12	nsubj	_	_
+10	kvoter	kvote	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	12	nsubj:pass	_	_
 11	kunne	kunne	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	12	aux	_	_
 12	slås	slå	VERB	verb	VerbForm=Inf|Voice=Pass	7	advcl	_	_
 13	sammen	sammen	ADV	adv	_	12	advmod	_	_
@@ -32314,7 +32314,7 @@
 12	tryggere	trygg	ADJ	adj	Degree=Cmp	11	xcomp	_	_
 13	og	og	CCONJ	konj	_	19	cc	_	_
 14	at	at	SCONJ	sbu	_	19	mark	_	_
-15	fornyingskraften	fornyingskraft	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	19	nsubj	_	_
+15	fornyingskraften	fornyingskraft	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	19	nsubj:pass	_	_
 16	i	i	ADP	prep	_	17	case	_	_
 17	flåten	flåte	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	_
 18	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux:pass	_	_
@@ -32323,7 +32323,7 @@
 
 # sent_id = 019854
 # text = Rød-grønn protest
-1	Rød-grønn	rød-grønn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	2	amod	_	_
+1	Rød-grønn	rød-grønn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	2	amod	_	_
 2	protest	protest	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 
 # sent_id = 019855
@@ -32408,7 +32408,7 @@
 7	nye	ny	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	8	amod	_	_
 8	ordningen	ordning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 9	politikerne	politiker	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	10	obl	_	_
-10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	det	_	_
+10	sin	sin	PRON	det	Gender=Masc|Number=Sing|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	styringsrett	styringsrett	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 12	over	over	ADP	prep	_	16	case	_	_
 13	hvem	hvem	PRON	pron	Animacy=Hum|PronType=Int	16	nsubj	_	_
@@ -32478,7 +32478,7 @@
 1	Fisken	fisk	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	nasjonal	nasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	nasjonal	nasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	ressurs	ressurs	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 6	på	på	ADP	prep	_	7	case	_	_
 7	linje	linje	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	nmod	_	_
@@ -32662,7 +32662,7 @@
 19	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	23	cop	_	_
 20	i	i	ADP	prep	_	23	case	_	_
 21	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
-22	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	23	amod	_	_
+22	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	23	amod	_	_
 23	forfatning	forfatning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 24	.	$.	PUNCT	clb	_	7	punct	_	_
 
@@ -32676,7 +32676,7 @@
 6	Norge	Norge	PROPN	subst	_	7	nsubj	_	_
 7	ført	føre	VERB	verb	VerbForm=Part	0	root	_	_
 8	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-9	tøff	tøff	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	tøff	tøff	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	linje	linje	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	obj	_	_
 11	i	i	ADP	prep	_	13	case	_	_
 12	internasjonale	internasjonal	ADJ	adj	Degree=Pos|Number=Plur	13	amod	_	_
@@ -32690,7 +32690,7 @@
 20	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	7	conj	_	_
 21	at	at	SCONJ	sbu	_	25	mark	_	_
 22	denne	denne	DET	det	Gender=Masc|Number=Sing|PronType=Dem	23	det	_	_
-23	linjen	linje	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	25	nsubj	_	_
+23	linjen	linje	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	25	nsubj:pass	_	_
 24	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	25	aux:pass	_	_
 25	ført	føre	VERB	verb	VerbForm=Part	20	csubj	_	_
 26	videre	vid	ADJ	adj	Degree=Cmp	25	advmod	_	SpaceAfter=No
@@ -32705,7 +32705,7 @@
 5	av	av	ADP	prep	_	6	case	_	_
 6	silda	sild	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	4	nmod	_	_
 7	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	_	_
-8	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	advcl	_	SpaceAfter=No
+8	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	advcl	_	SpaceAfter=No
 9	-	$-	PUNCT	<strek>	_	8	punct	_	_
 10	går	gå	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	18	dislocated	_	_
 11	i	i	ADP	prep	_	13	case	_	_
@@ -32750,7 +32750,7 @@
 # text = Vi er bekymret for rekrutteringen til flåten.
 1	Vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	bekymret	bekymre	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	0	root	_	_
+3	bekymret	bekymre	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	0	root	_	_
 4	for	for	ADP	prep	_	5	case	_	_
 5	rekrutteringen	rekruttering	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
 6	til	til	ADP	prep	_	7	case	_	_
@@ -32916,7 +32916,7 @@
 11	for	for	ADP	prep	_	12	case	_	_
 12	helsa	helse	NOUN	subst	Definite=Def|Gender=Fem|Number=Sing	10	nmod	_	_
 13	til	til	ADP	prep	_	15	case	_	_
-14	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	15	det	_	_
+14	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	15	nmod:poss	_	_
 15	barn	barn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	12	nmod	_	_
 16	og	og	CCONJ	konj	_	17	cc	_	_
 17	barnebarn	barnebarn	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	15	conj	_	SpaceAfter=No
@@ -32929,7 +32929,7 @@
 3	muggsopp	muggsopp	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	1	conj	_	SpaceAfter=No
 4	,	$,	PUNCT	<komma>	_	7	punct	_	_
 5	og	og	CCONJ	konj	_	7	cc	_	_
-6	farlig	farlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	farlig	farlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	inneluft	inneluft	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	1	conj	_	_
 8	preger	prege	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 9	hverdagen	hverdag	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	obj	_	_
@@ -32944,7 +32944,7 @@
 # sent_id = 019887
 # text = Fattige kommuner blir nå tilbudt lån fra den fattige norske stat til å oppruste skolene.
 1	Fattige	fattig	ADJ	adj	Degree=Pos|Number=Plur	2	amod	_	_
-2	kommuner	kommune	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	nsubj	_	_
+2	kommuner	kommune	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	nsubj:pass	_	_
 3	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux:pass	_	_
 4	nå	nå	ADV	adv	_	5	advmod	_	_
 5	tilbudt	tilby	VERB	verb	VerbForm=Part	0	root	_	_
@@ -33031,7 +33031,7 @@
 1	Lokalpolitikeren	lokalpolitiker	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 2	sitter	sitte	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	med	med	ADP	prep	_	5	case	_	_
-4	tom	tom	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	tom	tom	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	verktøykasse	verktøykasse	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	2	obl	_	_
 6	mens	mens	SCONJ	sbu	_	8	mark	_	_
 7	rikspolitikeren	rikspolitiker	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
@@ -33121,7 +33121,7 @@
 # text = - Ingen personer ble skadd, men lastebåten gikk til bunns, opplyser redningsleder Eric Willassen ved Hovedredningssentralen Sør-Norge (HRS) til NTB.
 1	-	$-	PUNCT	<strek>	_	5	punct	_	_
 2	Ingen	ingen	DET	det	Number=Plur|Polarity=Neg	3	det	_	_
-3	personer	person	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	nsubj	_	_
+3	personer	person	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	5	nsubj:pass	_	_
 4	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	skadd	skade	VERB	verb	VerbForm=Part	13	ccomp	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	9	punct	_	_
@@ -33167,7 +33167,7 @@
 
 # sent_id = 019899
 # text = Mannskapet i lasteskipet ble raskt tatt om bord i fiskebåten, samtidig som to redningsskøyter gikk mot stedet.
-1	Mannskapet	mannskap	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	nsubj	_	_
+1	Mannskapet	mannskap	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	6	nsubj:pass	_	_
 2	i	i	ADP	prep	_	3	case	_	_
 3	lasteskipet	lasteskip	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	1	nmod	_	_
 4	ble	bli	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
@@ -33259,7 +33259,7 @@
 8	men	men	CCONJ	konj	_	12	cc	_	_
 9	med	med	ADP	prep	_	12	case	_	_
 10	litt	litt	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	11	advmod	_	_
-11	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+11	dårlig	dårlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	sikt	sikt	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	conj	_	_
 13	på	på	ADP	prep	_	14	case	_	_
 14	grunn	grunn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obl	_	_
@@ -33325,7 +33325,7 @@
 3	Sør-Trøndelag	Sør-Trøndelag	PROPN	subst	_	1	nmod	_	_
 4	frykter	frykte	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 5	at	at	SCONJ	sbu	_	13	mark	_	_
-6	byggingen	bygging	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	_
+6	byggingen	bygging	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	nsubj:pass	_	_
 7	av	av	ADP	prep	_	10	case	_	_
 8	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
 9	nye	ny	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	10	amod	_	_
@@ -33376,7 +33376,7 @@
 2	var	være	AUX	verb	Mood=Ind|Tense=Past|VerbForm=Fin	13	cop	_	_
 3	planen	plan	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	13	nsubj:outer	_	_
 4	at	at	SCONJ	sbu	_	13	mark	_	_
-5	byggefase	byggefase	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nsubj	_	_
+5	byggefase	byggefase	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	13	nsubj:pass	_	_
 6	to	to	NUM	det	Number=Plur|NumType=Card	5	nmod	_	_
 7	av	av	ADP	prep	_	9	case	_	_
 8	nye	ny	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	9	amod	_	_
@@ -33402,7 +33402,7 @@
 5	nå	nå	ADV	adv	_	6	advmod	_	_
 6	ta	ta	VERB	verb	VerbForm=Inf	0	root	_	_
 7	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	runde	runde	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	6	obj	_	_
 10	på	på	ADP	prep	_	11	case	_	_
 11	rammene	ramme	NOUN	subst	Definite=Def|Gender=Fem|Number=Plur	6	obl	_	_
@@ -33492,7 +33492,7 @@
 
 # sent_id = 019916
 # text = Vi er blitt lovet et topp moderne sykehus og risikerer å sitte igjen med et halvferdig sykehus.
-1	Vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	_	_
+1	Vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj:pass	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	blitt	bli	AUX	verb	VerbForm=Part	4	aux:pass	_	_
 4	lovet	love	VERB	verb	VerbForm=Part	0	root	_	_
@@ -33575,7 +33575,7 @@
 5	for	for	ADP	prep	_	6	case	_	_
 6	alle	alle	PRON	pron	Number=Plur|Person=3|PronType=Prs,Tot	4	nmod	_	_
 7	og	og	CCONJ	konj	_	9	cc	_	_
-8	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	9	amod	_	_
+8	felles	felles	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	9	amod	_	_
 9	velferd	velferd	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	conj	_	_
 10	framfor	framfor	ADP	prep	_	12	case	_	_
 11	nye	ny	ADJ	adj	Degree=Pos|Number=Plur	12	amod	_	_
@@ -33589,8 +33589,8 @@
 3	sikre	sikre	VERB	verb	VerbForm=Inf	8	advcl	_	_
 4	velferden	velferd	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	3	obj	_	_
 5	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	_	_
-6	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
-7	sektor	sektor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nsubj	_	_
+6	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
+7	sektor	sektor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nsubj:pass	_	_
 8	styrkes	styrke	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	8	punct	_	_
 
@@ -33598,8 +33598,8 @@
 # text = Derfor må offentlig sektor fornyes og utvikles.
 1	Derfor	derfor	ADV	adv	_	5	advmod	_	_
 2	må	måtte	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
-3	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
-4	sektor	sektor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj	_	_
+3	offentlig	offentlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
+4	sektor	sektor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj:pass	_	_
 5	fornyes	fornye	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 6	og	og	CCONJ	konj	_	7	cc	_	_
 7	utvikles	utvikle	VERB	verb	VerbForm=Inf|Voice=Pass	5	conj	_	SpaceAfter=No
@@ -33643,7 +33643,7 @@
 # sent_id = 019925
 # text = Ingen lokalsykehus skal legges ned.
 1	Ingen	ingen	DET	det	Number=Plur|Polarity=Neg	2	det	_	_
-2	lokalsykehus	lokalsykehus	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	4	nsubj	_	_
+2	lokalsykehus	lokalsykehus	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	4	nsubj:pass	_	_
 3	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	_	_
 4	legges	legge	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 5	ned	ned	ADV	prep	_	4	advmod	_	SpaceAfter=No
@@ -33665,7 +33665,7 @@
 12	noe	noe	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Ind,Prs	3	dislocated	_	_
 13	som	som	SCONJ	sbu	_	14	mark	_	_
 14	fremmer	fremme	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	acl:relcl	_	_
-15	styrket	styrke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	16	amod	_	_
+15	styrket	styrke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	16	amod	_	_
 16	kvalitet	kvalitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	obj	_	_
 17	i	i	ADP	prep	_	18	case	_	_
 18	pasientbehandlingen	pasientbehandling	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	SpaceAfter=No
@@ -33673,7 +33673,7 @@
 
 # sent_id = 019927
 # text = Tilbudet til mennesker med psykiske lidelser skal bedres ved at opptrappingsplanen for psykisk helse blir gjennomført.
-1	Tilbudet	tilbud	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	8	nsubj	_	_
+1	Tilbudet	tilbud	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	8	nsubj:pass	_	_
 2	til	til	ADP	prep	_	3	case	_	_
 3	mennesker	menneske	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	1	nmod	_	_
 4	med	med	ADP	prep	_	6	case	_	_
@@ -33683,9 +33683,9 @@
 8	bedres	bedre	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 9	ved	ved	ADP	prep	_	16	case	_	_
 10	at	at	SCONJ	sbu	_	16	mark	_	_
-11	opptrappingsplanen	opptrappingsplan	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	16	nsubj	_	_
+11	opptrappingsplanen	opptrappingsplan	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	16	nsubj:pass	_	_
 12	for	for	ADP	prep	_	14	case	_	_
-13	psykisk	psykisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	14	amod	_	_
+13	psykisk	psykisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	14	amod	_	_
 14	helse	helse	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	nmod	_	_
 15	blir	bli	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	aux:pass	_	_
 16	gjennomført	gjennomføre	VERB	verb	VerbForm=Part	8	advcl	_	SpaceAfter=No
@@ -33697,8 +33697,8 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	utarbeide	utarbeide	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-5	nasjonal	nasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
-6	forpliktende	forpliktende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+5	nasjonal	nasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
+6	forpliktende	forpliktende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	opptrappingsplan	opptrappingsplan	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 8	for	for	ADP	prep	_	9	case	_	_
 9	rusfeltet	rusfelt	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	7	nmod	_	SpaceAfter=No
@@ -33731,7 +33731,7 @@
 
 # sent_id = 019931
 # text = Vårt mål er 10 000 flere ansatte i eldreomsorgen.
-1	Vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	2	det	_	_
+1	Vårt	vår	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 2	mål	mål	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	7	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	_	_
 4	10	10	NUM	det	Number=Plur|NumType=Card	5	compound	_	_
@@ -33775,7 +33775,7 @@
 7	gode	god	ADJ	adj	Degree=Pos|Number=Plur	8	amod	_	_
 8	vilkår	vilkår	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	5	nmod	_	_
 9	for	for	ADP	prep	_	11	case	_	_
-10	frivillig	frivillig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	frivillig	frivillig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	sektor	sektor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nmod	_	_
 12	som	som	ADP	prep	_	14	case	_	_
 13	viktige	viktig	ADJ	adj	Degree=Pos|Number=Plur	14	amod	_	_
@@ -33921,7 +33921,7 @@
 4	barnehager	barnehage	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	2	obl	_	_
 5	som	som	ADP	prep	_	8	case	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	frivillig	frivillig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	frivillig	frivillig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obl	_	_
 9	av	av	ADP	prep	_	10	case	_	_
 10	utdanningsløpet	utdanningsløp	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	8	nmod	_	SpaceAfter=No
@@ -33932,7 +33932,7 @@
 1	Vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	sikre	sikre	VERB	verb	VerbForm=Inf	0	root	_	_
-4	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	barnehagedekning	barnehagedekning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obj	_	SpaceAfter=No
 6	,	$,	PUNCT	<komma>	_	7	punct	_	_
 7	sette	sette	VERB	verb	VerbForm=Inf	3	conj	_	_
@@ -33954,7 +33954,7 @@
 23	i	i	ADP	prep	_	24	case	_	_
 24	barnehage	barnehage	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	22	nmod	_	_
 25	når	når	SCONJ	sbu	_	29	mark	_	_
-26	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	27	amod	_	_
+26	full	full	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	27	amod	_	_
 27	barnehagedekning	barnehagedekning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	29	nsubj	_	_
 28	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	29	cop	_	_
 29	nådd	nå	VERB	verb	VerbForm=Part	19	advcl	_	SpaceAfter=No
@@ -33994,7 +33994,7 @@
 3	legge	legge	VERB	verb	VerbForm=Inf	0	root	_	_
 4	fram	fram	ADV	prep	_	3	advmod	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	helhetlig	helhetlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	helhetlig	helhetlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	plan	plan	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 8	for	for	ADP	prep	_	10	case	_	_
 9	å	å	PART	inf-merke	_	10	mark	_	_
@@ -34042,7 +34042,7 @@
 # sent_id = 019950
 # text = En sosial boligpolitikk skal støtte opp om fattigdomsbekjempelsen.
 1	En	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	sosial	sosial	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	amod	_	_
+2	sosial	sosial	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	amod	_	_
 3	boligpolitikk	boligpolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nsubj	_	_
 4	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 5	støtte	støtte	VERB	verb	VerbForm=Inf	0	root	_	_
@@ -34069,7 +34069,7 @@
 4	på	på	ADP	prep	_	5	case	_	_
 5	prinsippet	prinsipp	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	3	obl	_	_
 6	om	om	ADP	prep	_	8	case	_	_
-7	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	utvikling	utvikling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	nmod	_	_
 9	og	og	CCONJ	konj	_	10	cc	_	_
 10	solidaritet	solidaritet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	conj	_	_
@@ -34117,7 +34117,7 @@
 5	enklere	enkel	ADJ	adj	Degree=Cmp	3	xcomp	_	_
 6	å	å	PART	inf-merke	_	8	mark	_	_
 7	være	være	AUX	verb	VerbForm=Inf	8	cop	_	_
-8	miljøvennlig	miljøvennlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	3	xcomp	_	_
+8	miljøvennlig	miljøvennlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	3	xcomp	_	_
 9	i	i	ADP	prep	_	10	case	_	_
 10	hverdagen	hverdag	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 11	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -34137,7 +34137,7 @@
 
 # sent_id = 019956
 # text = Vefsnavassdraget skal vernes mot kraftutbygging.
-1	Vefsnavassdraget	Vefsnavassdraget	PROPN	subst	_	3	nsubj	_	_
+1	Vefsnavassdraget	Vefsnavassdraget	PROPN	subst	_	3	nsubj:pass	_	_
 2	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	vernes	verne	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 4	mot	mot	ADP	prep	_	5	case	_	_
@@ -34241,13 +34241,13 @@
 5	at	at	SCONJ	sbu	_	17	mark	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
 7	større	stor	ADJ	adj	Degree=Cmp	8	amod	_	_
-8	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	nsubj	_	_
+8	del	del	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	nsubj:pass	_	_
 9	av	av	ADP	prep	_	10	case	_	_
 10	naturgassen	naturgass	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 11	som	som	SCONJ	sbu	_	12	mark	_	_
 12	utvinnes	utvinne	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	10	acl:relcl	_	_
 13	på	på	ADP	prep	_	15	case	_	_
-14	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	norsk	norsk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	sokkel	sokkel	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	12	obl	_	SpaceAfter=No
 16	,	$,	PUNCT	<komma>	_	8	punct	_	_
 17	tas	ta	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	3	advcl	_	_
@@ -34263,7 +34263,7 @@
 27	-transportformål	-transportformål	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	23	conj	_	SpaceAfter=No
 28	,	$,	PUNCT	<komma>	_	23	punct	_	_
 29	innenfor	innenfor	ADP	prep	_	32	case	_	_
-30	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	32	det	_	_
+30	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	32	nmod:poss	_	_
 31	internasjonale	internasjonal	ADJ	adj	Degree=Pos|Number=Plur	32	amod	_	_
 32	klimaforpliktelser	klimaforpliktelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Plur	17	obl	_	SpaceAfter=No
 33	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -34275,7 +34275,7 @@
 3	være	være	AUX	verb	VerbForm=Inf	4	cop	_	_
 4	verdensledende	verdensledende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	0	root	_	_
 5	i	i	ADP	prep	_	7	case	_	_
-6	miljøvennlig	miljøvennlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	miljøvennlig	miljøvennlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	bruk	bruk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	_
 8	av	av	ADP	prep	_	9	case	_	_
 9	naturgass	naturgass	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
@@ -34316,7 +34316,7 @@
 3	sørge	sørge	VERB	verb	VerbForm=Inf	0	root	_	_
 4	for	for	ADP	prep	_	17	case	_	_
 5	at	at	SCONJ	sbu	_	17	mark	_	_
-6	arbeidet	arbeid	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	17	nsubj	_	_
+6	arbeidet	arbeid	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	17	nsubj:pass	_	_
 7	med	med	ADP	prep	_	9	case	_	_
 8	å	å	PART	inf-merke	_	9	mark	_	_
 9	etablere	etablere	VERB	verb	VerbForm=Inf	6	acl	_	_
@@ -34374,7 +34374,7 @@
 20	,	$,	PUNCT	<komma>	_	18	punct	_	_
 21	avgjøres	avgjøre	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	_
 22	hvilke	hvilken	DET	det	Number=Plur|PronType=Int	23	det	_	_
-23	områder	område	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	26	nsubj	_	_
+23	områder	område	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	26	nsubj:pass	_	_
 24	som	som	SCONJ	sbu	_	26	mark	_	_
 25	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	26	aux	_	_
 26	åpnes	åpne	VERB	verb	VerbForm=Inf|Voice=Pass	21	xcomp	_	SpaceAfter=No
@@ -34419,7 +34419,7 @@
 
 # sent_id = 019971
 # text = Velferd og gode vilkår for næringsvirksomhet skapes i et samarbeid mellom næringsliv, arbeidstakere og det offentlige.
-1	Velferd	velferd	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	nsubj	_	_
+1	Velferd	velferd	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	nsubj:pass	_	_
 2	og	og	CCONJ	konj	_	4	cc	_	_
 3	gode	god	ADJ	adj	Degree=Pos|Number=Plur	4	amod	_	_
 4	vilkår	vilkår	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	1	conj	_	_
@@ -34442,7 +34442,7 @@
 # text = Det offentlige virkemiddelapparatet skal styrkes.
 1	Det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
 2	offentlige	offentlig	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	3	amod	_	_
-3	virkemiddelapparatet	virkemiddelapparat	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	5	nsubj	_	_
+3	virkemiddelapparatet	virkemiddelapparat	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	5	nsubj:pass	_	_
 4	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 5	styrkes	styrke	VERB	verb	VerbForm=Inf|Voice=Pass	0	root	_	SpaceAfter=No
 6	.	$.	PUNCT	clb	_	5	punct	_	_
@@ -34457,10 +34457,10 @@
 6	innenfor	innenfor	ADP	prep	_	7	case	_	_
 7	næringsområder	næringsområde	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	3	obl	_	_
 8	som	som	ADP	prep	_	10	case	_	_
-9	marin	marin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	amod	_	_
+9	marin	marin	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	amod	_	_
 10	sektor	sektor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
 11	,	$,	PUNCT	<komma>	_	13	punct	_	_
-12	maritim	maritim	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	maritim	maritim	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	sektor	sektor	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	conj	_	SpaceAfter=No
 14	,	$,	PUNCT	<komma>	_	15	punct	_	_
 15	energi	energi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	10	conj	_	SpaceAfter=No
@@ -34483,7 +34483,7 @@
 9	til	til	ADP	prep	_	10	case	_	_
 10	rette	rett	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	8	advmod	_	_
 11	for	for	ADP	prep	_	13	case	_	_
-12	lønnsom	lønnsom	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+12	lønnsom	lønnsom	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 13	videreforedling	videreforedling	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	10	nmod	_	_
 14	av	av	ADP	prep	_	16	case	_	_
 15	norske	norsk	ADJ	adj	Degree=Pos|Number=Plur	16	amod	_	_
@@ -34497,7 +34497,7 @@
 1	Samferdsel	samferdsel	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	nsubj	_	_
 2	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	amod	_	_
+4	viktig	viktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	amod	_	_
 5	forutsetning	forutsetning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	0	root	_	_
 6	for	for	ADP	prep	_	7	case	_	_
 7	bosetting	bosetting	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	nmod	_	SpaceAfter=No
@@ -34522,7 +34522,7 @@
 
 # sent_id = 019977
 # text = Luftforurensningen i de store byene må reduseres gjennom en satsing på kollektivtransport og på sykkel- og gangveier.
-1	Luftforurensningen	luftforurensning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
+1	Luftforurensningen	luftforurensning	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	7	nsubj:pass	_	_
 2	i	i	ADP	prep	_	5	case	_	_
 3	de	de	DET	det	Number=Plur|PronType=Art	5	det	_	_
 4	store	stor	ADJ	adj	Degree=Pos|Number=Plur	5	amod	_	_
@@ -34547,7 +34547,7 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	gjennomføre	gjennomføre	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	distriktspolitisk	distriktspolitisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	distriktspolitisk	distriktspolitisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	snuoperasjon	snuoperasjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 7	for	for	ADP	prep	_	9	case	_	_
 8	å	å	PART	inf-merke	_	9	mark	_	_
@@ -34571,7 +34571,7 @@
 8	skal	skulle	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux	_	_
 9	det	den	DET	det	Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
 10	store	stor	ADJ	adj	Definite=Def|Degree=Pos|Number=Sing	11	amod	_	_
-11	potensialet	potensial	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	17	nsubj	_	_
+11	potensialet	potensial	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	17	nsubj:pass	_	_
 12	for	for	ADP	prep	_	13	case	_	_
 13	verdiskaping	verdiskaping	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	11	nmod	_	_
 14	i	i	ADP	prep	_	16	case	_	_
@@ -34630,7 +34630,7 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	føre	føre	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	helhetlig	helhetlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	helhetlig	helhetlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	kystpolitikk	kystpolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -34642,7 +34642,7 @@
 4	i	i	ADP	prep	_	5	case	_	_
 5	verk	verk	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	3	obl	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	bred	bred	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	bred	bred	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	utredning	utredning	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 9	for	for	ADP	prep	_	11	case	_	_
 10	å	å	PART	inf-merke	_	11	mark	_	_
@@ -34695,9 +34695,9 @@
 1	Regjeringen	Regjeringen	PROPN	subst	_	2	nsubj	_	_
 2	anser	anse	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-4	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+4	sterk	sterk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 5	og	og	CCONJ	konj	_	6	cc	_	_
-6	sunn	sunn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	conj	_	_
+6	sunn	sunn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	conj	_	_
 7	kommuneøkonomi	kommuneøkonomi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	2	obj	_	_
 8	som	som	ADP	prep	_	10	case	_	_
 9	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
@@ -34714,7 +34714,7 @@
 20	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	21	aux	_	_
 21	gjennomføre	gjennomføre	VERB	verb	VerbForm=Inf	2	conj	_	_
 22	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
-23	flerårig	flerårig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	24	amod	_	_
+23	flerårig	flerårig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	24	amod	_	_
 24	opptrappingsplan	opptrappingsplan	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	21	obj	_	_
 25	for	for	ADP	prep	_	27	case	_	_
 26	å	å	PART	inf-merke	_	27	mark	_	_
@@ -34771,7 +34771,7 @@
 4	ha	ha	VERB	verb	VerbForm=Inf	0	root	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
 6	mer	mye	ADJ	adj	Degree=Cmp	7	advmod	_	_
-7	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	aktiv	aktiv	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	kamp	kamp	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obj	_	_
 9	mot	mot	ADP	prep	_	10	case	_	_
 10	kriminalitet	kriminalitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
@@ -34803,7 +34803,7 @@
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
 5	tilbakeføringsgaranti	tilbakeføringsgaranti	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 6	for	for	ADP	prep	_	8	case	_	_
-7	tett	tett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	tett	tett	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	oppfølging	oppfølging	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	nmod	_	_
 9	ved	ved	ADP	prep	_	10	case	_	_
 10	løslatelse	løslatelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nmod	_	_
@@ -34886,7 +34886,7 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	stimulere	stimulere	VERB	verb	VerbForm=Inf	0	root	_	_
 4	til	til	ADP	prep	_	6	case	_	_
-5	økt	øke	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	6	amod	_	_
+5	økt	øke	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	6	amod	_	_
 6	aktivitet	aktivitet	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 7	innen	innen	ADP	prep	_	8	case	_	_
 8	topp-	topp-	NOUN	subst	_	6	nmod	_	_
@@ -34900,9 +34900,9 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	føre	føre	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-5	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+5	ny	ny	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 6	og	og	CCONJ	konj	_	7	cc	_	_
-7	helhetlig	helhetlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	5	conj	_	_
+7	helhetlig	helhetlig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	5	conj	_	_
 8	frivillighetspolitikk	frivillighetspolitikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	SpaceAfter=No
 9	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -34941,7 +34941,7 @@
 10	kirke	kirke	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	8	flat:name	_	_
 11	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	cop	_	_
 12	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
-13	åpen	åpen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	16	amod	_	_
+13	åpen	åpen	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	16	amod	_	_
 14	og	og	CCONJ	konj	_	15	cc	_	_
 15	inkluderende	inkludere	ADJ	adj	VerbForm=Part	13	conj	_	_
 16	folkekirke	folkekirke	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	5	nmod	_	SpaceAfter=No
@@ -34955,7 +34955,7 @@
 4	opp	opp	ADP	prep	_	8	case	_	_
 5	til	til	ADP	prep	_	8	case	_	_
 6	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	bred	bred	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	8	amod	_	_
+7	bred	bred	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	8	amod	_	_
 8	debatt	debatt	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 9	om	om	ADP	prep	_	10	case	_	_
 10	stat	stat	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	nmod	_	_
@@ -34979,7 +34979,7 @@
 7	til	til	ADP	prep	_	9	case	_	_
 8	å	å	PART	inf-merke	_	9	mark	_	_
 9	utvikle	utvikle	VERB	verb	VerbForm=Inf	6	acl	_	_
-10	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	det	_	_
+10	sine	sin	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	11	nmod:poss	_	_
 11	evner	evne	NOUN	subst	Definite=Ind|Gender=Fem|Number=Plur	9	obj	_	SpaceAfter=No
 12	,	$,	PUNCT	<komma>	_	13	punct	_	_
 13	uavhengig	uavhengig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	9	advmod	_	_
@@ -34988,19 +34988,19 @@
 16	,	$,	PUNCT	<komma>	_	17	punct	_	_
 17	alder	alder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	conj	_	SpaceAfter=No
 18	,	$,	PUNCT	<komma>	_	20	punct	_	_
-19	sosial	sosial	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	amod	_	_
+19	sosial	sosial	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	amod	_	_
 20	bakgrunn	bakgrunn	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	conj	_	SpaceAfter=No
 21	,	$,	PUNCT	<komma>	_	22	punct	_	_
 22	religion	religion	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	conj	_	SpaceAfter=No
 23	,	$,	PUNCT	<komma>	_	25	punct	_	_
-24	etnisk	etnisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	25	amod	_	_
+24	etnisk	etnisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	25	amod	_	_
 25	tilhørighet	tilhørighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	15	conj	_	SpaceAfter=No
 26	,	$,	PUNCT	<komma>	_	27	punct	_	_
 27	hudfarge	hudfarge	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	15	conj	_	SpaceAfter=No
 28	,	$,	PUNCT	<komma>	_	29	punct	_	_
 29	funksjonsnivå	funksjonsnivå	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	15	conj	_	_
 30	og	og	CCONJ	konj	_	32	cc	_	_
-31	seksuell	seksuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	32	amod	_	_
+31	seksuell	seksuell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	32	amod	_	_
 32	orientering	orientering	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	15	conj	_	SpaceAfter=No
 33	.	$.	PUNCT	clb	_	2	punct	_	_
 
@@ -35034,7 +35034,7 @@
 14	at	at	SCONJ	sbu	_	16	mark	_	_
 15	Sametinget	Sametinget	PROPN	subst	_	16	nsubj	_	_
 16	får	få	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	advcl	_	_
-17	reell	reell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	18	amod	_	_
+17	reell	reell	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	18	amod	_	_
 18	innflytelse	innflytelse	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	16	obj	_	_
 19	på	på	ADP	prep	_	20	case	_	_
 20	politikkområder	politikkområde	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	18	nmod	_	_
@@ -35053,13 +35053,13 @@
 2	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	føre	føre	VERB	verb	VerbForm=Inf	0	root	_	_
 4	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	6	amod	_	_
+5	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	6	amod	_	_
 6	politikk	politikk	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obj	_	_
 7	som	som	SCONJ	sbu	_	8	mark	_	_
 8	bidrar	bidra	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	_	_
 9	til	til	ADP	prep	_	12	case	_	_
-10	fortsatt	fortsette	ADJ	adj	Definite=Ind|Gender=Fem,Masc|Number=Sing|VerbForm=Part	12	amod	_	_
-11	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	12	amod	_	_
+10	fortsatt	fortsette	ADJ	adj	Definite=Ind|Gender=Com|Number=Sing|VerbForm=Part	12	amod	_	_
+11	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	12	amod	_	_
 12	vekst	vekst	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 13	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -35106,7 +35106,7 @@
 5	i	i	ADP	prep	_	7	case	_	_
 6	å	å	PART	inf-merke	_	7	mark	_	_
 7	nå	nå	VERB	verb	VerbForm=Inf	4	advcl	_	_
-8	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	9	det	_	_
+8	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	9	nmod:poss	_	_
 9	mål	mål	NOUN	subst	Definite=Ind|Gender=Neut|Number=Plur	7	obj	_	SpaceAfter=No
 10	,	$,	PUNCT	<komma>	_	4	punct	_	_
 11	vil	ville	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	_	_
@@ -35127,16 +35127,16 @@
 # text = Hensynet til lav arbeidsledighet, høy sysselsetting, stabil økonomisk og bærekraftig utvikling er grunnleggende hensyn i Regjeringens økonomiske politikk.
 1	Hensynet	hensyn	NOUN	subst	Definite=Def|Gender=Neut|Number=Sing	16	nsubj	_	_
 2	til	til	ADP	prep	_	4	case	_	_
-3	lav	lav	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	4	amod	_	_
+3	lav	lav	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	4	amod	_	_
 4	arbeidsledighet	arbeidsledighet	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	1	nmod	_	SpaceAfter=No
 5	,	$,	PUNCT	<komma>	_	7	punct	_	_
-6	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	høy	høy	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	sysselsetting	sysselsetting	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	4	conj	_	SpaceAfter=No
 8	,	$,	PUNCT	<komma>	_	13	punct	_	_
-9	stabil	stabil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
-10	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	13	amod	_	_
+9	stabil	stabil	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
+10	økonomisk	økonomisk	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	13	amod	_	_
 11	og	og	CCONJ	konj	_	12	cc	_	_
-12	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	conj	_	_
+12	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	conj	_	_
 13	utvikling	utvikling	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	conj	_	_
 14	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	16	cop	_	_
 15	grunnleggende	grunnleggende	ADJ	adj	Degree=Pos|Number=Plur	16	amod	_	_
@@ -35154,11 +35154,11 @@
 3	bidra	bidra	VERB	verb	VerbForm=Inf	0	root	_	_
 4	til	til	ADP	prep	_	7	case	_	_
 5	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	økonomi	økonomi	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	3	obl	_	_
 8	også	også	ADV	adv	_	11	advmod	_	_
 9	på	på	ADP	prep	_	11	case	_	_
-10	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	11	amod	_	_
+10	lang	lang	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	11	amod	_	_
 11	sikt	sikt	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
 12	.	$.	PUNCT	clb	_	3	punct	_	_
 
@@ -35247,7 +35247,7 @@
 2	har	ha	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	_	_
 3	forvaltet	forvalte	VERB	verb	VerbForm=Part	0	root	_	_
 4	ressursene	ressurs	NOUN	subst	Definite=Def|Gender=Masc|Number=Plur	3	obj	_	_
-5	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	4	det	_	_
+5	våre	vår	PRON	det	Number=Plur|Poss=Yes|PronType=Prs	4	nmod:poss	_	_
 6	langsiktig	langsiktig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	3	advmod	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	11	punct	_	_
 8	og	og	CCONJ	konj	_	11	cc	_	_
@@ -35256,7 +35256,7 @@
 11	sørget	sørge	VERB	verb	VerbForm=Part	3	conj	_	_
 12	for	for	ADP	prep	_	15	case	_	_
 13	en	en	DET	det	Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
-14	jevn	jevn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	15	amod	_	_
+14	jevn	jevn	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	15	amod	_	_
 15	fordeling	fordeling	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	11	obl	_	_
 16	av	av	ADP	prep	_	17	case	_	_
 17	godene	gode	NOUN	subst	Definite=Def|Gender=Neut|Number=Plur	15	nmod	_	SpaceAfter=No
@@ -35277,7 +35277,7 @@
 
 # sent_id = 020014
 # text = Vår oppgave er å gjøre Norge enda bedre - et bedre land å vokse opp i, et bedre land å leve, arbeide og utfolde seg i og et bedre land å bli gammel i under verdige forhold, samtidig som vi ikke blir innadvendte, men engasjerer oss enda sterkere internasjonalt.
-1	Vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	2	det	_	_
+1	Vår	vår	PRON	det	Gender=Fem|Number=Sing|Poss=Yes|PronType=Prs	2	nmod:poss	_	_
 2	oppgave	oppgave	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	å	å	PART	inf-merke	_	5	mark	_	_
@@ -35311,7 +35311,7 @@
 32	land	land	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	12	conj	_	_
 33	å	å	PART	inf-merke	_	34	mark	_	_
 34	bli	bli	VERB	verb	VerbForm=Inf	32	acl	_	_
-35	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	34	xcomp	_	_
+35	gammel	gammel	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	34	xcomp	_	_
 36	i	i	ADV	prep	_	34	advmod	_	_
 37	under	under	ADP	prep	_	39	case	_	_
 38	verdige	verdig	ADJ	adj	Degree=Pos|Number=Plur	39	amod	_	_
@@ -35522,7 +35522,7 @@
 20	som	som	SCONJ	sbu	_	23	mark	_	_
 21	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	23	cop	_	_
 22	mer	mye	ADJ	adj	Degree=Cmp	23	advmod	_	_
-23	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	19	amod	_	SpaceAfter=No
+23	bærekraftig	bærekraftig	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	19	amod	_	SpaceAfter=No
 24	,	$,	PUNCT	<komma>	_	27	punct	_	_
 25	sterkere	sterk	ADJ	adj	Degree=Cmp	26	advmod	_	_
 26	internasjonalt	internasjonal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	27	advmod	_	_
@@ -35557,7 +35557,7 @@
 12	seg	seg	PRON	pron	Case=Acc|PronType=Prs|Reflex=Yes	11	obj	_	_
 13	etter	etter	ADP	prep	_	3	case	_	_
 14	i	i	ADP	prep	_	16	case	_	_
-15	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	16	det	_	_
+15	sitt	sin	PRON	det	Gender=Neut|Number=Sing|Poss=Yes|PronType=Prs	16	nmod:poss	_	_
 16	arbeid	arbeid	NOUN	subst	Definite=Ind|Gender=Neut|Number=Sing	11	obl	_	SpaceAfter=No
 17	.	$.	PUNCT	clb	_	11	punct	_	_
 
@@ -35601,7 +35601,7 @@
 3	foreslå	foreslå	VERB	verb	VerbForm=Inf	0	root	_	_
 4	at	at	SCONJ	sbu	_	7	mark	_	_
 5	Regjeringens	Regjeringen	PROPN	subst	Case=Gen	6	nmod	_	_
-6	erklæring	erklæring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	nsubj	_	_
+6	erklæring	erklæring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	7	nsubj:pass	_	_
 7	legges	legge	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	3	ccomp	_	_
 8	ut	ut	ADP	prep	_	10	case	_	_
 9	til	til	ADP	prep	_	10	case	_	_
@@ -35615,7 +35615,7 @@
 # sent_id = 020029
 # text = - Det anses vedtatt.
 1	-	$-	PUNCT	<strek>	_	3	punct	_	_
-2	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+2	Det	den	PRON	pron	Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj:pass	_	_
 3	anses	anse	VERB	verb	Mood=Ind|Tense=Pres|VerbForm=Fin|Voice=Pass	0	root	_	_
 4	vedtatt	vedta	VERB	verb	VerbForm=Part	3	ccomp	_	SpaceAfter=No
 5	.	$.	PUNCT	clb	_	3	punct	_	_
@@ -35736,12 +35736,12 @@
 3	denne	denne	DET	det	Gender=Masc|Number=Sing|PronType=Dem	4	det	_	_
 4	ressursen	ressurs	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	_
 5	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	_	_
-6	minimal	minimal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	0	root	_	SpaceAfter=No
+6	minimal	minimal	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	0	root	_	SpaceAfter=No
 7	.	$.	PUNCT	clb	_	6	punct	_	_
 
 # sent_id = 020037
 # text = Konvensjonen for bevaring av marine levende ressurser i Antarktis (CCAMLR) ble inngått mellom 25 stater for å koordinere forskningsaktiviteter, som igjen skal gi grunnlag for retningslinjer for fangst og kvotesetting.
-1	Konvensjonen	Konvensjonen	PROPN	subst	_	14	nsubj	_	_
+1	Konvensjonen	Konvensjonen	PROPN	subst	_	14	nsubj:pass	_	_
 2	for	for	ADP	prep	_	1	flat:name	_	_
 3	bevaring	bevaring	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	1	flat:name	_	_
 4	av	av	ADP	prep	_	1	flat:name	_	_
@@ -35778,7 +35778,7 @@
 
 # sent_id = 020038
 # text = Kjell Inge Røkkes Aker Biomarine er nå den største kommersielle krillaktøren i Sørishavet.
-1	Kjell	Kjell	PROPN	subst	Gender=Masc	4	nmod	_	_
+1	Kjell	Kjell	PROPN	subst	Gender=Masc	4	nmod:poss	_	_
 2	Inge	Inge	PROPN	subst	_	1	flat:name	_	_
 3	Røkkes	Røkke	PROPN	subst	Case=Gen	1	flat:name	_	_
 4	Aker	Aker	PROPN	subst	_	11	nsubj	_	_
@@ -35823,7 +35823,7 @@
 3	kan	kunne	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	_	_
 4	vi	vi	PRON	pron	Animacy=Hum|Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	_	_
 5	sikre	sikre	VERB	verb	VerbForm=Inf	13	ccomp	_	_
-6	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	7	amod	_	_
+6	god	god	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	7	amod	_	_
 7	forvaltning	forvaltning	NOUN	subst	Definite=Ind|Gender=Fem|Number=Sing	5	obj	_	_
 8	gjennom	gjennom	ADP	prep	_	11	case	_	_
 9	blant	blant	ADP	prep	_	10	case	_	_
@@ -35836,7 +35836,7 @@
 16	,	$,	PUNCT	<komma>	_	17	punct	_	_
 17	leder	leder	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	14	appos	_	_
 18	for	for	ADP	prep	_	20	case	_	_
-19	miljørådgivende	miljørådgivende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	20	amod	_	_
+19	miljørådgivende	miljørådgivende	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	20	amod	_	_
 20	seksjon	seksjon	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
 21	.	$.	PUNCT	clb	_	13	punct	_	_
 
@@ -35845,7 +35845,7 @@
 1	Siden	siden	SCONJ	sbu	_	4	mark	_	_
 2	forskningsstasjonen	forskningsstasjon	NOUN	subst	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 3	er	være	AUX	verb	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	selvberget	selvberget	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Fem,Masc|Number=Sing	10	advcl	_	_
+4	selvberget	selvberget	ADJ	adj	Definite=Ind|Degree=Pos|Gender=Com|Number=Sing	10	advcl	_	_
 5	med	med	ADP	prep	_	6	case	_	_
 6	strøm	strøm	NOUN	subst	Definite=Ind|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
 7	,	$,	PUNCT	<komma>	_	4	punct	_	_

--- a/rules/rename_deprel_nb.grs
+++ b/rules/rename_deprel_nb.grs
@@ -465,10 +465,7 @@ rule temporal_aux_vare_ha { %problematic when it is changing cop to aux
 rule passive_subject_verbform {
   pattern {
     V [ upos=VERB, Voice=Pass, form=re".*s" ];
-    e: V -[ 1=nsubj|csubj ]-> S;
-  }
-  without {
-    e.2 = pass;
+    e: V -[ 1=nsubj|csubj, !2]-> S;
   }
   commands {
     e.2 = pass;
@@ -480,7 +477,7 @@ rule passive_subject_periphrastic {
   pattern {
     V [ VerbForm=Part ];
     V -[1=aux, 2=pass]-> *;
-    e: V -[ 1=nsubj|csubj, 2<>pass|outer]-> S;
+    e: V -[ 1=nsubj|csubj, !2]-> S;
   }
   commands {
     e.2 = pass;
@@ -490,7 +487,7 @@ rule passive_subject_periphrastic {
 rule inf_obj_control {
   pattern { DEP [ VerbForm=Inf|Part ];
             e: GOV -[ DOBJ | POBJ ]-> DEP; }
-  without {e2: DEP -[nsubj | csubj | nsubj:pass | csubj:pass ]-> SUB;}
+  without {e2: DEP -[1 = nsubj | csubj ]-> SUB;}
   commands { e.label = xcomp }
 }
 
@@ -498,7 +495,7 @@ rule inf_obj_control_aux {
   pattern { D2 [ VerbForm=Inf ];
             e1: GOV -[ DOBJ | POBJ ]-> D1;
             e2: D1 -[cop|aux|aux:pass]-> D2;}
-  without {e3: D1 -[nsubj | csubj | nsubj:pass | csubj:pass ]-> SUB;}
+  without {e3: D1 -[ 1 = nsubj | csubj ]-> SUB;}
   commands { e1.label = xcomp }
 }
 
@@ -548,15 +545,26 @@ rule error_og_adv {
 
 rule multiple_subjects_predicate_clause {
   pattern {
-    e: GOV -[nsubj | csubj ]-> D1;
+    e: GOV -[1 = nsubj | csubj, !2 ]-> D1;
   }
   with {
-    GOV -[nsubj | csubj ]-> D2;
+    GOV -[ 1 = nsubj | csubj ]-> D2;
     D1 << D2
   }
-  without {
+  commands {
     e.2 = outer;
   }
+}
+
+rule multiple_passive_subjects_predicate_clause {
+  pattern {
+    e: GOV -[1 = nsubj | csubj, 2 <> outer]-> D1;
+  }
+  with {
+    GOV -[ 1 = nsubj | csubj ]-> D2;
+    D1 << D2
+  }
+  without { e.2 = outer; }
   commands {
     e.2 = outer;
   }


### PR DESCRIPTION
# Endringer

- Fiks: Reglene som la til `:pass` og `outer` på `nsubj` og `csubj`-relasjoner overskrev hverandre i en evig loop. Legg til ekstra regler som fokuserer på 1 tilfelle av gangen og som eksluderer de tilfellene som allerede er håndtert av en annen regel. 
- legg til `-o` og `-r` flagg til `convert_ndt2ud.sh`-skriptet slik at man kan spesifisere hvilken fil man vil skrive UD-formatet og valideringsrapporten til. Default er `UD_output.conllu` (for -o) og `validation-report.txt` (for -r). 
- Legg til de konverterte UD-filene som er helt oppdaterte med reglene vi har skrevet, som kan kopieres videre til de offisielle UD-repoene. 