### PR TITLE
Fiks report_errors

### DIFF
--- a/src/ndt2ud/__init__.py
+++ b/src/ndt2ud/__init__.py
@@ -114,7 +114,7 @@ def _validate(args):
         ud_path=args.ud_path,
         report_file=args.report_file,
         validation_script=args.validation_script,
-        summarize=bool(args.summarize),
+        summarize=args.summarize,
     )
 
 
@@ -122,7 +122,7 @@ def validate(
     ud_path: Path | list[Path],
     report_file: Path,
     validation_script: str = "tools/validate.py",
-    summarize: bool = True,
+    summarize: str | None = None,
 ):
     """Run the UD tools/validate.py script on a UD treebank"""
     if not Path(validation_script).exists():
@@ -159,8 +159,8 @@ def validate(
         "Validation report written to %s",
         report_file,
     )
-    if summarize:
-        utils.report_errors(report_file)
+    if summarize is not None:
+        utils.report_errors(report_file, output_file=summarize)
 
 
 def main():
@@ -260,8 +260,8 @@ def main():
         "-s",
         "--summarize",
         nargs="?",
-        const="validation_summary.txt",
-        help=("Sum up the error types in the validation report."),
+        const="error_summary.txt",
+        help="Sum up the error types in the validation report.",
     )
     parser_validate.set_defaults(func=_validate)
 

--- a/src/ndt2ud/utils.py
+++ b/src/ndt2ud/utils.py
@@ -73,7 +73,9 @@ def udapi_fixes(input_file: str, output_file: str):
     doc.store_conllu(output_file)
 
 
-def report_errors(report_file: Path, error_type: str | None = None) -> None:
+def report_errors(
+    report_file: Path, error_type: str | None = None, output_file: str | Path = "-"
+) -> None:
     """Parse the error report from the UniversalDependencies/tools/validate.py script,
     and print a compressed report with the sum of each error type.
 
@@ -81,6 +83,7 @@ def report_errors(report_file: Path, error_type: str | None = None) -> None:
         filepath: Path to the validation report file. Should be a Path for a txt-file.
         error_type: specific error type to filter on.
             The error messages for the given type are printed to a csv file.
+        output_file: Path to write output report to. Default is -, which means it'll just print to the terminal window.
     """
     rows = report_file.read_text(encoding="utf-8").splitlines()
 
@@ -88,6 +91,7 @@ def report_errors(report_file: Path, error_type: str | None = None) -> None:
         r"^\[Line (\d+)(?: Sent )?(\d+)?(?: Node )?(\d+)?\]\: \[(L.*)\] (.*)(\[[0-9]*, [0-9]*\])?(.*)?$",
         flags=re.DOTALL,
     )
+
     errors = []
     for row in rows:
         m = error_info_regx.fullmatch(row)
@@ -115,8 +119,11 @@ def report_errors(report_file: Path, error_type: str | None = None) -> None:
 
     type_counts = df.errortype.value_counts()
 
-    print("Validation report summary:")
-    print(type_counts.sort_index())
+    if output_file.startswith("-"):
+        print("Validation report summary:")
+        print(type_counts)
+    else:
+        type_counts.to_csv(output_file)
 
 
 def remove_comment_lines(input_file: str, output_file: str):

--- a/src/ndt2ud/utils.py
+++ b/src/ndt2ud/utils.py
@@ -1,8 +1,9 @@
+# %%
 import logging
 import re
-import urllib.request
 from pathlib import Path
 
+# %%
 import grewpy
 import pandas as pd
 from udapi import Document
@@ -13,8 +14,6 @@ from udapi.block.ud.fixpunct import FixPunct
 from udapi.block.ud.fixrightheaded import FixRightheaded
 from udapi.block.ud.setspaceafterfromtext import SetSpaceAfterFromText
 from udapi.block.util.normalize import Normalize
-
-from ndt2ud.parse_conllu import parse_conll_file, write_conll
 
 
 def set_spaceafter_from_text(graph: grewpy.Graph):
