### PR TITLE
regel: "her" som formelt subjekt annoteres som ADV

### DIFF
--- a/data/lia_train.conllu
+++ b/data/lia_train.conllu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f6f1071e20df17f9fcf05ab1549df264f8a9032f1b287f140d392f07284515bf
-size 1881342
+oid sha256:4feb26666dc7ea27ab79c955d9dc8a9e992c2dac322fcd0a4ea422aee08f5abb
+size 1881341

--- a/notebooks/workflow.ipynb
+++ b/notebooks/workflow.ipynb
@@ -60,10 +60,8 @@
     "from ndt2ud.morphological_features import convert_morphology\n",
     "from ndt2ud.parse_conllu import parse_conll_file, write_conll\n",
     "\n",
-    "notebook_path = pathlib.Path.cwd()\n",
-    "\n",
-    "\n",
-    "data_dir = Path(notebook_path.parent / \"data\")\n",
+    "repo_dir = pathlib.Path.cwd().parent\n",
+    "data_dir = Path(repo_dir / \"data\")\n",
     "treebank_file = data_dir / \"lia_train.conllu\"\n",
     "UD_treebank_file = data_dir / \"UD_output.conllu\"\n",
     "\n",
@@ -207,10 +205,14 @@
     "from ndt2ud.utils import Edge, Node, view_search_results\n",
     "\n",
     "# Definer søkemønsteret\n",
-    "edge = Edge(source=\"H\", label=\"IK\", target=\"N\")\n",
-    "node = Node(name=\"N\", feats={\"upos\": \"ellipsis\"})\n",
     "\n",
-    "pattern = f\"{node};{edge}\"\n",
+    "# node = Node(name=\"N\", feats={\"upos\": \"ADV\", \"form\": \"her\"})\n",
+    "global_match = 'sent_id = \"000642\"'\n",
+    "pattern = f\"\"\"\n",
+    "H [upos=NOUN];\n",
+    "N [upos=PROPN|NOUN];\n",
+    "e: H-> N;\n",
+    "\"\"\"\n",
     "\n",
     "\n",
     "# Søk med mønsteret i corpuset og se på resultatene\n",
@@ -245,11 +247,10 @@
     "    Rule,\n",
     ")\n",
     "\n",
-    "edge.label = \"punct\"\n",
-    "node.upos = \"PUNCT\"\n",
-    "\n",
     "commands = Commands(f\"\"\"\n",
-    "e.label = {edge.label};\n",
+    "del_edge e;\n",
+    "add_edge e1: H-> D;\n",
+    "e1.label = expl;       \n",
     "\"\"\")\n",
     "\n",
     "\n",
@@ -285,13 +286,13 @@
     "\n",
     "original_matches = original_corpus.count(request)\n",
     "request_matches = corpus.count(request)\n",
-    "command_matches = corpus.count(Request().pattern(str(edge)))\n",
+    "# command_matches = corpus.count(Request().pattern(str(edge)))\n",
     "\n",
     "# Burde være 0 nå\n",
     "print(f\"Treff på regelmønster FØR endringen: {original_matches}\")\n",
     "# Burde være 0 nå\n",
     "print(f\"Treff på regelmønster ETTER endringen: {request_matches}\")\n",
