### PR TITLE
141 unkown upos elipsis and punct

### DIFF
--- a/src/rules/rename_deprel_nn.grs
+++ b/src/rules/rename_deprel_nn.grs
@@ -644,8 +644,8 @@ rule rename_ufullst_FRAG {
 
 rule rename_ufullst_FYLL {
   pattern {
+    N [upos=ufullst];
     e: H -[FYLL|REP|SLETT]-> N;
-    N [upos=ufullst]
   }
   commands {
     N.upos=X;

--- a/src/rules/rename_deprel_nn.grs
+++ b/src/rules/rename_deprel_nn.grs
@@ -629,3 +629,23 @@ rule rename_FYLL {
     N.upos = X
   }
 }
+
+rule rename_ufullst {
+  pattern {
+    N [upos=ufullst]
+  }
+  commands {
+    N.upos = X
+  }
+}
+
+rule rename_elipsis_FYLL {
+  pattern {
+    N [upos=ellipsis];
+    e: H -[FYLL]-> N
+  }
+  commands {
+    N.upos = PUNCT;
+    e.label = punct;
+  }
+}

--- a/src/rules/rename_deprel_nn.grs
+++ b/src/rules/rename_deprel_nn.grs
@@ -620,17 +620,6 @@ rule rename_ufullst_tall {
   }
 }
 
-rule rename_ufullst_ADV {
-  pattern {
-    N [upos=ufullst];
-    e: H -[ADV]-> N;
-  }
-  commands {
-    N.upos = X;
-    e.label = reparandum;
-  }
-}
-
 rule rename_ufullst_FRAG {
   pattern {
     N [upos=ufullst];
@@ -642,10 +631,10 @@ rule rename_ufullst_FRAG {
   }
 }
 
-rule rename_ufullst_FYLL {
+rule rename_ufullst {
   pattern {
     N [upos=ufullst];
-    e: H -[FYLL|REP|SLETT]-> N;
+    e: H -[FYLL|REP|SLETT|ADV]-> N;
   }
   commands {
     N.upos=X;

--- a/src/rules/rename_deprel_nn.grs
+++ b/src/rules/rename_deprel_nn.grs
@@ -587,10 +587,10 @@ rule multiple_subjects_predicate_clause {
   }
 }
 
-rule rename_anf_pause_IK {
+rule rename_IK_FYLL_punctuation {
   pattern {
     N [ upos=anf|pause|ellipsis|ufullst, form="«"|"»"|"#"|"##"|"…"|"-"|"–"|"—"|"−"];
-    e: H -[IK]-> N
+    e: H -[IK|FYLL]-> N
   }
   commands {
     e.label = punct;
@@ -610,42 +610,57 @@ rule rename_nol {
   }
 }
 
+rule rename_ufullst_tall {
+  pattern {
+    N [upos=ufullst];
+    e: H -[DET]-> N;
+  }
+  commands {
+    N.upos = NUM;
+  }
+}
+
+rule rename_ufullst_ADV {
+  pattern {
+    N [upos=ufullst];
+    e: H -[ADV]-> N;
+  }
+  commands {
+    N.upos = X;
+    e.label = reparandum;
+  }
+}
+
+rule rename_ufullst_FRAG {
+  pattern {
+    N [upos=ufullst];
+    e: H -[FRAG]-> N;
+  }
+  commands {
+    N.upos = X;
+    e.label = root;
+  }
+}
+
+rule rename_ufullst_FYLL {
+  pattern {
+    e: H -[FYLL|REP|SLETT]-> N;
+    N [upos=ufullst]
+  }
+  commands {
+    N.upos=X;
+    e.label = reparandum;
+  }
+}
+
 rule rename_reparandum {
   pattern {
     e: H -[REP|SLETT]-> N
     }
+  without {
+    N[upos=ufullst]
+  }
   commands {
     e.label = reparandum
-  }
-}
-
-rule rename_FYLL {
-  pattern {
-    e: H -[FYLL]-> N;
-    N [upos=ufullst]
-  }
-  commands {
-    e.label = reparandum;
-    N.upos = X
-  }
-}
-
-rule rename_ufullst {
-  pattern {
-    N [upos=ufullst]
-  }
-  commands {
-    N.upos = X
-  }
-}
-
-rule rename_elipsis_FYLL {
-  pattern {
-    N [upos=ellipsis];
-    e: H -[FYLL]-> N
-  }
-  commands {
-    N.upos = PUNCT;
-    e.label = punct;
   }
 }

--- a/validation_summary_dev.txt
+++ b/validation_summary_dev.txt
@@ -1,5 +1,4 @@
 error_level,error_class,error_name,count
-L2,Morpho,unknown-upos,11
 L3,Syntax,rel-upos-expl,6
 L2,Syntax,invalid-deprel,4
 L4,Syntax,unknown-deprel,4

--- a/validation_summary_test.txt
+++ b/validation_summary_test.txt
@@ -1,7 +1,6 @@
 error_level,error_class,error_name,count
-L2,Morpho,unknown-upos,12
-L2,Syntax,invalid-deprel,6
-L4,Syntax,unknown-deprel,6
+L2,Syntax,invalid-deprel,5
+L4,Syntax,unknown-deprel,5
 L4,Morpho,feature-upos-not-permitted,5
 L3,Warning,pron-det-without-prontype,4
 L4,Morpho,feature-value-upos-not-permitted,4

--- a/validation_summary_train.txt
+++ b/validation_summary_train.txt
@@ -1,9 +1,8 @@
 error_level,error_class,error_name,count
-L2,Morpho,unknown-upos,54
-L4,Syntax,unknown-deprel,39
-L2,Syntax,invalid-deprel,33
-L4,Morpho,feature-upos-not-permitted,28
+L4,Morpho,feature-upos-not-permitted,27
+L4,Syntax,unknown-deprel,24
 L3,Syntax,rel-upos-expl,21
+L2,Syntax,invalid-deprel,18
 L3,Warning,pron-det-without-prontype,10
 L4,Format,invalid-word-with-space,5
 L4,Morpho,feature-value-upos-not-permitted,5


### PR DESCRIPTION
## Endringer 

Det er flere regler for å håndtere noder med upos=ufullst: 
* Der relasjonen er FYLL, REP, SLETT eller ADV får noden upos=X og ny relasjon "reparandum". ADV er antageligvis en feilannotasjon.
* Der relasjonen er FRAG er hele ytringen et fragment og det ufullstendige ordet er roten (relasjon=root). upos=X. 
* Der relasjonen er DET er ordformen egentlig et tallestimat ("to-tre" og "seksti-søtti". Ny upos er NUM. 
* Hvis formen er et tegn og relasjonen er FYLL eller IK, blir ny upos PUNCT og relasjon "punct". 
* For alle andre noder der relasjonen er REP eller SLETT og upos *ikke* er ufullst, blir ny relasjon "reparandum".

Closes #141 