@@ -73,60 +72,60 @@ def udapi_fixes(input_file: str, output_file: str):
     doc.store_conllu(output_file)
 
 
-def report_errors(
-    report_file: Path, error_type: str | None = None, output_file: str | Path = "-"
-) -> None:
+# %%
+
+
+def report_errors(report_file: Path, output_file: str | Path = "-") -> pd.DataFrame:
     """Parse the error report from the UniversalDependencies/tools/validate.py script,
     and print a compressed report with the sum of each error type.
 
     Args:
         filepath: Path to the validation report file. Should be a Path for a txt-file.
-        error_type: specific error type to filter on.
-            The error messages for the given type are printed to a csv file.
         output_file: Path to write output report to. Default is -, which means it'll just print to the terminal window.
     """
     rows = report_file.read_text(encoding="utf-8").splitlines()
 
     error_info_regx = re.compile(
-        r"^\[Line (\d+)(?: Sent )?(\d+)?(?: Node )?(\d+)?\]\: \[(L.*)\] (.*)(\[[0-9]*, [0-9]*\])?(.*)?$",
-        flags=re.DOTALL,
+        r"^\["
+        + r"(?:File )?(?P<file>[^ ]+)?\s*"
+        + r"(?:Line )?(?P<line>\d+)?\s*"
+        + r"(?:Sent )?(?P<sent>\d+)?\s*"
+        + r"(?:Node )?(?P<node>\d+)?"
+        + r"\]: \["
+        + r"(?P<error_level>L[1234])"
+        + " "
+        + r"(?P<error_class>\w+)"
+        + " "
+        + r"(?P<error_name>[\w-]+)"
+        + r"\] "
+        + r"(?P<error_message>.*)"
+        + r"$"
     )
 
     errors = []
     for row in rows:
         m = error_info_regx.fullmatch(row)
         if m is None:
-            logging.debug("Couldn't match this with the regex pattern: %s", row)
+            logging.debug("Row didn't match the error regex pattern: %s", row)
             continue
-        errors.append(m.groups())
+        errors.append(m.groupdict())
 
-    df = pd.DataFrame(
-        errors,
-        columns=[
-            "line",
-            "sent",
-            "node",
-            "errortype",
-            "message",
-            "relevant_nodes",
-            "message2",
-        ],
-    )
-    if error_type is not None:
-        df[df.errortype.str.contains(error_type)].to_csv(
-            f"error_{error_type}.csv", index=False
-        )
+    df = pd.DataFrame(errors)
+    type_counts = df.value_counts(subset=["error_level", "error_class", "error_name"])
 
-    type_counts = df.errortype.value_counts()
-
-    if output_file.startswith("-"):
-        print("Validation report summary:")
+    if str(output_file).startswith("-"):
+        print("## Summary \n")
         print(type_counts)
     else:
         type_counts.to_csv(output_file)
+
+    return df
 
 
 def remove_comment_lines(input_file: str, output_file: str):
     """Remove all lines starting with `#` from a file."""
     with open(input_file, "r") as infile, open(output_file, "w") as outfile:
         outfile.writelines(line for line in infile if not line.startswith("#"))
+
+
+# %%

--- a/tests/ndt2ud/test_validate.py
+++ b/tests/ndt2ud/test_validate.py
@@ -28,7 +28,7 @@ def test_validate_runs_and_writes_report(monkeypatch, ud_file, tmp_path):
     monkeypatch.setattr(ndt2ud.subprocess, "run", lambda *a, **kw: DummyCompleted())
 
     ndt2ud.validate(
-        ud_file, report_file, validation_script=str(script_file), summarize=False
+        ud_file, report_file, validation_script=str(script_file), summarize="-"
     )
     # Check that report file was written
     assert report_file.exists()
@@ -37,6 +37,7 @@ def test_validate_runs_and_writes_report(monkeypatch, ud_file, tmp_path):
 
 def test_validate_missing_script_logs_error(monkeypatch, ud_file, tmp_path):
     report_file = tmp_path / "report.txt"
+    summary_file = tmp_path / "summary.txt"
     script_file = tmp_path / "missing_validate.py"
 
     # Patch Path.exists to False for script path