-    "print(f\"Treff på nytt mønster etter endringen: {command_matches}\")"
+    "# print(f\"Treff på nytt mønster etter endringen: {command_matches}\")"
    ]
   },
   {
@@ -440,7 +441,7 @@
    "outputs": [],
    "source": [
     "# Hent ut en bestemt setningsgraf med setnings-ID\n",
-    "sent_id = \"76\"\n",
+    "sent_id = \"000642\"\n",
     "\n",
     "visualize_graph(original_corpus[sent_id])"
    ]
@@ -454,13 +455,6 @@
     "# Se på samme grafen etter omskrivingsregelen\n",
     "visualize_graph(corpus[sent_id])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/src/rules/NDT_fix.grs
+++ b/src/rules/NDT_fix.grs
@@ -188,8 +188,7 @@ rule fix_postag_X {
 
 % 004797: Og sjølv om aktørane i boka påfallande ofte seier hø-hø-hø, og nokre gonger hå-hå, er her ikkje eigentleg humor, slik at boka kan forklarast som parodi eller karikatur.
 rule adverbial_formal_subject {
-    global { sent_id = "004797" | "014451" ; }
-    pattern { N [upos=ADV]; e: V -[FSUBJ]-> N;}
+    pattern { N [upos=ADV, form="her"]; e: V -[FSUBJ]-> N;}
     commands { e.label = ADV; }
 }
 

--- a/src/rules/rename_deprel_nn.grs
+++ b/src/rules/rename_deprel_nn.grs
@@ -143,7 +143,13 @@ rule ukjent {
 
 rule expletive_subj {
   pattern { e: GOV -[ FSUBJ ]-> DEP }
+  without {DEP[upos=NOUN]}
   commands { e.label = expl }
+}
+
+rule formal_nsubj {
+  pattern { DEP[upos=NOUN]; e: GOV -[ FSUBJ ]-> DEP }
+  commands { e.label = nsubj }
 }
 
 rule expletive_obj {

--- a/validation_summary_dev.txt
+++ b/validation_summary_dev.txt
@@ -1,5 +1,4 @@
 error_level,error_class,error_name,count
-L3,Syntax,rel-upos-expl,6
 L2,Syntax,invalid-deprel,4
 L4,Syntax,unknown-deprel,4
 L4,Morpho,feature-value-upos-not-permitted,4

--- a/validation_summary_test.txt
+++ b/validation_summary_test.txt
@@ -4,5 +4,4 @@ L4,Syntax,unknown-deprel,5
 L4,Morpho,feature-upos-not-permitted,5
 L3,Warning,pron-det-without-prontype,4
 L4,Morpho,feature-value-upos-not-permitted,4
-L3,Syntax,rel-upos-expl,3
 L3,Syntax,rel-upos-cc,1

--- a/validation_summary_test.txt
+++ b/validation_summary_test.txt
@@ -1,7 +1,7 @@
 error_level,error_class,error_name,count
 L2,Syntax,invalid-deprel,5
-L4,Syntax,unknown-deprel,5
 L4,Morpho,feature-upos-not-permitted,5
+L4,Syntax,unknown-deprel,5
 L3,Warning,pron-det-without-prontype,4
 L4,Morpho,feature-value-upos-not-permitted,4
 L3,Syntax,rel-upos-cc,1

--- a/validation_summary_train.txt
+++ b/validation_summary_train.txt
@@ -3,10 +3,9 @@ L4,Morpho,feature-upos-not-permitted,27
 L4,Syntax,unknown-deprel,24
 L2,Syntax,invalid-deprel,18
 L3,Warning,pron-det-without-prontype,10
-L4,Format,invalid-word-with-space,5
 L4,Morpho,feature-value-upos-not-permitted,5
+L4,Format,invalid-word-with-space,5
 L2,Syntax,root-is-not-0,3
 L3,Syntax,rel-upos-cc,2
 L3,Syntax,too-many-subjects,2
-L3,Syntax,rel-upos-expl,1
 L3,Syntax,right-to-left-conj,1

--- a/validation_summary_train.txt
+++ b/validation_summary_train.txt
@@ -1,12 +1,12 @@
 error_level,error_class,error_name,count
 L4,Morpho,feature-upos-not-permitted,27
 L4,Syntax,unknown-deprel,24
-L3,Syntax,rel-upos-expl,21
 L2,Syntax,invalid-deprel,18
 L3,Warning,pron-det-without-prontype,10
 L4,Format,invalid-word-with-space,5
 L4,Morpho,feature-value-upos-not-permitted,5
 L2,Syntax,root-is-not-0,3
 L3,Syntax,rel-upos-cc,2
+L3,Syntax,rel-upos-expl,2
 L3,Syntax,too-many-subjects,2
 L3,Syntax,right-to-left-conj,1

--- a/validation_summary_train.txt
+++ b/validation_summary_train.txt
@@ -7,6 +7,6 @@ L4,Format,invalid-word-with-space,5
 L4,Morpho,feature-value-upos-not-permitted,5
 L2,Syntax,root-is-not-0,3
 L3,Syntax,rel-upos-cc,2
-L3,Syntax,rel-upos-expl,2
 L3,Syntax,too-many-subjects,2
+L3,Syntax,rel-upos-expl,1
 L3,Syntax,right-to-left-conj,1


### PR DESCRIPTION
* Regel i `rules/NDT_fix.grs`: Søk etter en node med upos=ADV og form="her", og relasjon FSUBJ. Fjern setnings-ID-filteret. Matchende kanter får relasjon ADV. 
* Regel i `rules/rename_deprel_nn.grs`: Sørg for at FSUBJ skrives om til expl bare for relasjoner der sluttnoden ikke er et substantiv. Legg til regel for at FSUBJ som går til en node med upos=NOUN får relasjonen nsubj istedet.

Disse endringene fjerner feiltypen "rel-upos-expl" fra valideringsoppsummeringene