@@ -62,9 +63,13 @@ def test_validate_missing_script_logs_error(monkeypatch, ud_file, tmp_path):
     )
 
     ndt2ud.validate(
-        ud_file, report_file, validation_script=str(script_file), summarize=False
+        ud_file,
+        report_file,
+        validation_script=str(script_file),
+        summarize=str(summary_file),
     )
     assert "Can't find the path to the validation script" in called.get("error", "")
     # Should still write the report file
     assert report_file.exists()
     assert report_file.read_text() == "validation error"
+    assert summary_file.exists()

--- a/tests/ndt2ud/test_validate.py
+++ b/tests/ndt2ud/test_validate.py
@@ -27,9 +27,7 @@ def test_validate_runs_and_writes_report(monkeypatch, ud_file, tmp_path):
 
     monkeypatch.setattr(ndt2ud.subprocess, "run", lambda *a, **kw: DummyCompleted())
 
-    ndt2ud.validate(
-        ud_file, report_file, validation_script=str(script_file), summarize="-"
-    )
+    ndt2ud.validate(ud_file, report_file, validation_script=str(script_file))
     # Check that report file was written
     assert report_file.exists()
     assert report_file.read_text() == "validation error"
@@ -37,7 +35,6 @@ def test_validate_runs_and_writes_report(monkeypatch, ud_file, tmp_path):
 
 def test_validate_missing_script_logs_error(monkeypatch, ud_file, tmp_path):
     report_file = tmp_path / "report.txt"
-    summary_file = tmp_path / "summary.txt"
     script_file = tmp_path / "missing_validate.py"
 
     # Patch Path.exists to False for script path
@@ -62,14 +59,8 @@ def test_validate_missing_script_logs_error(monkeypatch, ud_file, tmp_path):
         ndt2ud.logging, "error", lambda msg, *a, **kw: called.setdefault("error", msg)
     )
 
-    ndt2ud.validate(
-        ud_file,
-        report_file,
-        validation_script=str(script_file),
-        summarize=str(summary_file),
-    )
+    ndt2ud.validate(ud_file, report_file, validation_script=str(script_file))
     assert "Can't find the path to the validation script" in called.get("error", "")
     # Should still write the report file
     assert report_file.exists()
     assert report_file.read_text() == "validation error"
-    assert summary_file.exists()

--- a/tests/utils/test_report_errors.py
+++ b/tests/utils/test_report_errors.py
@@ -1,0 +1,22 @@
+import pytest
+
+from ndt2ud.utils import report_errors
+
+
+def test_report_errors_catches_all_message_pieces(tmp_path):
+    report_file = tmp_path / "report.txt"
+    text = "[File aal_uio_02_output.conllu Line 1816 Sent 110]: [L2 Syntax invalid-deprel] Invalid DEPREL value 'SLETT'. Only lowercase English letters or a colon are expected."
+    report_file.write_text(text)
+    assert report_file.read_text() == text
+
+    result = report_errors(report_file)
+    row = result.iloc[0]
+
+    assert len(result.columns) == 8
+    assert row.file == "aal_uio_02_output.conllu"
+    assert row.line == "1816"
+    assert row.sent == "110"
+    assert row.node == None
+    assert row.error_level == "L2"
+    assert row.error_class == "Syntax"
+    assert row.error_name == "invalid-deprel"


### PR DESCRIPTION
# Endringer 

- `ndt2ud.utils.report_errors` tar et argument istedet for et flagg for å skrive oppsummeringen til fil, eller til terminalen (`summarize="-"`)
- regex-mønsteret er blitt oppdatert med navngitte grupper, slik at radene som matcher filteret enkelt kan lastes inn til en dataramme. 
- Funksjonen returnerer en dataramme
- Har endret testene som kjørte valideringen tidligere til å droppe argumentet "summarize" 
- Lagt til en test for å sjekke at mønsteret fanger opp de forventede regex-gruppene, og returnerer en dataramme med forventede kolonner og verdier, selv når ett felt mangler og blir `None`.
 